### PR TITLE
ci(worklow): standardize docker images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches: [ main ]
-    tags: ["v*"]
+    tags: [ "v*" ]
 
   pull_request:
     branches: [ main ]
@@ -17,6 +17,24 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
 
+      - name: Set up context
+        id: project_context
+        uses: FranzDiebold/github-env-vars-action@v2.3.1
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: docker_metadata
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,event=pr,value=${{ env.CI_ACTION_REF_NAME_SLUG }}
+            type=raw,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},value=nightly
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+          labels: |
+            org.opencontainers.image.vendor=OKP4
+
       - name: Login to Docker registry
         uses: docker/login-action@v1
         with:
@@ -24,39 +42,11 @@ jobs:
           username: ${{ secrets.DOCKER_REGISTRY_ID }}
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
-      - name: Set up context
-        id: project_context
-        uses: FranzDiebold/github-env-vars-action@v2.3.1
-
-      - name: Set up versions
-        id: project_version
-        run: |
-          version=`head -n 1 version`
-          echo "::set-output name=version::$version"
-          echo "::set-output name=major::$(echo $version | cut -d. -f1)"
-          echo "::set-output name=minor::$(echo $version | cut -d. -f2)"
-          echo "::set-output name=revision::$(echo $version | cut -d. -f3)"
-          echo "::set-output name=image::$GITHUB_REPOSITORY"
-
       - name: Build and publish image(s)
-        run: |
-          if [[ $GITHUB_REF == refs/tags/v* ]]; then
-            echo "Publish docker image for branch"
-            docker build \
-              -t ghcr.io/${{ steps.project_version.outputs.image }}:${{ steps.project_version.outputs.major }} \
-              -t ghcr.io/${{ steps.project_version.outputs.image }}:${{ steps.project_version.outputs.major }}.${{ steps.project_version.outputs.minor }} \
-              -t ghcr.io/${{ steps.project_version.outputs.image }}:${{ steps.project_version.outputs.version }} \
-              -t ghcr.io/${{ steps.project_version.outputs.image }}:latest \
-              .
-          elif [[ $GITHUB_EVENT_NAME == pull_request ]]; then
-            echo "Publish docker image for branch"
-            docker build \
-              -t ghcr.io/${{ steps.project_version.outputs.image }}:$CI_ACTION_REF_NAME_SLUG \
-              .
-          else
-            echo "Publish docker image for nightly"
-            docker build \
-              -t ghcr.io/${{ steps.project_version.outputs.image }}:nightly \
-              .
-          fi
-          docker push ghcr.io/${{ steps.project_version.outputs.image }} --all-tags
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.docker_metadata.outputs.tags }}
+          labels: ${{ steps.docker_metadata.outputs.labels }}


### PR DESCRIPTION
Use the following github actions to standardize the way we build (tag, label) & publish our docker images.

- [docker/metadata-action](https://github.com/docker/metadata-action)
- [docker/build-push-action](https://github.com/docker/build-push-action)

(it also simplifies the workflow quite a bit)

Docker image tag follows our conventions:
- **git tag** produces `x.y.z`, `x.y`, `x` and `latest` docker tags
- **branch `main`** produces a `nightly` docker tag
- a **feature branch** produces the `slug of the branch name` for the docker tag