### PR TITLE
ci(workflow): exclude docker lint for dependabot PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,6 +58,7 @@ jobs:
 
   lint-dockerfile:
     runs-on: ubuntu-20.04
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Check out repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Resolves (well, it does the job) the following issue during docker linting (luke142367/Docker-Lint-Action[https://github.com/luke142367/Docker-Lint-Action]) for `dependabot` PRs.

```
2020-09-30T08:02:05.2247762Z Error HttpError: Resource not accessible by integration
2020-09-30T08:02:05.2249254Z     at response.text.then.message (/.docker-lint-action/node_modules/@octokit/request/dist-node/index.js:66:23)
2020-09-30T08:02:05.2250159Z     at processTicksAndRejections (internal/process/task_queues.js:86:5)
2020-09-30T08:02:05.2282012Z Dockerfile Lint failed
```

See: https://github.com/luke142367/Docker-Lint-Action/issues/13