### PR TITLE
chore(chain): update genesis file for testnet

### DIFF
--- a/chains/testnet/genesis.json
+++ b/chains/testnet/genesis.json
@@ -1,330 +1,319 @@
 {
-    "genesis_time": "2022-02-07T14:22:48.730151046Z",
-    "chain_id": "okp4-testnet-1",
-    "initial_height": "1",
-    "consensus_params": {
-        "block": {
-            "max_bytes": "22020096",
-            "max_gas": "-1",
-            "time_iota_ms": "1000"
-        },
-        "evidence": {
-            "max_age_num_blocks": "100000",
-            "max_age_duration": "172800000000000",
-            "max_bytes": "1048576"
-        },
-        "validator": {
-            "pub_key_types": ["ed25519"]
-        },
-        "version": {}
+  "genesis_time": "2022-02-07T19:53:42.562407Z",
+  "chain_id": "okp4-testnet-1",
+  "initial_height": "1",
+  "consensus_params": {
+    "block": {
+      "max_bytes": "22020096",
+      "max_gas": "-1",
+      "time_iota_ms": "1000"
     },
-    "app_hash": "",
-    "app_state": {
-        "auth": {
-            "params": {
-                "max_memo_characters": "256",
-                "tx_sig_limit": "7",
-                "tx_size_cost_per_byte": "10",
-                "sig_verify_cost_ed25519": "590",
-                "sig_verify_cost_secp256k1": "1000"
-            },
-            "accounts": [
-                {
-                    "@type": "/cosmos.auth.v1beta1.BaseAccount",
-                    "address": "okp415g0mlec54l3u0k6x5j2pd7wjlezuvz9sztnxze",
-                    "pub_key": null,
-                    "account_number": "0",
-                    "sequence": "0"
-                },
-                {
-                    "@type": "/cosmos.auth.v1beta1.BaseAccount",
-                    "address": "okp416qrwhtwshu3gsevq7k4t4e4gkp390tm69ksr27",
-                    "pub_key": null,
-                    "account_number": "0",
-                    "sequence": "0"
-                },
-                {
-                    "@type": "/cosmos.auth.v1beta1.BaseAccount",
-                    "address": "okp4143n5c3uucy5ac6hxhzgyqdj3lwhycz88q5n8n2",
-                    "pub_key": null,
-                    "account_number": "0",
-                    "sequence": "0"
-                },
-                {
-                    "@type": "/cosmos.auth.v1beta1.BaseAccount",
-                    "address": "okp41gj0am83pyygdqa8f5yt6d6xq4uep790zfmnc77",
-                    "pub_key": null,
-                    "account_number": "0",
-                    "sequence": "0"
-                },
-                {
-                    "@type": "/cosmos.auth.v1beta1.BaseAccount",
-                    "address": "okp41l2mx5gvaf464mumy30cqt0yu8ue8g5dl9eg67z",
-                    "pub_key": null,
-                    "account_number": "0",
-                    "sequence": "0"
-                }
-            ]
+    "evidence": {
+      "max_age_num_blocks": "100000",
+      "max_age_duration": "172800000000000",
+      "max_bytes": "1048576"
+    },
+    "validator": {
+      "pub_key_types": [
+        "ed25519"
+      ]
+    },
+    "version": {}
+  },
+  "app_hash": "",
+  "app_state": {
+    "auth": {
+      "params": {
+        "max_memo_characters": "256",
+        "tx_sig_limit": "7",
+        "tx_size_cost_per_byte": "10",
+        "sig_verify_cost_ed25519": "590",
+        "sig_verify_cost_secp256k1": "1000"
+      },
+      "accounts": [
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "okp41ql0zyp5hrvpn3k2m0jevk4ty4zhsaaf3hy0ja8",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
         },
-        "bank": {
-            "params": {
-                "send_enabled": [],
-                "default_send_enabled": true
-            },
-            "balances": [
-                {
-                    "address": "okp41gj0am83pyygdqa8f5yt6d6xq4uep790zfmnc77",
-                    "coins": [
-                        {
-                            "denom": "know",
-                            "amount": "1000000000000"
-                        }
-                    ]
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "okp41fhpjzjskxuthnsu42w2aggw3lz68uktpz8t6dj",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "okp414g6a44ahpklxdlfuzhhl7sk56rmx2utm9c64j8",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        },
+        {
+          "@type": "/cosmos.auth.v1beta1.BaseAccount",
+          "address": "okp416d6ht72rcul0zfsferht0ag744adfngvddf7lq",
+          "pub_key": null,
+          "account_number": "0",
+          "sequence": "0"
+        }
+      ]
+    },
+    "bank": {
+      "params": {
+        "send_enabled": [],
+        "default_send_enabled": true
+      },
+      "balances": [
+        {
+          "address": "okp41ql0zyp5hrvpn3k2m0jevk4ty4zhsaaf3hy0ja8",
+          "coins": [
+            {
+              "denom": "know",
+              "amount": "100000000000"
+            }
+          ]
+        },
+        {
+          "address": "okp41fhpjzjskxuthnsu42w2aggw3lz68uktpz8t6dj",
+          "coins": [
+            {
+              "denom": "know",
+              "amount": "10000000000"
+            }
+          ]
+        },
+        {
+          "address": "okp414g6a44ahpklxdlfuzhhl7sk56rmx2utm9c64j8",
+          "coins": [
+            {
+              "denom": "know",
+              "amount": "10000000000"
+            }
+          ]
+        },
+        {
+          "address": "okp416d6ht72rcul0zfsferht0ag744adfngvddf7lq",
+          "coins": [
+            {
+              "denom": "know",
+              "amount": "10000000000"
+            }
+          ]
+        }
+      ],
+      "supply": [],
+      "denom_metadata": []
+    },
+    "capability": {
+      "index": "1",
+      "owners": []
+    },
+    "crisis": {
+      "constant_fee": {
+        "denom": "know",
+        "amount": "1000"
+      }
+    },
+    "distribution": {
+      "params": {
+        "community_tax": "0.020000000000000000",
+        "base_proposer_reward": "0.010000000000000000",
+        "bonus_proposer_reward": "0.040000000000000000",
+        "withdraw_addr_enabled": true
+      },
+      "fee_pool": {
+        "community_pool": []
+      },
+      "delegator_withdraw_infos": [],
+      "previous_proposer": "",
+      "outstanding_rewards": [],
+      "validator_accumulated_commissions": [],
+      "validator_historical_rewards": [],
+      "validator_current_rewards": [],
+      "delegator_starting_infos": [],
+      "validator_slash_events": []
+    },
+    "evidence": {
+      "evidence": []
+    },
+    "feegrant": {
+      "allowances": []
+    },
+    "genutil": {
+      "gen_txs": [
+        {
+          "body": {
+            "messages": [
+              {
+                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
+                "description": {
+                  "moniker": "OKP4",
+                  "identity": "6C36E7C076BFDCE4",
+                  "website": "https://okp4.com",
+                  "security_contact": "validator@okp4.network",
+                  "details": "At the core of the stakes of data valorisation"
                 },
-                {
-                    "address": "okp415g0mlec54l3u0k6x5j2pd7wjlezuvz9sztnxze",
-                    "coins": [
-                        {
-                            "denom": "know",
-                            "amount": "100000000000"
-                        }
-                    ]
+                "commission": {
+                  "rate": "0.100000000000000000",
+                  "max_rate": "0.200000000000000000",
+                  "max_change_rate": "0.010000000000000000"
                 },
-                {
-                    "address": "okp4143n5c3uucy5ac6hxhzgyqdj3lwhycz88q5n8n2",
-                    "coins": [
-                        {
-                            "denom": "know",
-                            "amount": "97"
-                        }
-                    ]
+                "min_self_delegation": "1",
+                "delegator_address": "okp41ql0zyp5hrvpn3k2m0jevk4ty4zhsaaf3hy0ja8",
+                "validator_address": "okp4valoper1ql0zyp5hrvpn3k2m0jevk4ty4zhsaaf3zrlmrx",
+                "pubkey": {
+                  "@type": "/cosmos.crypto.ed25519.PubKey",
+                  "key": "sg8x+d1t7TPNkiIGGGPWslRrUzQPWoSeWrXdMVmQOCY="
                 },
-                {
-                    "address": "okp416qrwhtwshu3gsevq7k4t4e4gkp390tm69ksr27",
-                    "coins": [
-                        {
-                            "denom": "know",
-                            "amount": "234"
-                        }
-                    ]
-                },
-                {
-                    "address": "okp41l2mx5gvaf464mumy30cqt0yu8ue8g5dl9eg67z",
-                    "coins": [
-                        {
-                            "denom": "know",
-                            "amount": "1000000000000"
-                        }
-                    ]
+                "value": {
+                  "denom": "know",
+                  "amount": "1000000000"
                 }
+              }
             ],
-            "supply": [],
-            "denom_metadata": []
-        },
-        "capability": {
-            "index": "1",
-            "owners": []
-        },
-        "crisis": {
-            "constant_fee": {
-                "denom": "know",
-                "amount": "1000"
-            }
-        },
-        "distribution": {
-            "params": {
-                "community_tax": "0.020000000000000000",
-                "base_proposer_reward": "0.010000000000000000",
-                "bonus_proposer_reward": "0.040000000000000000",
-                "withdraw_addr_enabled": true
-            },
-            "fee_pool": {
-                "community_pool": []
-            },
-            "delegator_withdraw_infos": [],
-            "previous_proposer": "",
-            "outstanding_rewards": [],
-            "validator_accumulated_commissions": [],
-            "validator_historical_rewards": [],
-            "validator_current_rewards": [],
-            "delegator_starting_infos": [],
-            "validator_slash_events": []
-        },
-        "evidence": {
-            "evidence": []
-        },
-        "feegrant": {
-            "allowances": []
-        },
-        "genutil": {
-            "gen_txs": [
-                {
-                    "body": {
-                        "messages": [
-                            {
-                                "@type": "/cosmos.staking.v1beta1.MsgCreateValidator",
-                                "description": {
-                                    "moniker": "OKP4",
-                                    "identity": "6C36E7C076BFDCE4",
-                                    "website": "https://okp4.com",
-                                    "security_contact": "validator@okp4.network",
-                                    "details": "At the core of the stakes of data valorisation"
-                                },
-                                "commission": {
-                                    "rate": "0.100000000000000000",
-                                    "max_rate": "0.200000000000000000",
-                                    "max_change_rate": "0.010000000000000000"
-                                },
-                                "min_self_delegation": "1",
-                                "delegator_address": "okp415g0mlec54l3u0k6x5j2pd7wjlezuvz9sztnxze",
-                                "validator_address": "okp4valoper15g0mlec54l3u0k6x5j2pd7wjlezuvz9shvr0uc",
-                                "pubkey": {
-                                    "@type": "/cosmos.crypto.ed25519.PubKey",
-                                    "key": "BvPug25ZXcLNUVmLbobZQPCFn6vyCO7hge/k9ySK3Hw="
-                                },
-                                "value": {
-                                    "denom": "know",
-                                    "amount": "100000000"
-                                }
-                            }
-                        ],
-                        "memo": "aa75a1e89e57b11de127ad108c046d0f5de9b01d@100.64.2.200:26656",
-                        "timeout_height": "0",
-                        "extension_options": [],
-                        "non_critical_extension_options": []
-                    },
-                    "auth_info": {
-                        "signer_infos": [
-                            {
-                                "public_key": {
-                                    "@type": "/cosmos.crypto.secp256k1.PubKey",
-                                    "key": "AtlOCMroUekMCJTD3isT7CK3zuFsYxm5RAPwqvr47/kK"
-                                },
-                                "mode_info": {
-                                    "single": {
-                                        "mode": "SIGN_MODE_DIRECT"
-                                    }
-                                },
-                                "sequence": "0"
-                            }
-                        ],
-                        "fee": {
-                            "amount": [],
-                            "gas_limit": "200000",
-                            "payer": "",
-                            "granter": ""
-                        }
-                    },
-                    "signatures": [
-                        "ldd1PVQDDSdpejoIXMYwLQu4g/pMChc0f8k1wojdYWwRrB3OjSOc3IsBrtytIG1e7tNVwaVcDggVspkA7JFI1Q=="
-                    ]
-                }
-            ]
-        },
-        "gov": {
-            "starting_proposal_id": "1",
-            "deposits": [],
-            "votes": [],
-            "proposals": [],
-            "deposit_params": {
-                "min_deposit": [
-                    {
-                        "denom": "know",
-                        "amount": "10000000"
-                    }
-                ],
-                "max_deposit_period": "172800s"
-            },
-            "voting_params": {
-                "voting_period": "172800s"
-            },
-            "tally_params": {
-                "quorum": "0.334000000000000000",
-                "threshold": "0.500000000000000000",
-                "veto_threshold": "0.334000000000000000"
-            }
-        },
-        "ibc": {
-            "client_genesis": {
-                "clients": [],
-                "clients_consensus": [],
-                "clients_metadata": [],
-                "params": {
-                    "allowed_clients": ["06-solomachine", "07-tendermint"]
+            "memo": "86d808c105513e5ac2d5214f6792e69f59a09809@192.168.13.11:26656",
+            "timeout_height": "0",
+            "extension_options": [],
+            "non_critical_extension_options": []
+          },
+          "auth_info": {
+            "signer_infos": [
+              {
+                "public_key": {
+                  "@type": "/cosmos.crypto.secp256k1.PubKey",
+                  "key": "Az4s6wQk8+xZ1PaUiFIY3dxcl576R5tUnVXXl+ewpPWS"
                 },
-                "create_localhost": false,
-                "next_client_sequence": "0"
-            },
-            "connection_genesis": {
-                "connections": [],
-                "client_connection_paths": [],
-                "next_connection_sequence": "0",
-                "params": {
-                    "max_expected_time_per_block": "30000000000"
-                }
-            },
-            "channel_genesis": {
-                "channels": [],
-                "acknowledgements": [],
-                "commitments": [],
-                "receipts": [],
-                "send_sequences": [],
-                "recv_sequences": [],
-                "ack_sequences": [],
-                "next_channel_sequence": "0"
+                "mode_info": {
+                  "single": {
+                    "mode": "SIGN_MODE_DIRECT"
+                  }
+                },
+                "sequence": "0"
+              }
+            ],
+            "fee": {
+              "amount": [],
+              "gas_limit": "200000",
+              "payer": "",
+              "granter": ""
             }
+          },
+          "signatures": [
+            "fPe5QAATp927KojgDZ5QcPyVbAndIatPtL9RofSJn0d/5SWSnIX87TC5aSvUZyCyvWsQwvDb+qGE0PmBJ6iZQw=="
+          ]
+        }
+      ]
+    },
+    "gov": {
+      "starting_proposal_id": "1",
+      "deposits": [],
+      "votes": [],
+      "proposals": [],
+      "deposit_params": {
+        "min_deposit": [
+          {
+            "denom": "know",
+            "amount": "10000000"
+          }
+        ],
+        "max_deposit_period": "172800s"
+      },
+      "voting_params": {
+        "voting_period": "172800s"
+      },
+      "tally_params": {
+        "quorum": "0.334000000000000000",
+        "threshold": "0.500000000000000000",
+        "veto_threshold": "0.334000000000000000"
+      }
+    },
+    "ibc": {
+      "client_genesis": {
+        "clients": [],
+        "clients_consensus": [],
+        "clients_metadata": [],
+        "params": {
+          "allowed_clients": [
+            "06-solomachine",
+            "07-tendermint"
+          ]
         },
-        "mint": {
-            "minter": {
-                "inflation": "0.130000000000000000",
-                "annual_provisions": "0.000000000000000000"
-            },
-            "params": {
-                "mint_denom": "know",
-                "inflation_rate_change": "0.130000000000000000",
-                "inflation_max": "0.200000000000000000",
-                "inflation_min": "0.070000000000000000",
-                "goal_bonded": "0.670000000000000000",
-                "blocks_per_year": "6311520"
-            }
-        },
-        "params": null,
-        "slashing": {
-            "params": {
-                "signed_blocks_window": "100",
-                "min_signed_per_window": "0.500000000000000000",
-                "downtime_jail_duration": "600s",
-                "slash_fraction_double_sign": "0.050000000000000000",
-                "slash_fraction_downtime": "0.010000000000000000"
-            },
-            "signing_infos": [],
-            "missed_blocks": []
-        },
-        "staking": {
-            "params": {
-                "unbonding_time": "1814400s",
-                "max_validators": 100,
-                "max_entries": 7,
-                "historical_entries": 10000,
-                "bond_denom": "know"
-            },
-            "last_total_power": "0",
-            "last_validator_powers": [],
-            "validators": [],
-            "delegations": [],
-            "unbonding_delegations": [],
-            "redelegations": [],
-            "exported": false
-        },
-        "transfer": {
-            "port_id": "transfer",
-            "denom_traces": [],
-            "params": {
-                "send_enabled": true,
-                "receive_enabled": true
-            }
-        },
-        "upgrade": {},
-        "vesting": {}
-    }
+        "create_localhost": false,
+        "next_client_sequence": "0"
+      },
+      "connection_genesis": {
+        "connections": [],
+        "client_connection_paths": [],
+        "next_connection_sequence": "0",
+        "params": {
+          "max_expected_time_per_block": "30000000000"
+        }
+      },
+      "channel_genesis": {
+        "channels": [],
+        "acknowledgements": [],
+        "commitments": [],
+        "receipts": [],
+        "send_sequences": [],
+        "recv_sequences": [],
+        "ack_sequences": [],
+        "next_channel_sequence": "0"
+      }
+    },
+    "mint": {
+      "minter": {
+        "inflation": "0.130000000000000000",
+        "annual_provisions": "0.000000000000000000"
+      },
+      "params": {
+        "mint_denom": "know",
+        "inflation_rate_change": "0.130000000000000000",
+        "inflation_max": "0.200000000000000000",
+        "inflation_min": "0.070000000000000000",
+        "goal_bonded": "0.670000000000000000",
+        "blocks_per_year": "6311520"
+      }
+    },
+    "params": null,
+    "slashing": {
+      "params": {
+        "signed_blocks_window": "100",
+        "min_signed_per_window": "0.500000000000000000",
+        "downtime_jail_duration": "600s",
+        "slash_fraction_double_sign": "0.050000000000000000",
+        "slash_fraction_downtime": "0.010000000000000000"
+      },
+      "signing_infos": [],
+      "missed_blocks": []
+    },
+    "staking": {
+      "params": {
+        "unbonding_time": "1814400s",
+        "max_validators": 100,
+        "max_entries": 7,
+        "historical_entries": 10000,
+        "bond_denom": "know"
+      },
+      "last_total_power": "0",
+      "last_validator_powers": [],
+      "validators": [],
+      "delegations": [],
+      "unbonding_delegations": [],
+      "redelegations": [],
+      "exported": false
+    },
+    "transfer": {
+      "port_id": "transfer",
+      "denom_traces": [],
+      "params": {
+        "send_enabled": true,
+        "receive_enabled": true
+      }
+    },
+    "upgrade": {},
+    "vesting": {}
+  }
 }


### PR DESCRIPTION
Update the genesis file for the OKP4 `testnet` with the appropriate settings.

The genesis file considers the following accounts:

- name: `okp4-validator`
  address: `okp41ql0zyp5hrvpn3k2m0jevk4ty4zhsaaf3hy0ja8`
  pubkey:
```json
  {
    "@type": "/cosmos.crypto.secp256k1.PubKey",
    "key": "Az4s6wQk8+xZ1PaUiFIY3dxcl576R5tUnVXXl+ewpPWS",
  }
```
- name: `safe1`
  address: `okp41fhpjzjskxuthnsu42w2aggw3lz68uktpz8t6dj`
  pubkey:
```json
  {
    "@type": "/cosmos.crypto.secp256k1.PubKey",
    "key": "AryC0vucplSvFrs6saTHwGHmnu3gLqK9GIGud8bfl53H",
  }
```
- name: `safe2`
  address: `okp414g6a44ahpklxdlfuzhhl7sk56rmx2utm9c64j8`
  pubkey: 
```json
  {
    "@type": "/cosmos.crypto.secp256k1.PubKey",
    "key": "A240ABtZ4cReI3HN1wmrNliz7rTdCoPywipyAK7yWRLV",
  }
```
- name: `safe3`
  address: `okp416d6ht72rcul0zfsferht0ag744adfngvddf7lq`
  pubkey:
```json
  {
    "@type": "/cosmos.crypto.secp256k1.PubKey",
    "key": "A33qkrighvTv8NlmUnUIyoFq1JSqv8tpiQk2AyW9MxN0",
  }
```