### PR TITLE
ci(workflow): prevent golinting if no change

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,8 +52,18 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
 
+      - name: Find changed go files
+        id: changed-go-files
+        uses: tj-actions/changed-files@v17.2
+        with:
+          files: |
+            **/*.go
+            go.mod
+            go.sum
+
       - name: Lint go code (golangci-lint)
         uses: golangci/golangci-lint-action@v2
+        if: steps.changed-go-files.outputs.any-changed == 'true'
         with:
           version: v1.44
 


### PR DESCRIPTION
Self explanatory.

Implementation relies on [tj-actions/changed-files](https://github.com/tj-actions/changed-files) github action (which we already use in the project [okp4/docker-images](https://github.com/okp4/docker-images) for example). Can help to save a few minutes of execution, when updating the README for example...



<img width="390" alt="image" src="https://user-images.githubusercontent.com/9574336/156891700-a59dcecb-3e60-460d-aea2-21e263745821.png">
