### PR TITLE
ci(release): add missing `exe` suffix for windows binary

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -35,7 +35,7 @@ plugins:
         - name: okp4d_linux_amd64
           label: Binary - Linux amd64
           path: "./target/dist/linux/amd64/okp4d"
-        - name: okp4d_windows_amd64
+        - name: okp4d_windows_amd64.exe
           label: Binary - Windows amd64
           path: "./target/dist/windows/amd64/okp4d.exe"
   - - "@semantic-release/git"


### PR DESCRIPTION
Continuation of #41, add the missing `exe` suffix for windows binary (it's better to have it).