### PR TITLE
ci: fix git dependency version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.0.0/libwasmvm_muslc.
 
 # hadolint ignore=DL4006
 RUN set -eux \
-    && apk add --no-cache ca-certificates=20211220-r0 build-base=0.5-r3 git=2.36.1-r0 \
+    && apk add --no-cache ca-certificates=20211220-r0 build-base=0.5-r3 git=2.36.2-r0 \
     && sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 7d2239e9f25e96d0d4daba982ce92367aacf0cbd95d2facb8442268f2b1cc1fc \
     && sha256sum /lib/libwasmvm_muslc.x86_64.a | grep f6282df732a13dec836cda1f399dd874b1e3163504dbd9607c6af915b2740479 \
     && cp "/lib/libwasmvm_muslc.$(uname -m).a" /lib/libwasmvm_muslc.a


### PR DESCRIPTION
Fixes the docker build error by setting the version of the `git` dependency.

```
ERROR: unable to select packages:
  git-2.36.2-r0:
    breaks: world[git=2.36.1-r0]
```