### PR TITLE
ci(lint): fix ignite version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -183,7 +183,7 @@ jobs:
 
       - name: Install Ignite CLI
         run: |
-          curl https://get.ignite.com/cli! | bash
+          curl https://get.ignite.com/cli@v0.22.2! | bash
 
       - name: Generate OpenAPI spec for the chain
         run: |
@@ -192,7 +192,7 @@ jobs:
 
       - name: Check Git diff in generated files (openapi.yml)
         run: |
-          if [[ $(git status -s | grep -v 'go.mod$' | grep -v 'go.sum$' ) != "" ]]; then
+          if [[ $(git status -s | grep -v 'go.mod$' | grep -v 'go.sum$') != "" ]]; then
             >&2 echo "❌ There is a diff between generated files and source code"
             >&2 git status
             exit 1

--- a/docs/static/openapi.yml
+++ b/docs/static/openapi.yml
@@ -17721,6 +17721,9 @@ paths:
                         }
       parameters:
         - name: body
+          description: |-
+            SimulateRequest is the request type for the Service.Simulate
+            RPC method.
           in: body
           required: true
           schema:
@@ -18520,6 +18523,11 @@ paths:
                         }
       parameters:
         - name: body
+          description: >-
+            BroadcastTxRequest is the request type for the
+            Service.BroadcastTxRequest
+
+            RPC method.
           in: body
           required: true
           schema:


### PR DESCRIPTION
Fix the installed ignite cli version when checking generated sources.

To avoid any inconsistencies between local generation the CI generation, use the `--clear-cache` flag when proceeding locally to prevent `ignite` from checking sources checksums before generating the spec:

```sh
ignite generate openapi --yes --clear-cache
```