### PR TITLE
Ci/docker publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,6 @@ on:
     branches: [ main ]
     tags: [ "v*" ]
 
-  pull_request:
-    branches: [ main ]
-
 concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: true
@@ -19,10 +16,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
-      - name: Set up context
-        id: project_context
-        uses: FranzDiebold/github-env-vars-action@v2.4.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -32,7 +25,6 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type=raw,enable=${{ !endsWith(github.ref, github.event.repository.default_branch) }},value=${{ env.CI_ACTION_REF_NAME_SLUG }}
             type=raw,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},value=nightly
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,12 @@ jobs:
           username: ${{ secrets.DOCKER_REGISTRY_ID }}
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: okp4
+          password: ${{ secrets.DOCKER_HUB_REGISTRY_TOKEN }}
+
       - name: Build and publish image(s)
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION
Some refinements on the publish CI workflow.

I propose through these changes to no longer publish PR docker images on `ghcr.io` and keep the publication only for `nightly` and release builds. If needed we can discuss to setup a specific manually triggered workflow for PR publication, maybe in a second time.

Additionally, the [Docker Hub](https://hub.docker.com/) registry has been added to the targeted registry at publication.