### PR TITLE
ci(publish): explicitely reference docker hub as registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         id: docker_metadata
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/${{ github.repository }},${{ github.repository }}
           tags: |
             type=raw,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }},value=nightly
             type=semver,pattern={{version}}


### PR DESCRIPTION
Fix the docker publication on the Docker Hub, login was done the the registry was missing in the image names.