### PR TITLE
Ci/release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,6 @@ jobs:
         with:
           token: ${{ secrets.OKP4_TOKEN }}
 
-      - name: Setup Go environment
-        uses: actions/setup-go@v3.3.0
-        with:
-          go-version: "1.19"
-
       - name: Release project
         uses: cycjimmy/semantic-release-action@v2
         with:

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -22,12 +22,24 @@ plugins:
               numReplacements: 1
   - - "@semantic-release/exec"
     - prepareCmd: |
-        make build-go-linux-amd64
+        make release-assets
   - - "@semantic-release/github"
     - assets:
-        - name: okp4d_linux_amd64
-          label: Binary - Linux amd64
-          path: "./target/dist/linux/amd64/okp4d"
+        - name: okp4d-${nextRelease.version}-linux-amd64
+          label: okp4d-${nextRelease.version}-linux-amd64
+          path: "./target/release/okp4d-${nextRelease.version}-linux-amd64"
+        - name: okp4d-${nextRelease.version}-linux-amd64.tar.gz
+          label: okp4d-${nextRelease.version}-linux-amd64.tar.gz
+          path: "./target/release/okp4d-${nextRelease.version}-linux-amd64.tar.gz"
+        - name: okp4d-${nextRelease.version}-linux-arm64
+          label: okp4d-${nextRelease.version}-linux-arm64
+          path: "./target/release/okp4d-${nextRelease.version}-linux-arm64"
+        - name: okp4d-${nextRelease.version}-linux-arm64.tar.gz
+          label: okp4d-${nextRelease.version}-linux-arm64.tar.gz
+          path: "./target/release/okp4d-${nextRelease.version}-linux-arm64.tar.gz"
+        - name: sha256sum.txt
+          label: sha256sum.txt
+          path: "./target/release/sha256sum.txt"
   - - "@semantic-release/git"
     - assets:
         - CHANGELOG.md

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -31,12 +31,6 @@ plugins:
         - name: okp4d-${nextRelease.version}-linux-amd64.tar.gz
           label: okp4d-${nextRelease.version}-linux-amd64.tar.gz
           path: "./target/release/okp4d-${nextRelease.version}-linux-amd64.tar.gz"
-        - name: okp4d-${nextRelease.version}-linux-arm64
-          label: okp4d-${nextRelease.version}-linux-arm64
-          path: "./target/release/okp4d-${nextRelease.version}-linux-arm64"
-        - name: okp4d-${nextRelease.version}-linux-arm64.tar.gz
-          label: okp4d-${nextRelease.version}-linux-arm64.tar.gz
-          path: "./target/release/okp4d-${nextRelease.version}-linux-arm64.tar.gz"
         - name: sha256sum.txt
           label: sha256sum.txt
           path: "./target/release/sha256sum.txt"

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ $(RELEASE_TARGETS): ensure-buildx-builder
 		--load \
 		.; \
 	mkdir -p ${RELEASE_FOLDER}; \
+	docker rm -f tmp-okp4d || true; \
 	docker create -ti --name tmp-okp4d $$BINARY_NAME; \
 	docker cp tmp-okp4d:/usr/bin/okp4d ${RELEASE_FOLDER}/$$BINARY_NAME; \
 	docker rm -f tmp-okp4d; \

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,9 @@ proto-gen: proto-build ## Generate all the code from the Protobuf files
 	@cp -r github.com/okp4/okp4d/x/* x/
 	@rm -rf github.com
 
+## Release:
+release-assets: release-binary-all release-checksums ## Generate release assets
+
 release-binary-all: $(RELEASE_TARGETS)
 
 $(RELEASE_TARGETS): ensure-buildx-builder

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,13 @@ $(RELEASE_TARGETS): ensure-buildx-builder
 	docker rm -f tmp-okp4d; \
 	tar -zcvf ${RELEASE_FOLDER}/$$BINARY_NAME.tar.gz ${RELEASE_FOLDER}/$$BINARY_NAME;
 
+release-checksums:
+	@echo "${COLOR_CYAN} 🐾 Generating release binary checksums${COLOR_RESET} into ${COLOR_YELLOW}${RELEASE_FOLDER}${COLOR_RESET}"
+	@rm ${RELEASE_FOLDER}/sha256sum.txt; \
+	for asset in `ls ${RELEASE_FOLDER}`; do \
+		shasum -a 256 ${RELEASE_FOLDER}/$$asset >> ${RELEASE_FOLDER}/sha256sum.txt; \
+	done;
+
 ensure-buildx-builder:
 	@echo "${COLOR_CYAN} 👷 Ensuring docker buildx builder${COLOR_RESET}"
 	@docker buildx ls | sed '1 d' | cut -f 1 -d ' ' | grep -q ${DOCKER_BUILDX_BUILDER} || \

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,7 @@ ENVIRONMENTS_TARGETS = $(addprefix build-go-, $(ENVIRONMENTS))
 
 # Release binaries
 RELEASE_BINARIES = \
-	linux-amd64 \
-	linux-arm64
+	linux-amd64
 RELEASE_TARGETS = $(addprefix release-binary-, $(RELEASE_BINARIES))
 
 .PHONY: all lint lint-go build build-go help

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@
 BINARY_NAME             = okp4d
 TARGET_FOLDER           = target
 DIST_FOLDER             = $(TARGET_FOLDER)/dist
+RELEASE_FOLDER          = $(TARGET_FOLDER)/release
 DOCKER_IMAGE_GOLANG_CI  = golangci/golangci-lint:v1.49
 DOCKER_IMAGE_BUF  		= okp4/buf-cosmos:0.3.1
+DOCKER_BUILDX_BUILDER   = okp4-builder
 CMD_ROOT               :=./cmd/${BINARY_NAME}
 
 # Some colors
@@ -51,6 +53,12 @@ ENVIRONMENTS = \
 	linux-amd64 \
 	linux-arm64
 ENVIRONMENTS_TARGETS = $(addprefix build-go-, $(ENVIRONMENTS))
+
+# Release binaries
+RELEASE_BINARIES = \
+	linux-amd64 \
+	linux-arm64
+RELEASE_TARGETS = $(addprefix release-binary-, $(RELEASE_BINARIES))
 
 .PHONY: all lint lint-go build build-go help
 
@@ -151,6 +159,30 @@ proto-gen: proto-build ## Generate all the code from the Protobuf files
 		generate proto --template buf.gen.proto.yaml -v
 	@cp -r github.com/okp4/okp4d/x/* x/
 	@rm -rf github.com
+
+release-binary-all: $(RELEASE_TARGETS)
+
+$(RELEASE_TARGETS): ensure-buildx-builder
+	@GOOS=$(word 3, $(subst -, ,$@)); \
+    GOARCH=$(word 4, $(subst -, ,$@)); \
+    BINARY_NAME="okp4d-${VERSION}-$$GOOS-$$GOARCH"; \
+	echo "${COLOR_CYAN} 🎁 Building ${COLOR_GREEN}$$GOOS $$GOARCH ${COLOR_CYAN}release binary${COLOR_RESET} into ${COLOR_YELLOW}${RELEASE_FOLDER}${COLOR_RESET}"; \
+	docker buildx use ${DOCKER_BUILDX_BUILDER}; \
+	docker buildx build \
+		--platform $$GOOS/$$GOARCH \
+		-t $$BINARY_NAME \
+		--load \
+		.; \
+	mkdir -p ${RELEASE_FOLDER}; \
+	docker create -ti --name tmp-okp4d $$BINARY_NAME; \
+	docker cp tmp-okp4d:/usr/bin/okp4d ${RELEASE_FOLDER}/$$BINARY_NAME; \
+	docker rm -f tmp-okp4d; \
+	tar -zcvf ${RELEASE_FOLDER}/$$BINARY_NAME.tar.gz ${RELEASE_FOLDER}/$$BINARY_NAME;
+
+ensure-buildx-builder:
+	@echo "${COLOR_CYAN} 👷 Ensuring docker buildx builder${COLOR_RESET}"
+	@docker buildx ls | sed '1 d' | cut -f 1 -d ' ' | grep -q ${DOCKER_BUILDX_BUILDER} || \
+	docker buildx create --name ${DOCKER_BUILDX_BUILDER}
 
 ## Help:
 help: ## Show this help.


### PR DESCRIPTION
The proposed changes rework the release workflow regarding the produced released assets integration.

## 🎁 Release assets

The release asset generation now relies on `Makefile` targets generating two binaries for `linux/amd64` and `linux/arm64` architectures, which are statically linked binaries built using docker buildx capabilities.

The binaries are integrated as release assets and available in raw and in `.tar.gz` compressed format, along with their corresponding `SHA256` checksums. The released assets are listed as below:
- `okp4d-${version}-linux-amd64`
- `okp4d-${version}-linux-amd64.tar.gz`
- `okp4d-${version}-linux-arm64`
- `okp4d-${version}-linux-arm64.tar.gz`
- `sha256sum.txt`

## 🏭 Release installation

Through their format, pre-compiled binaries can be installed quickly using a [oneliner script](https://github.com/jpillora/installer) with:

```sh
curl https://i.jpillora.com/okp4/okp4d@$version! | bash
```

## EDIT:

I removed `linux/arm64` as it is hanging, we'll try to re-introduce it later..