### PR TITLE
Ci/release arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           token: ${{ secrets.OKP4_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Release project
         uses: cycjimmy/semantic-release-action@v2
         with:

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -31,6 +31,12 @@ plugins:
         - name: okp4d-${nextRelease.version}-linux-amd64.tar.gz
           label: okp4d-${nextRelease.version}-linux-amd64.tar.gz
           path: "./target/release/okp4d-${nextRelease.version}-linux-amd64.tar.gz"
+        - name: okp4d-${nextRelease.version}-linux-arm64
+          label: okp4d-${nextRelease.version}-linux-arm64
+          path: "./target/release/okp4d-${nextRelease.version}-linux-arm64"
+        - name: okp4d-${nextRelease.version}-linux-arm64.tar.gz
+          label: okp4d-${nextRelease.version}-linux-arm64.tar.gz
+          path: "./target/release/okp4d-${nextRelease.version}-linux-arm64.tar.gz"
         - name: sha256sum.txt
           label: sha256sum.txt
           path: "./target/release/sha256sum.txt"

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ ENVIRONMENTS_TARGETS = $(addprefix build-go-, $(ENVIRONMENTS))
 
 # Release binaries
 RELEASE_BINARIES = \
-	linux-amd64
+	linux-amd64 \
+	linux-arm64
 RELEASE_TARGETS = $(addprefix release-binary-, $(RELEASE_BINARIES))
 
 .PHONY: all lint lint-go build build-go help


### PR DESCRIPTION
Following https://github.com/okp4/okp4d/pull/159, and some testing regarding CI, finally embed the `linux/arm64` release binary build as a release asset 🥳.