### PR TITLE
Feat/okp4 inflation calculation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -77,6 +77,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Find changed go files
         id: changed-go-files

--- a/app/app.go
+++ b/app/app.go
@@ -103,6 +103,7 @@ import (
 	intertx "github.com/cosmos/interchain-accounts/x/inter-tx"
 	intertxkeeper "github.com/cosmos/interchain-accounts/x/inter-tx/keeper"
 	intertxtypes "github.com/cosmos/interchain-accounts/x/inter-tx/types"
+	okp4types "github.com/okp4/okp4d/pkg/mint"
 	logicmodule "github.com/okp4/okp4d/x/logic"
 	logicmodulekeeper "github.com/okp4/okp4d/x/logic/keeper"
 	logicmoduletypes "github.com/okp4/okp4d/x/logic/types"
@@ -633,7 +634,7 @@ func New(
 		groupmodule.NewAppModule(appCodec, app.GroupKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 		crisis.NewAppModule(&app.CrisisKeeper, skipGenesisInvariants),
 		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
-		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper, minttypes.DefaultInflationCalculationFn),
+		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper, okp4types.Okp4InflationCalculationFn),
 		slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
 		distr.NewAppModule(appCodec, app.DistrKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
 		staking.NewAppModule(appCodec, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/okp4/okp4d
 go 1.19
 
 require (
+	cosmossdk.io/errors v1.0.0-beta.7
 	github.com/CosmWasm/wasmd v0.28.0
 	github.com/cosmos/cosmos-sdk v0.46.1
 	github.com/cosmos/gogoproto v1.4.2
@@ -13,6 +14,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/ignite/cli v0.24.0
 	github.com/prometheus/client_golang v1.13.0
+	github.com/smartystreets/goconvey v1.6.4
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.5.0
 	github.com/stretchr/testify v1.8.0
@@ -29,7 +31,6 @@ require (
 	cloud.google.com/go/compute v1.7.0 // indirect
 	cloud.google.com/go/iam v0.3.0 // indirect
 	cloud.google.com/go/storage v1.22.1 // indirect
-	cosmossdk.io/errors v1.0.0-beta.7 // indirect
 	cosmossdk.io/math v1.0.0-beta.3 // indirect
 	filippo.io/edwards25519 v1.0.0-rc.1 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
@@ -103,6 +104,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.4.0 // indirect
 	github.com/googleapis/go-type-adapters v1.0.0 // indirect
 	github.com/gookit/color v1.5.1 // indirect
+	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
@@ -130,6 +132,7 @@ require (
 	github.com/jpillora/chisel v1.7.7 // indirect
 	github.com/jpillora/requestlog v1.0.0 // indirect
 	github.com/jpillora/sizestr v1.0.0 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
 	github.com/klauspost/compress v1.15.9 // indirect
 	github.com/lib/pq v1.10.6 // indirect
@@ -168,6 +171,7 @@ require (
 	github.com/sasha-s/go-deadlock v0.2.1-0.20190427202633-1595213edefa // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
+	github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d // indirect
 	github.com/spf13/afero v1.8.2 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -760,6 +760,7 @@ github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gookit/color v1.5.1 h1:Vjg2VEcdHpwq+oY63s/ksHrgJYCTo0bwWvmmYWdE9fQ=
 github.com/gookit/color v1.5.1/go.mod h1:wZFzea4X8qN6vHOSP2apMb4/+w/orMznEzYsIHPaqKM=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
@@ -917,6 +918,7 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jsternberg/zap-logfmt v1.0.0/go.mod h1:uvPs/4X51zdkcm5jXl5SYoN+4RK21K8mysFmDaM/h+o=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -1294,8 +1296,10 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=

--- a/pkg/mint/okp4InflationCalculationFn.go
+++ b/pkg/mint/okp4InflationCalculationFn.go
@@ -7,19 +7,18 @@ import (
 
 var (
 	initialInflation = sdk.NewDecWithPrec(15, 2)
-	inflationRate    = sdk.NewDecWithPrec(8, 1)
 )
 
 // Okp4InflationCalculationFn is the function used to calculate the inflation for the OKP4 network.
 // Inflation is calculated in absolute terms, without taking into account previous inflation, on the basis of the current
 // block height, knowing the total number of blocks for one year, using the formula:
 //
-// Inflation for year X = 0.15 * 0.8^(X-1)
+// Inflation for year X = 0.15 * inflationRateChange^(X-1)
 //
 // See: https://docs.okp4.network/docs/whitepaper/tokenomics#staking-rewards
 func Okp4InflationCalculationFn(ctx sdk.Context, minter minttypes.Minter, params minttypes.Params, _ sdk.Dec) sdk.Dec {
 	year := uint64(ctx.BlockHeight()) / params.BlocksPerYear
-	inflationForYear := initialInflation.Mul(inflationRate.Power(year))
+	inflationForYear := initialInflation.Mul(params.InflationRateChange.Power(year))
 
 	return inflationForYear.QuoInt64Mut(int64(params.BlocksPerYear))
 }

--- a/pkg/mint/okp4InflationCalculationFn.go
+++ b/pkg/mint/okp4InflationCalculationFn.go
@@ -1,0 +1,25 @@
+package mint
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+)
+
+var (
+	initialInflation = sdk.NewDecWithPrec(15, 2)
+	inflationRate    = sdk.NewDecWithPrec(8, 1)
+)
+
+// Okp4InflationCalculationFn is the function used to calculate the inflation for the OKP4 network.
+// Inflation is calculated in absolute terms, without taking into account previous inflation, on the basis of the current
+// block height, knowing the total number of blocks for one year, using the formula:
+//
+// Inflation for year X = 0.15 * 0.8^(X-1)
+//
+// See: https://docs.okp4.network/docs/whitepaper/tokenomics#staking-rewards
+func Okp4InflationCalculationFn(ctx sdk.Context, minter minttypes.Minter, params minttypes.Params, _ sdk.Dec) sdk.Dec {
+	year := uint64(ctx.BlockHeight()) / params.BlocksPerYear
+	inflationForYear := initialInflation.Mul(inflationRate.Power(year))
+
+	return inflationForYear.QuoInt64Mut(int64(params.BlocksPerYear))
+}

--- a/pkg/mint/okp4InflationCalculationFn_test.go
+++ b/pkg/mint/okp4InflationCalculationFn_test.go
@@ -1,0 +1,81 @@
+package mint
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestOkp4InflationCalculationFn(t *testing.T) {
+	Convey("Considering the Okp4InflationCalculationFn", t, func(c C) {
+		type args struct {
+			blockHeight   uint64
+			blocksPerYear uint64
+		}
+		tests := []struct {
+			name string
+			args args
+			want sdk.Dec
+		}{
+			{
+				name: "Inflation for the first block of the first year",
+				args: args{
+					blockHeight:   0,
+					blocksPerYear: 10,
+				}, want: sdk.NewDecWithPrec(15, 3),
+			},
+			{
+				name: "Inflation for the last block of the first year",
+				args: args{
+					blockHeight:   9,
+					blocksPerYear: 10,
+				}, want: sdk.NewDecWithPrec(15, 3),
+			},
+			{
+				name: "Inflation for the first block of the second year",
+				args: args{
+					blockHeight:   10,
+					blocksPerYear: 10,
+				}, want: sdk.NewDecWithPrec(12, 3),
+			},
+			{
+				name: "Inflation for the second block of the third year",
+				args: args{
+					blockHeight:   21,
+					blocksPerYear: 10,
+				}, want: sdk.MustNewDecFromStr("0.0096"),
+			},
+			{
+				name: "Inflation for a block in the 16th year",
+				args: args{
+					blockHeight:   87899401,
+					blocksPerYear: 5256000,
+				}, want: sdk.MustNewDecFromStr("0.000000000803296166"),
+			},
+		}
+
+		for i, tt := range tests {
+			Convey(fmt.Sprintf("Given the context for test case %d (%s)", i, tt.name), func() {
+				mkey := sdk.NewKVStoreKey(fmt.Sprintf("test-%d", i))
+				tkey := sdk.NewTransientStoreKey(fmt.Sprintf("transient_test_%d", i))
+				ctx := testutil.DefaultContext(mkey, tkey).WithBlockHeight(int64(tt.args.blockHeight))
+				minter := minttypes.DefaultInitialMinter()
+				params := minttypes.DefaultParams()
+				params.MintDenom = "uknow"
+				params.BlocksPerYear = tt.args.blocksPerYear
+
+				Convey("When calling testcase", func() {
+					got := Okp4InflationCalculationFn(ctx, minter, params, sdk.ZeroDec())
+
+					Convey(fmt.Sprintf("Then result should be '%d'", tt.want), func() {
+						So(got, ShouldEqual, tt.want)
+					})
+				})
+			})
+		}
+	})
+}

--- a/pkg/mint/okp4InflationCalculationFn_test.go
+++ b/pkg/mint/okp4InflationCalculationFn_test.go
@@ -13,8 +13,9 @@ import (
 func TestOkp4InflationCalculationFn(t *testing.T) {
 	Convey("Considering the Okp4InflationCalculationFn", t, func(c C) {
 		type args struct {
-			blockHeight   uint64
-			blocksPerYear uint64
+			blockHeight         uint64
+			blocksPerYear       uint64
+			inflationRateChange float64
 		}
 		tests := []struct {
 			name string
@@ -24,36 +25,41 @@ func TestOkp4InflationCalculationFn(t *testing.T) {
 			{
 				name: "Inflation for the first block of the first year",
 				args: args{
-					blockHeight:   0,
-					blocksPerYear: 10,
+					blockHeight:         0,
+					blocksPerYear:       10,
+					inflationRateChange: .8,
 				}, want: sdk.NewDecWithPrec(15, 3),
 			},
 			{
 				name: "Inflation for the last block of the first year",
 				args: args{
-					blockHeight:   9,
-					blocksPerYear: 10,
+					blockHeight:         9,
+					blocksPerYear:       10,
+					inflationRateChange: .8,
 				}, want: sdk.NewDecWithPrec(15, 3),
 			},
 			{
 				name: "Inflation for the first block of the second year",
 				args: args{
-					blockHeight:   10,
-					blocksPerYear: 10,
+					blockHeight:         10,
+					blocksPerYear:       10,
+					inflationRateChange: .8,
 				}, want: sdk.NewDecWithPrec(12, 3),
 			},
 			{
 				name: "Inflation for the second block of the third year",
 				args: args{
-					blockHeight:   21,
-					blocksPerYear: 10,
+					blockHeight:         21,
+					blocksPerYear:       10,
+					inflationRateChange: .8,
 				}, want: sdk.MustNewDecFromStr("0.0096"),
 			},
 			{
 				name: "Inflation for a block in the 16th year",
 				args: args{
-					blockHeight:   87899401,
-					blocksPerYear: 5256000,
+					blockHeight:         87899401,
+					blocksPerYear:       5256000,
+					inflationRateChange: .8,
 				}, want: sdk.MustNewDecFromStr("0.000000000803296166"),
 			},
 		}
@@ -67,6 +73,7 @@ func TestOkp4InflationCalculationFn(t *testing.T) {
 				params := minttypes.DefaultParams()
 				params.MintDenom = "uknow"
 				params.BlocksPerYear = tt.args.blocksPerYear
+				params.InflationRateChange = sdk.MustNewDecFromStr(fmt.Sprintf("%f", tt.args.inflationRateChange))
 
 				Convey("When calling testcase", func() {
 					got := Okp4InflationCalculationFn(ctx, minter, params, sdk.ZeroDec())


### PR DESCRIPTION
Implements and declares the custom OKP4 function for inflation calculation, according to the following formula:

```
inflation for the block of the year X = 0.15 * inflationRateChange^(X-1) / blocksPerYear
```

as stated in [whitepaper/tokenomics#staking-rewards](https://docs.okp4.network/docs/whitepaper/tokenomics#staking-rewards), where:

- `inflationRateChange` is the rate of inflation for each year, equal to `0.8` in the OKP4 network tokenomics.
- `blocksPerYear` is the (expected) total number of blocks in a year. E.g. approx. `5259600` blocks for a year at the rate of one block every 6 seconds.

Example of `mint` module configuration: 15% initial inflation - `0.8` inflation rate per year

```json
    "mint": {
      "minter": {
        "inflation": "0.150000000000000000",
        "annual_provisions": "0.000000000000000000"
      },
      "params": {
        "mint_denom": "uknow",
        "inflation_rate_change": "0.800000000000000000",
        "inflation_max": "0.000000000000000000",
        "inflation_min": "0.000000000000000000",
        "goal_bonded": "0.000000000000000000",
        "blocks_per_year": "5259600"
      }
    }
```