### PR TITLE
fix(mint): provide annual inflation rate

### DIFF
--- a/pkg/mint/okp4InflationCalculationFn.go
+++ b/pkg/mint/okp4InflationCalculationFn.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	initialInflation = sdk.NewDecWithPrec(15, 2)
+	initialInflation = sdk.NewDecWithPrec(75, 3)
 )
 
 // Okp4InflationCalculationFn is the function used to calculate the inflation for the OKP4 network.

--- a/pkg/mint/okp4InflationCalculationFn.go
+++ b/pkg/mint/okp4InflationCalculationFn.go
@@ -18,7 +18,6 @@ var (
 // See: https://docs.okp4.network/docs/whitepaper/tokenomics#staking-rewards
 func Okp4InflationCalculationFn(ctx sdk.Context, minter minttypes.Minter, params minttypes.Params, _ sdk.Dec) sdk.Dec {
 	year := uint64(ctx.BlockHeight()) / params.BlocksPerYear
-	inflationForYear := initialInflation.Mul(params.InflationRateChange.Power(year))
 
-	return inflationForYear.QuoInt64Mut(int64(params.BlocksPerYear))
+	return initialInflation.Mul(params.InflationRateChange.Power(year))
 }

--- a/pkg/mint/okp4InflationCalculationFn_test.go
+++ b/pkg/mint/okp4InflationCalculationFn_test.go
@@ -28,7 +28,7 @@ func TestOkp4InflationCalculationFn(t *testing.T) {
 					blockHeight:         0,
 					blocksPerYear:       10,
 					inflationRateChange: .8,
-				}, want: sdk.NewDecWithPrec(15, 2),
+				}, want: sdk.NewDecWithPrec(75, 3),
 			},
 			{
 				name: "Inflation for the last block of the first year",
@@ -36,7 +36,7 @@ func TestOkp4InflationCalculationFn(t *testing.T) {
 					blockHeight:         9,
 					blocksPerYear:       10,
 					inflationRateChange: .8,
-				}, want: sdk.NewDecWithPrec(15, 2),
+				}, want: sdk.NewDecWithPrec(75, 3),
 			},
 			{
 				name: "Inflation for the first block of the second year",
@@ -44,7 +44,7 @@ func TestOkp4InflationCalculationFn(t *testing.T) {
 					blockHeight:         10,
 					blocksPerYear:       10,
 					inflationRateChange: .8,
-				}, want: sdk.NewDecWithPrec(12, 2),
+				}, want: sdk.NewDecWithPrec(6, 2),
 			},
 			{
 				name: "Inflation for the second block of the third year",
@@ -52,7 +52,7 @@ func TestOkp4InflationCalculationFn(t *testing.T) {
 					blockHeight:         21,
 					blocksPerYear:       10,
 					inflationRateChange: .8,
-				}, want: sdk.MustNewDecFromStr("0.096"),
+				}, want: sdk.MustNewDecFromStr("0.048"),
 			},
 			{
 				name: "Inflation for a block in the 16th year",
@@ -60,7 +60,7 @@ func TestOkp4InflationCalculationFn(t *testing.T) {
 					blockHeight:         87899401,
 					blocksPerYear:       5256000,
 					inflationRateChange: .8,
-				}, want: sdk.MustNewDecFromStr("0.004222124650659840"),
+				}, want: sdk.MustNewDecFromStr("0.002111062325329920"),
 			},
 		}
 

--- a/pkg/mint/okp4InflationCalculationFn_test.go
+++ b/pkg/mint/okp4InflationCalculationFn_test.go
@@ -28,7 +28,7 @@ func TestOkp4InflationCalculationFn(t *testing.T) {
 					blockHeight:         0,
 					blocksPerYear:       10,
 					inflationRateChange: .8,
-				}, want: sdk.NewDecWithPrec(15, 3),
+				}, want: sdk.NewDecWithPrec(15, 2),
 			},
 			{
 				name: "Inflation for the last block of the first year",
@@ -36,7 +36,7 @@ func TestOkp4InflationCalculationFn(t *testing.T) {
 					blockHeight:         9,
 					blocksPerYear:       10,
 					inflationRateChange: .8,
-				}, want: sdk.NewDecWithPrec(15, 3),
+				}, want: sdk.NewDecWithPrec(15, 2),
 			},
 			{
 				name: "Inflation for the first block of the second year",
@@ -44,7 +44,7 @@ func TestOkp4InflationCalculationFn(t *testing.T) {
 					blockHeight:         10,
 					blocksPerYear:       10,
 					inflationRateChange: .8,
-				}, want: sdk.NewDecWithPrec(12, 3),
+				}, want: sdk.NewDecWithPrec(12, 2),
 			},
 			{
 				name: "Inflation for the second block of the third year",
@@ -52,7 +52,7 @@ func TestOkp4InflationCalculationFn(t *testing.T) {
 					blockHeight:         21,
 					blocksPerYear:       10,
 					inflationRateChange: .8,
-				}, want: sdk.MustNewDecFromStr("0.0096"),
+				}, want: sdk.MustNewDecFromStr("0.096"),
 			},
 			{
 				name: "Inflation for a block in the 16th year",
@@ -60,7 +60,7 @@ func TestOkp4InflationCalculationFn(t *testing.T) {
 					blockHeight:         87899401,
 					blocksPerYear:       5256000,
 					inflationRateChange: .8,
-				}, want: sdk.MustNewDecFromStr("0.000000000803296166"),
+				}, want: sdk.MustNewDecFromStr("0.004222124650659840"),
 			},
 		}
 


### PR DESCRIPTION
Fix the inflation calcul to provide an annual inflation rate, the per block being populated by the module itself.

Additionally, Staking rewards on the [Whitepaper](https://docs.okp4.network/docs/whitepaper/tokenomics#staking-rewards) being calculated once a year and the actual `mint` module calculating it every block there's a difference caused by previously minted coins. To mitigate this issue the initial inflation rate is set to 7.5% instead of 15%, but the distribution will not be linear across blocks, a re-implementation of the `mint` module shall be considered.