### PR TITLE
Ci/linter improvements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -101,6 +101,16 @@ jobs:
         with:
           version: v1.49
 
+      - name: Lint go code (gofumpt)
+        if: steps.changed-go-files.outputs.any_changed == 'true'
+        run: |
+          go install mvdan.cc/gofumpt@v0.4.0
+          if [ "$(gofumpt -l .)" != "" ]; then
+            echo "❌ Code is not gofumpt!"
+            exit 1
+          fi
+          echo "✅ Code is gofumpt!"
+
   lint-dockerfile:
     runs-on: ubuntu-20.04
     if: github.actor != 'dependabot[bot]'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,14 +44,11 @@ linters:
     - predeclared
     - promlinter
     - revive
-    - rowserrcheck
-    - sqlclosecheck
     - stylecheck
     - tenv
     - tparallel
     - unconvert
     - unparam
-    - wastedassign
     - whitespace
 
 linters-settings:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BINARY_NAME             = okp4d
 TARGET_FOLDER           = target
 DIST_FOLDER             = $(TARGET_FOLDER)/dist
 RELEASE_FOLDER          = $(TARGET_FOLDER)/release
+DOCKER_IMAGE_GOLANG		= golang:1.19-alpine3.16
 DOCKER_IMAGE_GOLANG_CI  = golangci/golangci-lint:v1.49
 DOCKER_IMAGE_BUF  		= okp4/buf-cosmos:0.3.1
 DOCKER_BUILDX_BUILDER   = okp4-builder
@@ -83,6 +84,18 @@ lint-proto: ## Lint proto files
   		-w /proto \
   		${DOCKER_IMAGE_BUF} \
   		lint proto -v
+
+## Format:
+format: format-go ## Run all available formatters
+
+format-go: ## Format go files
+	@echo "${COLOR_CYAN}📐 Formatting go source code${COLOR_RESET}"
+	@docker run --rm \
+  		-v `pwd`:/app:rw \
+  		-w /app \
+  		${DOCKER_IMAGE_GOLANG} \
+  		sh -c \
+		"go install mvdan.cc/gofumpt@v0.4.0; gofumpt -w -l ."
 
 ## Build:
 build: build-go ## Build all available artefacts (executable, docker image, etc.)

--- a/README.md
+++ b/README.md
@@ -34,27 +34,6 @@ Want to become a validator? 👉 [Checkout the documentation!](https://docs.okp4
 
 Looking for a network to join ? 👉 [Checkout the networks!](https://github.com/okp4/networks)
 
-## Developing & contributing
-
-`okp4d` is written in [Go] and built using [Cosmos SDK].
-
-### Prerequisites
-
-- install [Go] `1.19+` following instructions from the [official Go documentation](https://golang.org/doc/install);
-- use [gofumpt](https://github.com/mvdan/gofumpt) as formatter, you can integrate it in your favorite IDE following these [instructions](https://github.com/mvdan/gofumpt#installation);
-- verify that [Docker] is properly installed and if not, follow the [instructions](https://docs.docker.com) for your environment;
-- the project comes with a convenient `Makefile` so verify that [`make`](https://fr.wikipedia.org/wiki/Make) is properly installed.
-
-### Build
-
-To build the `okp4d` node, invoke the goal `build` of the `Makefile`:
-
-```sh
-make build
-```
-
-The binary will be generated under the folder `target/dist`.
-
 ## Supported platforms
 
 The `okp4d` blockchain currently supports the following builds:
@@ -110,7 +89,7 @@ docker run -v $(pwd)/home:/home okp4/okp4d:latest keys add my-wallet --keyring-b
 
 ### Start a node
 
-Everything you need to start a node and even more is explained here : <https://docs.okp4.network/docs/nodes/run-node>
+Everything you need to start a node and more is explained here: <https://docs.okp4.network/docs/nodes/run-node>
 
 ```bash
 MONIKER=node-in-my-name
@@ -130,6 +109,28 @@ Set `persistent_peers` in `config/config.toml` file.
 ```bash
 docker run -v $(pwd)/home:/home okp4/okp4d:latest start --home /home
 ```
+
+## Developing & contributing
+
+`okp4d` is written in [Go] and built using [Cosmos SDK]. A number of smart contracts are also deployed on the
+OKP4 blockchain and hosted in the [okp4/contracts](https://github.com/okp4/contracts) project.
+
+### Prerequisites
+
+- install [Go] `1.19+` following instructions from the [official Go documentation](https://golang.org/doc/install);
+- use [gofumpt](https://github.com/mvdan/gofumpt) as formatter. You can integrate it in your favorite IDE following these [instructions](https://github.com/mvdan/gofumpt#installation) or invoke the makefile `make format-go`;
+- verify that [Docker] is properly installed and if not, follow the [instructions](https://docs.docker.com) for your environment;
+- the project comes with a convenient `Makefile` so verify that [`make`](https://fr.wikipedia.org/wiki/Make) is properly installed.
+
+### Build
+
+To build the `okp4d` node, invoke the goal `build` of the `Makefile`:
+
+```sh
+make build
+```
+
+The binary will be generated under the folder `target/dist`.
 
 ## Bug reports & feature requests
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Looking for a network to join ? 👉 [Checkout the networks!](https://github.com
 ### Prerequisites
 
 - install [Go] `1.19+` following instructions from the [official Go documentation](https://golang.org/doc/install);
+- use [gofumpt](https://github.com/mvdan/gofumpt) as formatter, you can integrate it in your favorite IDE following these [instructions](https://github.com/mvdan/gofumpt#installation);
 - verify that [Docker] is properly installed and if not, follow the [instructions](https://docs.docker.com) for your environment;
 - the project comes with a convenient `Makefile` so verify that [`make`](https://fr.wikipedia.org/wiki/Make) is properly installed.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ we also apply the philosophical principles of [release early - release often](ht
 
 ## Docker image
 
-A docker image is available on [Docker hub](https://hub.docker.com/r/okp4/okp4d):
+For a quick start, a docker image is officially available on [Docker hub](https://hub.docker.com/r/okp4/okp4d).
 
 ```bash
 docker pull okp4/okp4d:latest
@@ -120,7 +120,51 @@ OKP4 blockchain and hosted in the [okp4/contracts](https://github.com/okp4/contr
 - install [Go] `1.19+` following instructions from the [official Go documentation](https://golang.org/doc/install);
 - use [gofumpt](https://github.com/mvdan/gofumpt) as formatter. You can integrate it in your favorite IDE following these [instructions](https://github.com/mvdan/gofumpt#installation) or invoke the makefile `make format-go`;
 - verify that [Docker] is properly installed and if not, follow the [instructions](https://docs.docker.com) for your environment;
-- the project comes with a convenient `Makefile` so verify that [`make`](https://fr.wikipedia.org/wiki/Make) is properly installed.
+- verify that [`make`](https://fr.wikipedia.org/wiki/Make) is properly installed if you intend to use the provided `Makefile`.
+
+### Makefile
+
+The project comes with a convenient `Makefile` that helps you to build, install, lint and test the project.
+
+```text
+$ make help
+
+Usage:
+  make <target>
+
+Targets:
+  Lint:
+    lint                Lint all available linters
+    lint-go             Lint go source code
+    lint-proto          Lint proto files
+  Format:
+    format              Run all available formatters
+    format-go           Format go files
+  Build:
+    build               Build all available artefacts (executable, docker image, etc.)
+    build-go            Build node executable for the current environment (default build)
+    build-go-all        Build node executables for all available environments
+  Install:
+    install             Install node executable
+  Test:
+    test                Pass all the tests
+    test-go             Pass the test for the go source code
+  Clean:
+    clean               Remove all the files from the target folder
+  Proto:
+    proto-format        Format Protobuf files
+    proto-build         Build all Protobuf files
+    proto-gen           Generate all the code from the Protobuf files
+  Release:
+    release-assets      Generate release assets
+  Help:
+    help                Show this help.
+
+This Makefile depends on docker. To install it, please follow the instructions:
+- for macOS: https://docs.docker.com/docker-for-mac/install/
+- for Windows: https://docs.docker.com/docker-for-windows/install/
+- for Linux: https://docs.docker.com/engine/install/
+```
 
 ### Build
 

--- a/app/app.go
+++ b/app/app.go
@@ -629,7 +629,7 @@ func New(
 
 	// NOTE: we may consider parsing `appOpts` inside module constructors. For the moment
 	// we prefer to be more strict in what arguments the modules expect.
-	var skipGenesisInvariants = cast.ToBool(appOpts.Get(crisis.FlagSkipGenesisInvariants))
+	skipGenesisInvariants := cast.ToBool(appOpts.Get(crisis.FlagSkipGenesisInvariants))
 
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.

--- a/pkg/mint/okp4InflationCalculationFn.go
+++ b/pkg/mint/okp4InflationCalculationFn.go
@@ -5,9 +5,7 @@ import (
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 )
 
-var (
-	initialInflation = sdk.NewDecWithPrec(75, 3)
-)
+var initialInflation = sdk.NewDecWithPrec(75, 3)
 
 // Okp4InflationCalculationFn is the function used to calculate the inflation for the OKP4 network.
 // Inflation is calculated in absolute terms, without taking into account previous inflation, on the basis of the current

--- a/x/logic/client/cli/tx.go
+++ b/x/logic/client/cli/tx.go
@@ -10,9 +10,7 @@ import (
 	"github.com/okp4/okp4d/x/logic/types"
 )
 
-var (
-	DefaultRelativePacketTimeoutTimestamp = uint64((time.Duration(10) * time.Minute).Nanoseconds())
-)
+var DefaultRelativePacketTimeoutTimestamp = uint64((time.Duration(10) * time.Minute).Nanoseconds())
 
 //nolint:unused
 const (

--- a/x/logic/keeper/keeper.go
+++ b/x/logic/keeper/keeper.go
@@ -25,7 +25,6 @@ func NewKeeper(
 	storeKey,
 	memKey storetypes.StoreKey,
 	ps paramtypes.Subspace,
-
 ) *Keeper {
 	// set KeyTable if it has not already been set
 	if !ps.HasKeyTable() {
@@ -33,7 +32,6 @@ func NewKeeper(
 	}
 
 	return &Keeper{
-
 		cdc:        cdc,
 		storeKey:   storeKey,
 		memKey:     memKey,

--- a/x/vesting/msg_server.go
+++ b/x/vesting/msg_server.go
@@ -28,7 +28,8 @@ var _ types.MsgServer = msgServer{}
 
 //nolint:funlen
 func (s msgServer) CreateVestingAccount(goCtx context.Context,
-	msg *types.MsgCreateVestingAccount) (*types.MsgCreateVestingAccountResponse, error) {
+	msg *types.MsgCreateVestingAccount,
+) (*types.MsgCreateVestingAccountResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	ak := s.AccountKeeper
 	bk := s.BankKeeper
@@ -97,7 +98,8 @@ func (s msgServer) CreateVestingAccount(goCtx context.Context,
 }
 
 func (s msgServer) CreatePermanentLockedAccount(goCtx context.Context,
-	msg *types.MsgCreatePermanentLockedAccount) (*types.MsgCreatePermanentLockedAccountResponse, error) {
+	msg *types.MsgCreatePermanentLockedAccount,
+) (*types.MsgCreatePermanentLockedAccountResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	ak := s.AccountKeeper
 	bk := s.BankKeeper
@@ -159,7 +161,8 @@ func (s msgServer) CreatePermanentLockedAccount(goCtx context.Context,
 }
 
 func (s msgServer) CreatePeriodicVestingAccount(goCtx context.Context,
-	msg *types.MsgCreatePeriodicVestingAccount) (*types.MsgCreatePeriodicVestingAccountResponse, error) {
+	msg *types.MsgCreatePeriodicVestingAccount,
+) (*types.MsgCreatePeriodicVestingAccountResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	ak := s.AccountKeeper
@@ -220,7 +223,8 @@ func (s msgServer) CreatePeriodicVestingAccount(goCtx context.Context,
 
 //nolint:funlen
 func (s msgServer) CreateCliffVestingAccount(goCtx context.Context,
-	msg *types.MsgCreateCliffVestingAccount) (*types.MsgCreateCliffVestingAccountResponse, error) {
+	msg *types.MsgCreateCliffVestingAccount,
+) (*types.MsgCreateCliffVestingAccountResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	ak := s.AccountKeeper
 	bk := s.BankKeeper

--- a/x/vesting/types/msgs.go
+++ b/x/vesting/types/msgs.go
@@ -34,7 +34,8 @@ func NewMsgCreateVestingAccount(fromAddr,
 	toAddr sdk.AccAddress,
 	amount sdk.Coins,
 	endTime int64,
-	delayed bool) *MsgCreateVestingAccount {
+	delayed bool,
+) *MsgCreateVestingAccount {
 	return &MsgCreateVestingAccount{
 		FromAddress: fromAddr.String(),
 		ToAddress:   toAddr.String(),
@@ -141,7 +142,8 @@ func (msg MsgCreatePermanentLockedAccount) GetSigners() []sdk.AccAddress {
 func NewMsgCreatePeriodicVestingAccount(fromAddr,
 	toAddr sdk.AccAddress,
 	startTime int64,
-	periods []Period) *MsgCreatePeriodicVestingAccount {
+	periods []Period,
+) *MsgCreatePeriodicVestingAccount {
 	return &MsgCreatePeriodicVestingAccount{
 		FromAddress:    fromAddr.String(),
 		ToAddress:      toAddr.String(),
@@ -208,7 +210,8 @@ func (msg MsgCreatePeriodicVestingAccount) ValidateBasic() error {
 func NewMsgCreateCliffVestingAccount(fromAddr,
 	toAddr sdk.AccAddress,
 	amount sdk.Coins,
-	endTime, cliffTime int64) *MsgCreateCliffVestingAccount {
+	endTime, cliffTime int64,
+) *MsgCreateCliffVestingAccount {
 	return &MsgCreateCliffVestingAccount{
 		FromAddress: fromAddr.String(),
 		ToAddress:   toAddr.String(),

--- a/x/vesting/types/vesting_account.go
+++ b/x/vesting/types/vesting_account.go
@@ -211,7 +211,8 @@ func NewContinuousVestingAccountRaw(bva *BaseVestingAccount, startTime int64) *C
 // NewContinuousVestingAccount returns a new ContinuousVestingAccount.
 func NewContinuousVestingAccount(baseAcc *authtypes.BaseAccount,
 	originalVesting sdk.Coins,
-	startTime, endTime int64) *ContinuousVestingAccount {
+	startTime, endTime int64,
+) *ContinuousVestingAccount {
 	baseVestingAcc := &BaseVestingAccount{
 		BaseAccount:     baseAcc,
 		OriginalVesting: originalVesting,
@@ -331,7 +332,8 @@ func NewPeriodicVestingAccountRaw(bva *BaseVestingAccount, startTime int64, peri
 func NewPeriodicVestingAccount(baseAcc *authtypes.BaseAccount,
 	originalVesting sdk.Coins,
 	startTime int64,
-	periods Periods) *PeriodicVestingAccount {
+	periods Periods,
+) *PeriodicVestingAccount {
 	endTime := startTime
 	for _, p := range periods {
 		endTime += p.Length
@@ -617,7 +619,8 @@ func NewCliffVestingAccountRaw(bva *BaseVestingAccount, startTime int64, cliffTi
 // NewCliffVestingAccount returns a new CliffVestingAccount.
 func NewCliffVestingAccount(baseAcc *authtypes.BaseAccount,
 	originalVesting sdk.Coins,
-	startTime, cliffTime, endTime int64) *CliffVestingAccount {
+	startTime, cliffTime, endTime int64,
+) *CliffVestingAccount {
 	baseVestingAcc := &BaseVestingAccount{
 		BaseAccount:     baseAcc,
 		OriginalVesting: originalVesting,


### PR DESCRIPTION
Continue the work on linters initiated by @faddat: https://github.com/okp4/okp4d/pull/175 & https://github.com/okp4/okp4d/pull/174. Thank you by the way! 🙏 

- Enforce `gofumpt` code formatting by adding the linter to the `Lint` workflow.
- Add a target to the makefile to format go source code using `gofmpt`
- Improve documentation (a bit)