### PR TITLE
📚 Publish proto on buf registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,3 +38,25 @@ jobs:
       - name: Build docker image
         run: |
           docker build .
+
+  build-proto:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Find changed proto files
+        id: changed-proto-files
+        uses: tj-actions/changed-files@v31.0.3
+        with:
+          files: |
+            proto/**/*.proto
+
+      - name: Setup buf
+        if: steps.changed-proto-files.outputs.any_changed == 'true'
+        uses: bufbuild/buf-setup-action@v1.8.0
+
+      - name: Build and generate proto
+        if: steps.changed-proto-files.outputs.any_changed == 'true'
+        run: |
+          make proto-gen

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           docker build .
 
   build-proto:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -134,10 +134,12 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Find changed proto files
         id: changed-proto-files
-        uses: tj-actions/changed-files@v31.0.3
+        uses: tj-actions/changed-files@v34.5.4
         with:
           files: |
             proto/**/*.proto

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -135,7 +135,15 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3
 
+      - name: Find changed proto files
+        id: changed-proto-files
+        uses: tj-actions/changed-files@v31.0.3
+        with:
+          files: |
+            proto/**/*.proto
+
       - name: Lint proto files
+        if: steps.changed-proto-files.outputs.any_changed == 'true'
         run: |
           make lint-proto
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,3 +78,18 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_REGISTRY_TOKEN }}
           repository: okp4/okp4d
           readme-filepath: README.md
+
+  publish-buf-proto:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup buf
+        uses: bufbuild/buf-setup-action@v1.8.0
+
+      - name: Push okp4 proto on buf registry
+        uses: bufbuild/buf-push-action@v1
+        with:
+          input: 'proto'
+          buf_token: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
Publish protobuf file on [buf registry](https://buf.build/explore).

The lint process before the publish is already done on [lint workflow](https://github.com/okp4/okp4d/blob/main/.github/workflows/lint.yml#L121). 

#### ✏️ Todo
Before merge, those steps is **mandatory** and can only be done by account holder. _This PR is kept in draft since those actions are not done._ 
- [x] Create buf account 
- [x] Register okp4 and okp4d repository : `buf beta registry repository create buf.build/okp4/okp4d --visibility public`
- [x] Register `BUF_TOKEN` into GitHub action environment variables.  

https://docs.buf.build/tour/push-a-module