### PR TITLE
Bump: ledger v0.9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 #--- Build stage
 FROM golang:1.19-alpine3.16 AS go-builder
 
+# install Linux header and build-base for native C codes
+RUN apk add --no-cache \
+    ca-certificates \
+    build-base \
+    linux-headers
+
 WORKDIR /src
 
 # CosmWasm: see https://github.com/CosmWasm/wasmvm/releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,6 @@
 #--- Build stage
 FROM golang:1.19-alpine3.16 AS go-builder
 
-# install Linux header and build-base for native C codes
-RUN apk add --no-cache \
-    ca-certificates \
-    build-base \
-    linux-headers
-
 WORKDIR /src
 
 # CosmWasm: see https://github.com/CosmWasm/wasmvm/releases
@@ -15,7 +9,7 @@ ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.
 
 # hadolint ignore=DL4006
 RUN set -eux \
-    && apk add --no-cache ca-certificates=20220614-r0 build-base=0.5-r3 git=2.36.2-r0 \
+    && apk add --no-cache ca-certificates=20220614-r0 build-base=0.5-r3 git=2.36.2-r0 linux-headers=5.16.7-r1 \
     && sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 9ecb037336bd56076573dc18c26631a9d2099a7f2b40dc04b6cae31ffb4c8f9a \
     && sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 6e4de7ba9bad4ae9679c7f9ecf7e283dd0160e71567c6a7be6ae47c81ebe7f32 \
     && cp "/lib/libwasmvm_muslc.$(uname -m).a" /lib/libwasmvm_muslc.a

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ COLOR_CYAN   = $(shell tput -Txterm setaf 6)
 COLOR_RED    = $(shell tput -Txterm setaf 1)
 COLOR_RESET  = $(shell tput -Txterm sgr0)
 
-BUILD_TAGS += netgo
+BUILD_TAGS += netgo ledger
 BUILD_TAGS := $(strip $(BUILD_TAGS))
 
 # Flags

--- a/go.mod
+++ b/go.mod
@@ -212,5 +212,6 @@ require (
 
 replace (
 	github.com/CosmWasm/wasmd => github.com/notional-labs/wasmd v0.25.1-0.20220918064224-459cefae5a9a
+	github.com/cosmos/ledger-go => github.com/cosmos/ledger-go v0.9.3
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 )

--- a/go.sum
+++ b/go.sum
@@ -426,7 +426,6 @@ github.com/cosmos/interchain-accounts v0.3.5 h1:u8HI9B+KRKLDRNSz7aFvyi9xfrJxHIyT
 github.com/cosmos/interchain-accounts v0.3.5/go.mod h1:5G7oTCQJ/HO0vlII23i4tdER2dENfvPKn4uhiMs2JrE=
 github.com/cosmos/ledger-cosmos-go v0.11.1 h1:9JIYsGnXP613pb2vPjFeMMjBI5lEDsEaF6oYorTy6J4=
 github.com/cosmos/ledger-cosmos-go v0.11.1/go.mod h1:J8//BsAGTo3OC/vDLjMRFLW6q0WAaXvHnVc7ZmE8iUY=
-github.com/cosmos/ledger-go v0.9.2/go.mod h1:oZJ2hHAZROdlHiwTg4t7kP+GKIIkBT+o6c9QWFanOyI=
 github.com/cosmos/ledger-go v0.9.3 h1:WGyZK4ikuLIkbxJm3lEr1tdQYDdTdveTwoVla7hqfhQ=
 github.com/cosmos/ledger-go v0.9.3/go.mod h1:oZJ2hHAZROdlHiwTg4t7kP+GKIIkBT+o6c9QWFanOyI=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=


### PR DESCRIPTION
- Upgrade Ledger module to v0.9.3 to support latest Ledger model.
- Enable ledger support in binary.

Signed-off-by: dpierret <dapie@cros-nest.com>