### PR TITLE
Ci/adjust docker lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -123,13 +123,6 @@ jobs:
         with:
           verbose: true
 
-      - name: Lint dockerfile (docker-lint)
-        uses: luke142367/Docker-Lint-Action@v1.1.1
-        with:
-          target: Dockerfile
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   lint-proto:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -120,6 +120,8 @@ jobs:
 
       - name: Lint dockerfile (hadolint)
         uses: hadolint/hadolint-action@v2.1.0
+        with:
+          verbose: true
 
       - name: Lint dockerfile (docker-lint)
         uses: luke142367/Docker-Lint-Action@v1.1.1


### PR DESCRIPTION
Little tuning on docker linters:
- verbosify `hadolint`
- remove `dockerfilelint`, actually I think it is only a sublint of `hadolint`