### PR TITLE
Change comments syntax in markdown template

### DIFF
--- a/docs/proto/logic.md
+++ b/docs/proto/logic.md
@@ -1,4 +1,4 @@
-<!-- This file is auto-generated. Please do not modify it yourself. -->
+[//]: # (This file is auto-generated. Please do not modify it yourself.)
 # Protobuf Documentation
 <a name="top"></a>
 
@@ -44,13 +44,13 @@ Params defines the parameters for the module.
 
 
 
- <!-- end messages -->
+ [//]: # (end messages)
 
- <!-- end enums -->
+ [//]: # (end enums)
 
- <!-- end HasExtensions -->
+ [//]: # (end HasExtensions)
 
- <!-- end services -->
+ [//]: # (end services)
 
 
 
@@ -75,13 +75,13 @@ GenesisState defines the logic module's genesis state.
 
 
 
- <!-- end messages -->
+ [//]: # (end messages)
 
- <!-- end enums -->
+ [//]: # (end enums)
 
- <!-- end HasExtensions -->
+ [//]: # (end HasExtensions)
 
- <!-- end services -->
+ [//]: # (end services)
 
 
 
@@ -116,11 +116,11 @@ QueryServiceParamsResponse is response type for the QueryService/Params RPC meth
 
 
 
- <!-- end messages -->
+ [//]: # (end messages)
 
- <!-- end enums -->
+ [//]: # (end enums)
 
- <!-- end HasExtensions -->
+ [//]: # (end HasExtensions)
 
 
 <a name="logic.v1beta.QueryService"></a>
@@ -132,7 +132,7 @@ QueryService defines the gRPC querier service.
 | ----------- | ------------ | ------------- | ------------| ------- | -------- |
 | `Params` | [QueryServiceParamsRequest](#logic.v1beta.QueryServiceParamsRequest) | [QueryServiceParamsResponse](#logic.v1beta.QueryServiceParamsResponse) | Parameters queries the parameters of the module. | GET|/okp4/okp4d/logic/params|
 
- <!-- end services -->
+ [//]: # (end services)
 
 
 
@@ -142,11 +142,11 @@ QueryService defines the gRPC querier service.
 ## logic/v1beta/tx.proto
 
 
- <!-- end messages -->
+ [//]: # (end messages)
 
- <!-- end enums -->
+ [//]: # (end enums)
 
- <!-- end HasExtensions -->
+ [//]: # (end HasExtensions)
 
 
 <a name="logic.v1beta.MsgService"></a>
@@ -157,7 +157,7 @@ Msg defines the Msg service.
 | Method Name | Request Type | Response Type | Description | HTTP Verb | Endpoint |
 | ----------- | ------------ | ------------- | ------------| ------- | -------- |
 
- <!-- end services -->
+ [//]: # (end services)
 
 
 

--- a/docs/proto/protodoc-markdown.tmpl
+++ b/docs/proto/protodoc-markdown.tmpl
@@ -1,4 +1,4 @@
-<!-- This file is auto-generated. Please do not modify it yourself. -->
+[//]: # (This file is auto-generated. Please do not modify it yourself.)
 # Protobuf Documentation
 <a name="top"></a>
 
@@ -54,7 +54,7 @@
 {{end}}
 {{end}}
 
-{{end}} <!-- end messages -->
+{{end}} [//]: # (end messages)
 
 {{range .Enums}}
 <a name="{{.FullName}}"></a>
@@ -68,7 +68,7 @@
   | {{.Name}} | {{.Number}} | {{nobr .Description}} |
 {{end}}
 
-{{end}} <!-- end enums -->
+{{end}} [//]: # (end enums)
 
 {{if .HasExtensions}}
 <a name="{{$file_name}}-extensions"></a>
@@ -79,7 +79,7 @@
 {{range .Extensions -}}
   | `{{.Name}}` | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{nobr .Description}}{{if .DefaultValue}} Default: `{{.DefaultValue}}`{{end}} |
 {{end}}
-{{end}} <!-- end HasExtensions -->
+{{end}} [//]: # (end HasExtensions)
 
 {{range .Services}}
 <a name="{{.FullName}}"></a>
@@ -92,7 +92,7 @@
 {{range .Methods -}}
   | `{{.Name}}` | [{{.RequestLongType}}](#{{.RequestFullType}}){{if .RequestStreaming}} stream{{end}} | [{{.ResponseLongType}}](#{{.ResponseFullType}}){{if .ResponseStreaming}} stream{{end}} | {{nobr .Description}} | {{with (index .Options "google.api.http")}}{{range .Rules}}{{.Method}}|{{.Pattern}}{{end}}{{end}}|
 {{end}}
-{{end}} <!-- end services -->
+{{end}} [//]: # (end services)
 
 {{end}}
 

--- a/docs/proto/vesting.md
+++ b/docs/proto/vesting.md
@@ -1,4 +1,4 @@
-<!-- This file is auto-generated. Please do not modify it yourself. -->
+[//]: # (This file is auto-generated. Please do not modify it yourself.)
 # Protobuf Documentation
 <a name="top"></a>
 
@@ -160,13 +160,13 @@ Since: cosmos-sdk 0.43
 
 
 
- <!-- end messages -->
+ [//]: # (end messages)
 
- <!-- end enums -->
+ [//]: # (end enums)
 
- <!-- end HasExtensions -->
+ [//]: # (end HasExtensions)
 
- <!-- end services -->
+ [//]: # (end services)
 
 
 
@@ -302,11 +302,11 @@ MsgCreateVestingAccountResponse defines the Msg/CreateVestingAccount response ty
 
 
 
- <!-- end messages -->
+ [//]: # (end messages)
 
- <!-- end enums -->
+ [//]: # (end enums)
 
- <!-- end HasExtensions -->
+ [//]: # (end HasExtensions)
 
 
 <a name="vesting.v1beta1.Msg"></a>
@@ -325,7 +325,7 @@ Since: cosmos-sdk 0.46 | |
 Since: cosmos-sdk 0.46 | |
 | `CreateCliffVestingAccount` | [MsgCreateCliffVestingAccount](#vesting.v1beta1.MsgCreateCliffVestingAccount) | [MsgCreateCliffVestingAccountResponse](#vesting.v1beta1.MsgCreateCliffVestingAccountResponse) | CreateCliffVestingAccount defines a method that enables creating a cliff vesting account. | |
 
- <!-- end services -->
+ [//]: # (end services)
 
 
 


### PR DESCRIPTION
To make generated documentation compatible with docusaurus, we need to change the syntax of the comment used in the markdown template. Mdx doesn't support html comment `<!--...-->`. So replace to markdown comment `[//]: # (...)`.

[//]: # (Hey hey, you too you test this comment if it's work ? I didn't know too this syntax...)
[//]: # (🍍)
[//]: # (🍻)
