### PR TITLE
🦖 Make command doc compatible with docusaurus

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -24,7 +24,7 @@ jobs:
   update-docs:
     runs-on: ubuntu-22.04
     steps:
-      - name: Update docs repository
+      - name: Update modules docs repository
         uses: fjogeleit/http-request-action@v1
         with:
           url: 'https://api.github.com/repos/okp4/docs/actions/workflows/update-versioned-docs/dispatches'
@@ -38,6 +38,23 @@ jobs:
                 "repository": "${{github.repository}}",
                 "section": "modules",
                 "docs_directory": "docs/proto/*"
+              }
+            }
+
+      - name: Update commands docs repository
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.github.com/repos/okp4/docs/actions/workflows/update-versioned-docs/dispatches'
+          method: 'POST'
+          customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OKP4_TOKEN }}"}'
+          data: |-
+            {
+              "ref": "main",
+              "inputs": {
+                "version": "${{ github.event.release.tag_name }}",
+                "repository": "${{github.repository}}",
+                "section": "commands",
+                "docs_directory": "docs/command/*"
               }
             }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
   test-go:
     runs-on: ubuntu-22.04
     needs: check-tests
-    if: needs.check-tests.status
+    if: needs.check-tests.outputs.status
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     needs: check-tests
-    if: needs.check-tests.status
+    if: needs.check-tests.outputs.status
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,9 @@ doc-command: ## Generate markdown documentation for the command
 	go run ../scripts/generate_command_doc.go; \
 	sed -i $(SED_FLAG) 's/(default \"\/.*\/\.okp4d\")/(default \"\/home\/john\/\.okp4d\")/g' command/*.md; \
 	sed -i $(SED_FLAG) 's/node\ name\ (default\ \".*\")/node\ name\ (default\ \"my-machine\")/g' command/*.md; \
-	sed -i $(SED_FLAG) 's/IP\ (default\ \".*\")/IP\ (default\ \"127.0.0.1\")/g' command/*.md
+	sed -i $(SED_FLAG) 's/IP\ (default\ \".*\")/IP\ (default\ \"127.0.0.1\")/g' command/*.md; \
+	sed -i $(SED_FLAG) 's/<appd>/okp4d/g' command/*.md; \
+	sed -i $(SED_FLAG) 's/<\([a-zA-Z-]*\)>/\&lt;\1\&gt;/g' command/*.md
 
 ## Release:
 release-assets: release-binary-all release-checksums ## Generate release assets

--- a/docs/command/okp4d_add-genesis-account.md
+++ b/docs/command/okp4d_add-genesis-account.md
@@ -21,7 +21,7 @@ okp4d add-genesis-account [address_or_key_name] [coin][,[coin]] [flags]
   -h, --help                     help for add-genesis-account
       --home string              The application home directory (default "/home/john/.okp4d")
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test) (default "test")
-      --node string              <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string            Output format (text|json) (default "text")
       --vesting-amount string    amount of coins for vesting accounts
       --vesting-cliff-time int   schedule cliff time (unix epoch) for vesting accounts

--- a/docs/command/okp4d_config.md
+++ b/docs/command/okp4d_config.md
@@ -3,7 +3,7 @@
 Create or query an application CLI configuration file
 
 ```
-okp4d config <key> [value] [flags]
+okp4d config &lt;key&gt; [value] [flags]
 ```
 
 ### Options

--- a/docs/command/okp4d_debug_addr.md
+++ b/docs/command/okp4d_debug_addr.md
@@ -7,7 +7,7 @@ Convert an address between hex and bech32
 Convert an address between hex encoding and bech32.
 
 Example:
-$ <appd> debug addr cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg
+$ okp4d debug addr cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg
 			
 
 ```

--- a/docs/command/okp4d_debug_pubkey-raw.md
+++ b/docs/command/okp4d_debug_pubkey-raw.md
@@ -6,8 +6,8 @@ Decode a ED25519 or secp256k1 pubkey from hex, base64, or bech32
 
 Decode a pubkey from hex, base64, or bech32.
 Example:
-$ <appd> debug pubkey-raw TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz
-$ <appd> debug pubkey-raw cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg
+$ okp4d debug pubkey-raw TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz
+$ okp4d debug pubkey-raw cosmos1e0jnq2sun3dzjh8p2xq95kk0expwmd7shwjpfg
 			
 
 ```

--- a/docs/command/okp4d_debug_pubkey.md
+++ b/docs/command/okp4d_debug_pubkey.md
@@ -7,7 +7,7 @@ Decode a pubkey from proto JSON
 Decode a pubkey from proto JSON and display it's address.
 
 Example:
-$ <appd> debug pubkey '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ"}'
+$ okp4d debug pubkey '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ"}'
 			
 
 ```

--- a/docs/command/okp4d_debug_raw-bytes.md
+++ b/docs/command/okp4d_debug_raw-bytes.md
@@ -7,7 +7,7 @@ Convert raw bytes output (eg. [10 21 13 255]) to hex
 Convert raw-bytes to hex.
 
 Example:
-$ <appd> debug raw-bytes [72 101 108 108 111 44 32 112 108 97 121 103 114 111 117 110 100]
+$ okp4d debug raw-bytes [72 101 108 108 111 44 32 112 108 97 121 103 114 111 117 110 100]
 			
 
 ```

--- a/docs/command/okp4d_gentx.md
+++ b/docs/command/okp4d_gentx.md
@@ -17,7 +17,7 @@ file. The following default parameters are included:
 
 
 Example:
-$ <appd> gentx my-key-name 1000000stake --home=/path/to/home/dir --keyring-backend=os --chain-id=test-chain-1 \
+$ okp4d gentx my-key-name 1000000stake --home=/path/to/home/dir --keyring-backend=os --chain-id=test-chain-1 \
     --moniker="myvalidator" \
     --commission-max-change-rate=0.01 \
     --commission-max-rate=1.0 \
@@ -61,7 +61,7 @@ okp4d gentx [key_name] [amount] [flags]
       --ledger                              Use a connected Ledger device
       --min-self-delegation string          The minimum self delegation required on the validator
       --moniker string                      The validator's (optional) moniker
-      --node string                         <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                         &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --node-id string                      The node's NodeID
       --note string                         Note to add a description to the transaction (previously --memo)
       --offline                             Offline mode (does not allow any online functionality)

--- a/docs/command/okp4d_keys.md
+++ b/docs/command/okp4d_keys.md
@@ -40,7 +40,7 @@ The pass backend requires GnuPG: https://gnupg.org/
 ### SEE ALSO
 
 * [okp4d](okp4d.md)	 - OKP4 Daemon 👹
-* [okp4d keys add](okp4d_keys_add.md)	 - Add an encrypted private key (either newly generated or recovered), encrypt it, and save to <name> file
+* [okp4d keys add](okp4d_keys_add.md)	 - Add an encrypted private key (either newly generated or recovered), encrypt it, and save to &lt;name&gt; file
 * [okp4d keys delete](okp4d_keys_delete.md)	 - Delete the given keys
 * [okp4d keys export](okp4d_keys_export.md)	 - Export private keys
 * [okp4d keys import](okp4d_keys_import.md)	 - Import private keys into the local keybase

--- a/docs/command/okp4d_keys_add.md
+++ b/docs/command/okp4d_keys_add.md
@@ -1,6 +1,6 @@
 ## okp4d keys add
 
-Add an encrypted private key (either newly generated or recovered), encrypt it, and save to <name> file
+Add an encrypted private key (either newly generated or recovered), encrypt it, and save to &lt;name&gt; file
 
 ### Synopsis
 
@@ -25,7 +25,7 @@ Example:
 
 
 ```
-okp4d keys add <name> [flags]
+okp4d keys add &lt;name&gt; [flags]
 ```
 
 ### Options
@@ -44,7 +44,7 @@ okp4d keys add <name> [flags]
       --multisig-threshold int   K out of N required signatures. For use in conjunction with --multisig (default 1)
       --no-backup                Don't print out seed phrase (if others are watching the terminal)
       --nosort                   Keys passed to --multisig are taken in the order they're supplied
-      --pubkey string            Parse a public key in JSON format and saves key info to <name> file.
+      --pubkey string            Parse a public key in JSON format and saves key info to &lt;name&gt; file.
       --recover                  Provide seed phrase to recover existing key instead of creating
 ```
 

--- a/docs/command/okp4d_keys_delete.md
+++ b/docs/command/okp4d_keys_delete.md
@@ -12,7 +12,7 @@ private keys stored in a ledger device cannot be deleted with the CLI.
 
 
 ```
-okp4d keys delete <name>... [flags]
+okp4d keys delete &lt;name&gt;... [flags]
 ```
 
 ### Options

--- a/docs/command/okp4d_keys_export.md
+++ b/docs/command/okp4d_keys_export.md
@@ -14,7 +14,7 @@ FULLY AWARE OF THE RISKS. If you are unsure, you may want to do some research
 and export your keys in ASCII-armored encrypted format.
 
 ```
-okp4d keys export <name> [flags]
+okp4d keys export &lt;name&gt; [flags]
 ```
 
 ### Options

--- a/docs/command/okp4d_keys_import.md
+++ b/docs/command/okp4d_keys_import.md
@@ -7,7 +7,7 @@ Import private keys into the local keybase
 Import a ASCII armored private key into the local keybase.
 
 ```
-okp4d keys import <name> <keyfile> [flags]
+okp4d keys import &lt;name&gt; &lt;keyfile&gt; [flags]
 ```
 
 ### Options

--- a/docs/command/okp4d_migrate.md
+++ b/docs/command/okp4d_migrate.md
@@ -7,7 +7,7 @@ Migrate genesis to a specified target version
 Migrate the source genesis into the target version and print to STDOUT.
 
 Example:
-$ <appd> migrate v0.36 /path/to/genesis.json --chain-id=cosmoshub-3 --genesis-time=2019-04-22T17:00:00Z
+$ okp4d migrate v0.36 /path/to/genesis.json --chain-id=cosmoshub-3 --genesis-time=2019-04-22T17:00:00Z
 
 
 ```

--- a/docs/command/okp4d_query.md
+++ b/docs/command/okp4d_query.md
@@ -37,7 +37,7 @@ okp4d query [flags]
 * [okp4d query slashing](okp4d_query_slashing.md)	 - Querying commands for the slashing module
 * [okp4d query staking](okp4d_query_staking.md)	 - Querying commands for the staking module
 * [okp4d query tendermint-validator-set](okp4d_query_tendermint-validator-set.md)	 - Get the full tendermint validator set at given height
-* [okp4d query tx](okp4d_query_tx.md)	 - Query for a transaction by hash, "<addr>/<seq>" combination or comma-separated signatures in a committed block
+* [okp4d query tx](okp4d_query_tx.md)	 - Query for a transaction by hash, "&lt;addr&gt;/&lt;seq&gt;" combination or comma-separated signatures in a committed block
 * [okp4d query txs](okp4d_query_txs.md)	 - Query for paginated transactions that match a set of events
 * [okp4d query upgrade](okp4d_query_upgrade.md)	 - Querying commands for the upgrade module
 * [okp4d query wasm](okp4d_query_wasm.md)	 - Querying commands for the wasm module

--- a/docs/command/okp4d_query_account.md
+++ b/docs/command/okp4d_query_account.md
@@ -11,7 +11,7 @@ okp4d query account [address] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for account
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_auth_account.md
+++ b/docs/command/okp4d_query_auth_account.md
@@ -11,7 +11,7 @@ okp4d query auth account [address] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for account
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_auth_accounts.md
+++ b/docs/command/okp4d_query_auth_accounts.md
@@ -13,7 +13,7 @@ okp4d query auth accounts [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for accounts
       --limit uint        pagination limit of all-accounts to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of all-accounts to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of all-accounts to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_auth_address-by-acc-num.md
+++ b/docs/command/okp4d_query_auth_address-by-acc-num.md
@@ -9,7 +9,7 @@ okp4d query auth address-by-acc-num [acc-num] [flags]
 ### Examples
 
 ```
-<appd> q auth address-by-acc-num 1
+okp4d q auth address-by-acc-num 1
 ```
 
 ### Options
@@ -17,7 +17,7 @@ okp4d query auth address-by-acc-num [acc-num] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for address-by-acc-num
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_auth_module-account.md
+++ b/docs/command/okp4d_query_auth_module-account.md
@@ -9,7 +9,7 @@ okp4d query auth module-account [module-name] [flags]
 ### Examples
 
 ```
-<appd> q auth module-account auth
+okp4d q auth module-account auth
 ```
 
 ### Options
@@ -17,7 +17,7 @@ okp4d query auth module-account [module-name] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for module-account
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_auth_module-accounts.md
+++ b/docs/command/okp4d_query_auth_module-accounts.md
@@ -11,7 +11,7 @@ okp4d query auth module-accounts [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for module-accounts
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_auth_params.md
+++ b/docs/command/okp4d_query_auth_params.md
@@ -6,7 +6,7 @@ Query the current auth parameters
 
 Query the current auth parameters:
 
-$ <appd> query auth params
+$ okp4d query auth params
 
 ```
 okp4d query auth params [flags]
@@ -17,7 +17,7 @@ okp4d query auth params [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for params
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_authz_grants-by-grantee.md
+++ b/docs/command/okp4d_query_authz_grants-by-grantee.md
@@ -6,7 +6,7 @@ query authorization grants granted to a grantee
 
 Query authorization grants granted to a grantee.
 Examples:
-$ <appd> q authz grants-by-grantee cosmos1skj..
+$ okp4d q authz grants-by-grantee cosmos1skj..
 
 ```
 okp4d query authz grants-by-grantee [grantee-addr] [flags]
@@ -19,7 +19,7 @@ okp4d query authz grants-by-grantee [grantee-addr] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for grants-by-grantee
       --limit uint        pagination limit of grantee-grants to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of grantee-grants to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of grantee-grants to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_authz_grants-by-granter.md
+++ b/docs/command/okp4d_query_authz_grants-by-granter.md
@@ -6,7 +6,7 @@ query authorization grants granted by granter
 
 Query authorization grants granted by granter.
 Examples:
-$ <appd> q authz grants-by-granter cosmos1skj..
+$ okp4d q authz grants-by-granter cosmos1skj..
 
 ```
 okp4d query authz grants-by-granter [granter-addr] [flags]
@@ -19,7 +19,7 @@ okp4d query authz grants-by-granter [granter-addr] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for grants-by-granter
       --limit uint        pagination limit of granter-grants to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of granter-grants to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of granter-grants to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_authz_grants.md
+++ b/docs/command/okp4d_query_authz_grants.md
@@ -7,8 +7,8 @@ query grants for a granter-grantee pair and optionally a msg-type-url
 Query authorization grants for a granter-grantee pair. If msg-type-url
 is set, it will select grants only for that msg type.
 Examples:
-$ <appd> query authz grants cosmos1skj.. cosmos1skjwj..
-$ <appd> query authz grants cosmos1skjw.. cosmos1skjwj.. /cosmos.bank.v1beta1.MsgSend
+$ okp4d query authz grants cosmos1skj.. cosmos1skjwj..
+$ okp4d query authz grants cosmos1skjw.. cosmos1skjwj.. /cosmos.bank.v1beta1.MsgSend
 
 ```
 okp4d query authz grants [granter-addr] [grantee-addr] [msg-type-url]? [flags]
@@ -21,7 +21,7 @@ okp4d query authz grants [granter-addr] [grantee-addr] [msg-type-url]? [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for grants
       --limit uint        pagination limit of grants to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of grants to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of grants to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_bank_balances.md
+++ b/docs/command/okp4d_query_bank_balances.md
@@ -7,8 +7,8 @@ Query for account balances by address
 Query the total balance of an account or of a specific denomination.
 
 Example:
-  $ <appd> query bank balances [address]
-  $ <appd> query bank balances [address] --denom=[denom]
+  $ okp4d query bank balances [address]
+  $ okp4d query bank balances [address] --denom=[denom]
 
 ```
 okp4d query bank balances [address] [flags]
@@ -22,7 +22,7 @@ okp4d query bank balances [address] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for balances
       --limit uint        pagination limit of all balances to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of all balances to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of all balances to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_bank_denom-metadata.md
+++ b/docs/command/okp4d_query_bank_denom-metadata.md
@@ -8,10 +8,10 @@ Query the client metadata for all the registered coin denominations
 
 Example:
   To query for the client metadata of all coin denominations use:
-  $ <appd> query bank denom-metadata
+  $ okp4d query bank denom-metadata
 
 To query for the client metadata of a specific coin denomination use:
-  $ <appd> query bank denom-metadata --denom=[denom]
+  $ okp4d query bank denom-metadata --denom=[denom]
 
 ```
 okp4d query bank denom-metadata [flags]
@@ -23,7 +23,7 @@ okp4d query bank denom-metadata [flags]
       --denom string    The specific denomination to query client metadata for
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for denom-metadata
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_bank_total.md
+++ b/docs/command/okp4d_query_bank_total.md
@@ -7,10 +7,10 @@ Query the total supply of coins of the chain
 Query total supply of coins that are held by accounts in the chain.
 
 Example:
-  $ <appd> query bank total
+  $ okp4d query bank total
 
 To query for the total supply of a specific coin denomination use:
-  $ <appd> query bank total --denom=[denom]
+  $ okp4d query bank total --denom=[denom]
 
 ```
 okp4d query bank total [flags]
@@ -24,7 +24,7 @@ okp4d query bank total [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for total
       --limit uint        pagination limit of all supply totals to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of all supply totals to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of all supply totals to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_distribution_commission.md
+++ b/docs/command/okp4d_query_distribution_commission.md
@@ -7,7 +7,7 @@ Query distribution validator commission
 Query validator commission rewards from delegators to that validator.
 
 Example:
-$ <appd> query distribution commission okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
+$ okp4d query distribution commission okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
 
 ```
 okp4d query distribution commission [validator] [flags]
@@ -18,7 +18,7 @@ okp4d query distribution commission [validator] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for commission
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_distribution_community-pool.md
+++ b/docs/command/okp4d_query_distribution_community-pool.md
@@ -7,7 +7,7 @@ Query the amount of coins in the community pool
 Query all coins in the community pool which is under Governance control.
 
 Example:
-$ <appd> query distribution community-pool
+$ okp4d query distribution community-pool
 
 ```
 okp4d query distribution community-pool [flags]
@@ -18,7 +18,7 @@ okp4d query distribution community-pool [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for community-pool
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_distribution_params.md
+++ b/docs/command/okp4d_query_distribution_params.md
@@ -11,7 +11,7 @@ okp4d query distribution params [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for params
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_distribution_rewards.md
+++ b/docs/command/okp4d_query_distribution_rewards.md
@@ -7,8 +7,8 @@ Query all distribution delegator rewards or rewards from a particular validator
 Query all rewards earned by a delegator, optionally restrict to rewards from a single validator.
 
 Example:
-$ <appd> query distribution rewards okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
-$ <appd> query distribution rewards okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
+$ okp4d query distribution rewards okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
+$ okp4d query distribution rewards okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
 
 ```
 okp4d query distribution rewards [delegator-addr] [validator-addr] [flags]
@@ -19,7 +19,7 @@ okp4d query distribution rewards [delegator-addr] [validator-addr] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for rewards
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_distribution_slashes.md
+++ b/docs/command/okp4d_query_distribution_slashes.md
@@ -7,7 +7,7 @@ Query distribution validator slashes
 Query all slashes of a validator for a given block range.
 
 Example:
-$ <appd> query distribution slashes okp4valopervaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 0 100
+$ okp4d query distribution slashes okp4valopervaloper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 0 100
 
 ```
 okp4d query distribution slashes [validator] [start-height] [end-height] [flags]
@@ -20,7 +20,7 @@ okp4d query distribution slashes [validator] [start-height] [end-height] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for slashes
       --limit uint        pagination limit of validator slashes to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of validator slashes to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of validator slashes to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_distribution_validator-outstanding-rewards.md
+++ b/docs/command/okp4d_query_distribution_validator-outstanding-rewards.md
@@ -7,7 +7,7 @@ Query distribution outstanding (un-withdrawn) rewards for a validator and all th
 Query distribution outstanding (un-withdrawn) rewards for a validator and all their delegations.
 
 Example:
-$ <appd> query distribution validator-outstanding-rewards okp4valoper1lwjmdnks33xwnmfayc64ycprww49n33mtm92ne
+$ okp4d query distribution validator-outstanding-rewards okp4valoper1lwjmdnks33xwnmfayc64ycprww49n33mtm92ne
 
 ```
 okp4d query distribution validator-outstanding-rewards [validator] [flags]
@@ -18,7 +18,7 @@ okp4d query distribution validator-outstanding-rewards [validator] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for validator-outstanding-rewards
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_evidence.md
+++ b/docs/command/okp4d_query_evidence.md
@@ -7,8 +7,8 @@ Query for evidence by hash or for all (paginated) submitted evidence
 Query for specific submitted evidence by hash or query for all (paginated) evidence:
 
 Example:
-$ <appd> query evidence DF0C23E8634E480F84B9D5674A7CDC9816466DEC28A3358F73260F68D28D7660
-$ <appd> query evidence --page=2 --limit=50
+$ okp4d query evidence DF0C23E8634E480F84B9D5674A7CDC9816466DEC28A3358F73260F68D28D7660
+$ okp4d query evidence --page=2 --limit=50
 
 ```
 okp4d query evidence [flags]
@@ -21,7 +21,7 @@ okp4d query evidence [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for evidence
       --limit uint        pagination limit of evidence to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of evidence to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of evidence to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_feegrant_grant.md
+++ b/docs/command/okp4d_query_feegrant_grant.md
@@ -8,7 +8,7 @@ Query details for a grant.
 You can find the fee-grant of a granter and grantee.
 
 Example:
-$ <appd> query feegrant grant [granter] [grantee]
+$ okp4d query feegrant grant [granter] [grantee]
 
 ```
 okp4d query feegrant grant [granter] [grantee] [flags]
@@ -19,7 +19,7 @@ okp4d query feegrant grant [granter] [grantee] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for grant
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_feegrant_grants-by-grantee.md
+++ b/docs/command/okp4d_query_feegrant_grants-by-grantee.md
@@ -7,7 +7,7 @@ Query all grants of a grantee
 Queries all the grants for a grantee address.
 
 Example:
-$ <appd> query feegrant grants-by-grantee [grantee]
+$ okp4d query feegrant grants-by-grantee [grantee]
 
 ```
 okp4d query feegrant grants-by-grantee [grantee] [flags]
@@ -20,7 +20,7 @@ okp4d query feegrant grants-by-grantee [grantee] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for grants-by-grantee
       --limit uint        pagination limit of grants to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of grants to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of grants to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_feegrant_grants-by-granter.md
+++ b/docs/command/okp4d_query_feegrant_grants-by-granter.md
@@ -7,7 +7,7 @@ Query all grants by a granter
 Queries all the grants issued for a granter address.
 
 Example:
-$ <appd> query feegrant grants-by-granter [granter]
+$ okp4d query feegrant grants-by-granter [granter]
 
 ```
 okp4d query feegrant grants-by-granter [granter] [flags]
@@ -20,7 +20,7 @@ okp4d query feegrant grants-by-granter [granter] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for grants-by-granter
       --limit uint        pagination limit of grants to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of grants to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of grants to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_gov_deposit.md
+++ b/docs/command/okp4d_query_gov_deposit.md
@@ -7,7 +7,7 @@ Query details of a deposit
 Query details for a single proposal deposit on a proposal by its identifier.
 
 Example:
-$ <appd> query gov deposit 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
+$ okp4d query gov deposit 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 
 ```
 okp4d query gov deposit [proposal-id] [depositer-addr] [flags]
@@ -18,7 +18,7 @@ okp4d query gov deposit [proposal-id] [depositer-addr] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for deposit
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_deposits.md
+++ b/docs/command/okp4d_query_gov_deposits.md
@@ -5,10 +5,10 @@ Query deposits on a proposal
 ### Synopsis
 
 Query details for all deposits on a proposal.
-You can find the proposal-id by running "<appd> query gov proposals".
+You can find the proposal-id by running "okp4d query gov proposals".
 
 Example:
-$ <appd> query gov deposits 1
+$ okp4d query gov deposits 1
 
 ```
 okp4d query gov deposits [proposal-id] [flags]
@@ -21,7 +21,7 @@ okp4d query gov deposits [proposal-id] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for deposits
       --limit uint        pagination limit of deposits to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of deposits to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of deposits to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_gov_param.md
+++ b/docs/command/okp4d_query_gov_param.md
@@ -7,9 +7,9 @@ Query the parameters (voting|tallying|deposit) of the governance process
 Query the all the parameters for the governance process.
 
 Example:
-$ <appd> query gov param voting
-$ <appd> query gov param tallying
-$ <appd> query gov param deposit
+$ okp4d query gov param voting
+$ okp4d query gov param tallying
+$ okp4d query gov param deposit
 
 ```
 okp4d query gov param [param-type] [flags]
@@ -20,7 +20,7 @@ okp4d query gov param [param-type] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for param
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_params.md
+++ b/docs/command/okp4d_query_gov_params.md
@@ -7,7 +7,7 @@ Query the parameters of the governance process
 Query the all the parameters for the governance process.
 
 Example:
-$ <appd> query gov params
+$ okp4d query gov params
 
 ```
 okp4d query gov params [flags]
@@ -18,7 +18,7 @@ okp4d query gov params [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for params
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_proposal.md
+++ b/docs/command/okp4d_query_gov_proposal.md
@@ -5,10 +5,10 @@ Query details of a single proposal
 ### Synopsis
 
 Query details for a proposal. You can find the
-proposal-id by running "<appd> query gov proposals".
+proposal-id by running "okp4d query gov proposals".
 
 Example:
-$ <appd> query gov proposal 1
+$ okp4d query gov proposal 1
 
 ```
 okp4d query gov proposal [proposal-id] [flags]
@@ -19,7 +19,7 @@ okp4d query gov proposal [proposal-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for proposal
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_proposals.md
+++ b/docs/command/okp4d_query_gov_proposals.md
@@ -7,10 +7,10 @@ Query proposals with optional filters
 Query for a all paginated proposals that match optional filters:
 
 Example:
-$ <appd> query gov proposals --depositor cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
-$ <appd> query gov proposals --voter cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
-$ <appd> query gov proposals --status (DepositPeriod|VotingPeriod|Passed|Rejected)
-$ <appd> query gov proposals --page=2 --limit=100
+$ okp4d query gov proposals --depositor cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
+$ okp4d query gov proposals --voter cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
+$ okp4d query gov proposals --status (DepositPeriod|VotingPeriod|Passed|Rejected)
+$ okp4d query gov proposals --page=2 --limit=100
 
 ```
 okp4d query gov proposals [flags]
@@ -24,7 +24,7 @@ okp4d query gov proposals [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for proposals
       --limit uint         pagination limit of proposals to query for (default 100)
-      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of proposals to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of proposals to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_gov_proposer.md
+++ b/docs/command/okp4d_query_gov_proposer.md
@@ -7,7 +7,7 @@ Query the proposer of a governance proposal
 Query which address proposed a proposal with a given ID.
 
 Example:
-$ <appd> query gov proposer 1
+$ okp4d query gov proposer 1
 
 ```
 okp4d query gov proposer [proposal-id] [flags]
@@ -18,7 +18,7 @@ okp4d query gov proposer [proposal-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for proposer
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_tally.md
+++ b/docs/command/okp4d_query_gov_tally.md
@@ -5,10 +5,10 @@ Get the tally of a proposal vote
 ### Synopsis
 
 Query tally of votes on a proposal. You can find
-the proposal-id by running "<appd> query gov proposals".
+the proposal-id by running "okp4d query gov proposals".
 
 Example:
-$ <appd> query gov tally 1
+$ okp4d query gov tally 1
 
 ```
 okp4d query gov tally [proposal-id] [flags]
@@ -19,7 +19,7 @@ okp4d query gov tally [proposal-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for tally
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_vote.md
+++ b/docs/command/okp4d_query_gov_vote.md
@@ -7,7 +7,7 @@ Query details of a single vote
 Query details for a single vote on a proposal given its identifier.
 
 Example:
-$ <appd> query gov vote 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
+$ okp4d query gov vote 1 cosmos1skjwj5whet0lpe65qaq4rpq03hjxlwd9nf39lk
 
 ```
 okp4d query gov vote [proposal-id] [voter-addr] [flags]
@@ -18,7 +18,7 @@ okp4d query gov vote [proposal-id] [voter-addr] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for vote
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_votes.md
+++ b/docs/command/okp4d_query_gov_votes.md
@@ -7,8 +7,8 @@ Query votes on a proposal
 Query vote details for a single proposal by its identifier.
 
 Example:
-$ <appd> query gov votes 1
-$ <appd> query gov votes 1 --page=2 --limit=100
+$ okp4d query gov votes 1
+$ okp4d query gov votes 1 --page=2 --limit=100
 
 ```
 okp4d query gov votes [proposal-id] [flags]
@@ -21,7 +21,7 @@ okp4d query gov votes [proposal-id] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for votes
       --limit uint        pagination limit of votes to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of votes to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of votes to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_group_group-info.md
+++ b/docs/command/okp4d_query_group_group-info.md
@@ -11,7 +11,7 @@ okp4d query group group-info [id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for group-info
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_group-members.md
+++ b/docs/command/okp4d_query_group_group-members.md
@@ -11,7 +11,7 @@ okp4d query group group-members [id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for group-members
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_group-policies-by-admin.md
+++ b/docs/command/okp4d_query_group_group-policies-by-admin.md
@@ -11,7 +11,7 @@ okp4d query group group-policies-by-admin [admin] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for group-policies-by-admin
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_group-policies-by-group.md
+++ b/docs/command/okp4d_query_group_group-policies-by-group.md
@@ -11,7 +11,7 @@ okp4d query group group-policies-by-group [group-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for group-policies-by-group
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_group-policy-info.md
+++ b/docs/command/okp4d_query_group_group-policy-info.md
@@ -11,7 +11,7 @@ okp4d query group group-policy-info [group-policy-account] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for group-policy-info
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_groups-by-admin.md
+++ b/docs/command/okp4d_query_group_groups-by-admin.md
@@ -11,7 +11,7 @@ okp4d query group groups-by-admin [admin] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for groups-by-admin
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_groups-by-member.md
+++ b/docs/command/okp4d_query_group_groups-by-member.md
@@ -13,7 +13,7 @@ okp4d query group groups-by-member [address] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for groups-by-member
       --limit uint        pagination limit of groups-by-members to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of groups-by-members to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of groups-by-members to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_group_proposal.md
+++ b/docs/command/okp4d_query_group_proposal.md
@@ -11,7 +11,7 @@ okp4d query group proposal [id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for proposal
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_proposals-by-group-policy.md
+++ b/docs/command/okp4d_query_group_proposals-by-group-policy.md
@@ -11,7 +11,7 @@ okp4d query group proposals-by-group-policy [group-policy-account] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for proposals-by-group-policy
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_tally-result.md
+++ b/docs/command/okp4d_query_group_tally-result.md
@@ -11,7 +11,7 @@ okp4d query group tally-result [proposal-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for tally-result
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_vote.md
+++ b/docs/command/okp4d_query_group_vote.md
@@ -11,7 +11,7 @@ okp4d query group vote [proposal-id] [voter] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for vote
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_votes-by-proposal.md
+++ b/docs/command/okp4d_query_group_votes-by-proposal.md
@@ -11,7 +11,7 @@ okp4d query group votes-by-proposal [proposal-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for votes-by-proposal
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_votes-by-voter.md
+++ b/docs/command/okp4d_query_group_votes-by-voter.md
@@ -11,7 +11,7 @@ okp4d query group votes-by-voter [voter] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for votes-by-voter
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_channel.md
+++ b/docs/command/okp4d_query_ibc-fee_channel.md
@@ -13,7 +13,7 @@ okp4d query ibc-fee channel [port-id] [channel-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc-fee channel transfer channel-6
+okp4d query ibc-fee channel transfer channel-6
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc-fee channel [port-id] [channel-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for channel
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_channels.md
+++ b/docs/command/okp4d_query_ibc-fee_channels.md
@@ -13,7 +13,7 @@ okp4d query ibc-fee channels [flags]
 ### Examples
 
 ```
-<appd> query ibc-fee channels
+okp4d query ibc-fee channels
 ```
 
 ### Options
@@ -23,7 +23,7 @@ okp4d query ibc-fee channels [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for channels
       --limit uint        pagination limit of channels to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of channels to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of channels to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc-fee_counterparty-payee.md
+++ b/docs/command/okp4d_query_ibc-fee_counterparty-payee.md
@@ -13,7 +13,7 @@ okp4d query ibc-fee counterparty-payee [channel-id] [relayer] [flags]
 ### Examples
 
 ```
-<appd> query ibc-fee counterparty-payee channel-5 cosmos1layxcsmyye0dc0har9sdfzwckaz8sjwlfsj8zs
+okp4d query ibc-fee counterparty-payee channel-5 cosmos1layxcsmyye0dc0har9sdfzwckaz8sjwlfsj8zs
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc-fee counterparty-payee [channel-id] [relayer] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for counterparty-payee
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_packet.md
+++ b/docs/command/okp4d_query_ibc-fee_packet.md
@@ -13,7 +13,7 @@ okp4d query ibc-fee packet [port-id] [channel-id] [sequence] [flags]
 ### Examples
 
 ```
-<appd> query ibc-fee packet
+okp4d query ibc-fee packet
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc-fee packet [port-id] [channel-id] [sequence] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for packet
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_packets-for-channel.md
+++ b/docs/command/okp4d_query_ibc-fee_packets-for-channel.md
@@ -13,7 +13,7 @@ okp4d query ibc-fee packets-for-channel [port-id] [channel-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc-fee packets-for-channel
+okp4d query ibc-fee packets-for-channel
 ```
 
 ### Options
@@ -23,7 +23,7 @@ okp4d query ibc-fee packets-for-channel [port-id] [channel-id] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for packets-for-channel
       --limit uint        pagination limit of packets-for-channel to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of packets-for-channel to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of packets-for-channel to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc-fee_packets.md
+++ b/docs/command/okp4d_query_ibc-fee_packets.md
@@ -13,7 +13,7 @@ okp4d query ibc-fee packets [flags]
 ### Examples
 
 ```
-<appd> query ibc-fee packets
+okp4d query ibc-fee packets
 ```
 
 ### Options
@@ -23,7 +23,7 @@ okp4d query ibc-fee packets [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for packets
       --limit uint        pagination limit of packets to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of packets to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of packets to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc-fee_payee.md
+++ b/docs/command/okp4d_query_ibc-fee_payee.md
@@ -13,7 +13,7 @@ okp4d query ibc-fee payee [channel-id] [relayer] [flags]
 ### Examples
 
 ```
-<appd> query ibc-fee payee channel-5 cosmos1layxcsmyye0dc0har9sdfzwckaz8sjwlfsj8zs
+okp4d query ibc-fee payee channel-5 cosmos1layxcsmyye0dc0har9sdfzwckaz8sjwlfsj8zs
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc-fee payee [channel-id] [relayer] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for payee
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_total-ack-fees.md
+++ b/docs/command/okp4d_query_ibc-fee_total-ack-fees.md
@@ -13,7 +13,7 @@ okp4d query ibc-fee total-ack-fees [port-id] [channel-id] [sequence] [flags]
 ### Examples
 
 ```
-<appd> query ibc-fee total-ack-fees transfer channel-5 100
+okp4d query ibc-fee total-ack-fees transfer channel-5 100
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc-fee total-ack-fees [port-id] [channel-id] [sequence] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for total-ack-fees
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_total-recv-fees.md
+++ b/docs/command/okp4d_query_ibc-fee_total-recv-fees.md
@@ -13,7 +13,7 @@ okp4d query ibc-fee total-recv-fees [port-id] [channel-id] [sequence] [flags]
 ### Examples
 
 ```
-<appd> query ibc-fee total-recv-fees transfer channel-5 100
+okp4d query ibc-fee total-recv-fees transfer channel-5 100
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc-fee total-recv-fees [port-id] [channel-id] [sequence] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for total-recv-fees
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_total-timeout-fees.md
+++ b/docs/command/okp4d_query_ibc-fee_total-timeout-fees.md
@@ -13,7 +13,7 @@ okp4d query ibc-fee total-timeout-fees [port-id] [channel-id] [sequence] [flags]
 ### Examples
 
 ```
-<appd> query ibc-fee total-timeout-fees transfer channel-5 100
+okp4d query ibc-fee total-timeout-fees transfer channel-5 100
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc-fee total-timeout-fees [port-id] [channel-id] [sequence] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for total-timeout-fees
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-transfer_denom-hash.md
+++ b/docs/command/okp4d_query_ibc-transfer_denom-hash.md
@@ -13,7 +13,7 @@ okp4d query ibc-transfer denom-hash [trace] [flags]
 ### Examples
 
 ```
-<appd> query ibc-transfer denom-hash transfer/channel-0/uatom
+okp4d query ibc-transfer denom-hash transfer/channel-0/uatom
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc-transfer denom-hash [trace] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for denom-hash
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-transfer_denom-trace.md
+++ b/docs/command/okp4d_query_ibc-transfer_denom-trace.md
@@ -13,7 +13,7 @@ okp4d query ibc-transfer denom-trace [hash/denom] [flags]
 ### Examples
 
 ```
-<appd> query ibc-transfer denom-trace 27A6394C3F9FF9C9DCF5DFFADF9BB5FE9A37C7E92B006199894CF1824DF9AC7C
+okp4d query ibc-transfer denom-trace 27A6394C3F9FF9C9DCF5DFFADF9BB5FE9A37C7E92B006199894CF1824DF9AC7C
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc-transfer denom-trace [hash/denom] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for denom-trace
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-transfer_denom-traces.md
+++ b/docs/command/okp4d_query_ibc-transfer_denom-traces.md
@@ -13,7 +13,7 @@ okp4d query ibc-transfer denom-traces [flags]
 ### Examples
 
 ```
-<appd> query ibc-transfer denom-traces
+okp4d query ibc-transfer denom-traces
 ```
 
 ### Options
@@ -23,7 +23,7 @@ okp4d query ibc-transfer denom-traces [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for denom-traces
       --limit uint        pagination limit of denominations trace to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of denominations trace to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of denominations trace to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc-transfer_escrow-address.md
+++ b/docs/command/okp4d_query_ibc-transfer_escrow-address.md
@@ -13,7 +13,7 @@ okp4d query ibc-transfer escrow-address [flags]
 ### Examples
 
 ```
-<appd> query ibc-transfer escrow-address [port] [channel-id]
+okp4d query ibc-transfer escrow-address [port] [channel-id]
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc-transfer escrow-address [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for escrow-address
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-transfer_params.md
+++ b/docs/command/okp4d_query_ibc-transfer_params.md
@@ -13,7 +13,7 @@ okp4d query ibc-transfer params [flags]
 ### Examples
 
 ```
-<appd> query ibc-transfer params
+okp4d query ibc-transfer params
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc-transfer params [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for params
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_channel_channels.md
+++ b/docs/command/okp4d_query_ibc_channel_channels.md
@@ -13,7 +13,7 @@ okp4d query ibc channel channels [flags]
 ### Examples
 
 ```
-<appd> query ibc channel channels
+okp4d query ibc channel channels
 ```
 
 ### Options
@@ -23,7 +23,7 @@ okp4d query ibc channel channels [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for channels
       --limit uint        pagination limit of channels to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of channels to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of channels to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_channel_client-state.md
+++ b/docs/command/okp4d_query_ibc_channel_client-state.md
@@ -13,7 +13,7 @@ okp4d query ibc channel client-state [port-id] [channel-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc channel client-state [port-id] [channel-id]
+okp4d query ibc channel client-state [port-id] [channel-id]
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc channel client-state [port-id] [channel-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for client-state
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_channel_connections.md
+++ b/docs/command/okp4d_query_ibc_channel_connections.md
@@ -13,7 +13,7 @@ okp4d query ibc channel connections [connection-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc channel connections [connection-id]
+okp4d query ibc channel connections [connection-id]
 ```
 
 ### Options
@@ -23,7 +23,7 @@ okp4d query ibc channel connections [connection-id] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for connections
       --limit uint        pagination limit of channels associated with a connection to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of channels associated with a connection to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of channels associated with a connection to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_channel_end.md
+++ b/docs/command/okp4d_query_ibc_channel_end.md
@@ -13,7 +13,7 @@ okp4d query ibc channel end [port-id] [channel-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc channel end [port-id] [channel-id]
+okp4d query ibc channel end [port-id] [channel-id]
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc channel end [port-id] [channel-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for end
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --prove           show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_channel_next-sequence-receive.md
+++ b/docs/command/okp4d_query_ibc_channel_next-sequence-receive.md
@@ -13,7 +13,7 @@ okp4d query ibc channel next-sequence-receive [port-id] [channel-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc channel next-sequence-receive [port-id] [channel-id]
+okp4d query ibc channel next-sequence-receive [port-id] [channel-id]
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc channel next-sequence-receive [port-id] [channel-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for next-sequence-receive
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --prove           show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_channel_packet-ack.md
+++ b/docs/command/okp4d_query_ibc_channel_packet-ack.md
@@ -13,7 +13,7 @@ okp4d query ibc channel packet-ack [port-id] [channel-id] [sequence] [flags]
 ### Examples
 
 ```
-<appd> query ibc channel packet-ack [port-id] [channel-id] [sequence]
+okp4d query ibc channel packet-ack [port-id] [channel-id] [sequence]
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc channel packet-ack [port-id] [channel-id] [sequence] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for packet-ack
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --prove           show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_channel_packet-commitment.md
+++ b/docs/command/okp4d_query_ibc_channel_packet-commitment.md
@@ -13,7 +13,7 @@ okp4d query ibc channel packet-commitment [port-id] [channel-id] [sequence] [fla
 ### Examples
 
 ```
-<appd> query ibc channel packet-commitment [port-id] [channel-id] [sequence]
+okp4d query ibc channel packet-commitment [port-id] [channel-id] [sequence]
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc channel packet-commitment [port-id] [channel-id] [sequence] [fla
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for packet-commitment
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --prove           show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_channel_packet-commitments.md
+++ b/docs/command/okp4d_query_ibc_channel_packet-commitments.md
@@ -13,7 +13,7 @@ okp4d query ibc channel packet-commitments [port-id] [channel-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc channel packet-commitments [port-id] [channel-id]
+okp4d query ibc channel packet-commitments [port-id] [channel-id]
 ```
 
 ### Options
@@ -23,7 +23,7 @@ okp4d query ibc channel packet-commitments [port-id] [channel-id] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for packet-commitments
       --limit uint        pagination limit of packet commitments associated with a channel to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of packet commitments associated with a channel to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of packet commitments associated with a channel to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_channel_packet-receipt.md
+++ b/docs/command/okp4d_query_ibc_channel_packet-receipt.md
@@ -13,7 +13,7 @@ okp4d query ibc channel packet-receipt [port-id] [channel-id] [sequence] [flags]
 ### Examples
 
 ```
-<appd> query ibc channel packet-receipt [port-id] [channel-id] [sequence]
+okp4d query ibc channel packet-receipt [port-id] [channel-id] [sequence]
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc channel packet-receipt [port-id] [channel-id] [sequence] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for packet-receipt
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --prove           show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_channel_unreceived-acks.md
+++ b/docs/command/okp4d_query_ibc_channel_unreceived-acks.md
@@ -17,7 +17,7 @@ okp4d query ibc channel unreceived-acks [port-id] [channel-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc channel unreceived-acks [port-id] [channel-id] --sequences=1,2,3
+okp4d query ibc channel unreceived-acks [port-id] [channel-id] --sequences=1,2,3
 ```
 
 ### Options
@@ -25,7 +25,7 @@ okp4d query ibc channel unreceived-acks [port-id] [channel-id] [flags]
 ```
       --height int             Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help                   help for unreceived-acks
-      --node string            <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string            &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string          Output format (text|json) (default "text")
       --sequences int64Slice   comma separated list of packet sequence numbers (default [])
 ```

--- a/docs/command/okp4d_query_ibc_channel_unreceived-packets.md
+++ b/docs/command/okp4d_query_ibc_channel_unreceived-packets.md
@@ -17,7 +17,7 @@ okp4d query ibc channel unreceived-packets [port-id] [channel-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc channel unreceived-packets [port-id] [channel-id] --sequences=1,2,3
+okp4d query ibc channel unreceived-packets [port-id] [channel-id] --sequences=1,2,3
 ```
 
 ### Options
@@ -25,7 +25,7 @@ okp4d query ibc channel unreceived-packets [port-id] [channel-id] [flags]
 ```
       --height int             Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help                   help for unreceived-packets
-      --node string            <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string            &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string          Output format (text|json) (default "text")
       --sequences int64Slice   comma separated list of packet sequence numbers (default [])
 ```

--- a/docs/command/okp4d_query_ibc_client_consensus-state-heights.md
+++ b/docs/command/okp4d_query_ibc_client_consensus-state-heights.md
@@ -13,7 +13,7 @@ okp4d query ibc client consensus-state-heights [client-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc client consensus-state-heights [client-id]
+okp4d query ibc client consensus-state-heights [client-id]
 ```
 
 ### Options
@@ -23,7 +23,7 @@ okp4d query ibc client consensus-state-heights [client-id] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for consensus-state-heights
       --limit uint        pagination limit of consensus state heights to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of consensus state heights to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of consensus state heights to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_client_consensus-state.md
+++ b/docs/command/okp4d_query_ibc_client_consensus-state.md
@@ -14,7 +14,7 @@ okp4d query ibc client consensus-state [client-id] [height] [flags]
 ### Examples
 
 ```
-<appd> query ibc client  consensus-state [client-id] [height]
+okp4d query ibc client  consensus-state [client-id] [height]
 ```
 
 ### Options
@@ -23,7 +23,7 @@ okp4d query ibc client consensus-state [client-id] [height] [flags]
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for consensus-state
       --latest-height   return latest stored consensus state
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --prove           show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_client_consensus-states.md
+++ b/docs/command/okp4d_query_ibc_client_consensus-states.md
@@ -13,7 +13,7 @@ okp4d query ibc client consensus-states [client-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc client consensus-states [client-id]
+okp4d query ibc client consensus-states [client-id]
 ```
 
 ### Options
@@ -23,7 +23,7 @@ okp4d query ibc client consensus-states [client-id] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for consensus-states
       --limit uint        pagination limit of consensus states to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of consensus states to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of consensus states to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_client_header.md
+++ b/docs/command/okp4d_query_ibc_client_header.md
@@ -13,7 +13,7 @@ okp4d query ibc client header [flags]
 ### Examples
 
 ```
-<appd> query ibc client  header
+okp4d query ibc client  header
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc client header [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for header
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_client_params.md
+++ b/docs/command/okp4d_query_ibc_client_params.md
@@ -13,7 +13,7 @@ okp4d query ibc client params [flags]
 ### Examples
 
 ```
-<appd> query ibc client params
+okp4d query ibc client params
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc client params [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for params
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_client_self-consensus-state.md
+++ b/docs/command/okp4d_query_ibc_client_self-consensus-state.md
@@ -13,7 +13,7 @@ okp4d query ibc client self-consensus-state [flags]
 ### Examples
 
 ```
-<appd> query ibc client self-consensus-state
+okp4d query ibc client self-consensus-state
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc client self-consensus-state [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for self-consensus-state
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_client_state.md
+++ b/docs/command/okp4d_query_ibc_client_state.md
@@ -13,7 +13,7 @@ okp4d query ibc client state [client-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc client state [client-id]
+okp4d query ibc client state [client-id]
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc client state [client-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for state
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --prove           show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_client_states.md
+++ b/docs/command/okp4d_query_ibc_client_states.md
@@ -13,7 +13,7 @@ okp4d query ibc client states [flags]
 ### Examples
 
 ```
-<appd> query ibc client states
+okp4d query ibc client states
 ```
 
 ### Options
@@ -23,7 +23,7 @@ okp4d query ibc client states [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for states
       --limit uint        pagination limit of client states to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of client states to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of client states to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_client_status.md
+++ b/docs/command/okp4d_query_ibc_client_status.md
@@ -13,7 +13,7 @@ okp4d query ibc client status [client-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc client status [client-id]
+okp4d query ibc client status [client-id]
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc client status [client-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for status
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_connection_connections.md
+++ b/docs/command/okp4d_query_ibc_connection_connections.md
@@ -13,7 +13,7 @@ okp4d query ibc connection connections [flags]
 ### Examples
 
 ```
-<appd> query ibc connection connections
+okp4d query ibc connection connections
 ```
 
 ### Options
@@ -23,7 +23,7 @@ okp4d query ibc connection connections [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for connections
       --limit uint        pagination limit of connection ends to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of connection ends to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of connection ends to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_connection_end.md
+++ b/docs/command/okp4d_query_ibc_connection_end.md
@@ -13,7 +13,7 @@ okp4d query ibc connection end [connection-id] [flags]
 ### Examples
 
 ```
-<appd> query ibc connection end [connection-id]
+okp4d query ibc connection end [connection-id]
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc connection end [connection-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for end
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --prove           show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_connection_path.md
+++ b/docs/command/okp4d_query_ibc_connection_path.md
@@ -13,7 +13,7 @@ okp4d query ibc connection path [client-id] [flags]
 ### Examples
 
 ```
-<appd> query  ibc connection path [client-id]
+okp4d query  ibc connection path [client-id]
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query ibc connection path [client-id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for path
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --prove           show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_interchain-accounts_controller_interchain-account.md
+++ b/docs/command/okp4d_query_interchain-accounts_controller_interchain-account.md
@@ -13,7 +13,7 @@ okp4d query interchain-accounts controller interchain-account [owner] [connectio
 ### Examples
 
 ```
-<appd> query interchain-accounts controller interchain-account cosmos1layxcsmyye0dc0har9sdfzwckaz8sjwlfsj8zs connection-0
+okp4d query interchain-accounts controller interchain-account cosmos1layxcsmyye0dc0har9sdfzwckaz8sjwlfsj8zs connection-0
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query interchain-accounts controller interchain-account [owner] [connectio
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for interchain-account
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_interchain-accounts_controller_params.md
+++ b/docs/command/okp4d_query_interchain-accounts_controller_params.md
@@ -13,7 +13,7 @@ okp4d query interchain-accounts controller params [flags]
 ### Examples
 
 ```
-<appd> query interchain-accounts controller params
+okp4d query interchain-accounts controller params
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query interchain-accounts controller params [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for params
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_interchain-accounts_host_packet-events.md
+++ b/docs/command/okp4d_query_interchain-accounts_host_packet-events.md
@@ -13,7 +13,7 @@ okp4d query interchain-accounts host packet-events [channel-id] [sequence] [flag
 ### Examples
 
 ```
-<appd> query interchain-accounts host packet-events channel-0 100
+okp4d query interchain-accounts host packet-events channel-0 100
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query interchain-accounts host packet-events [channel-id] [sequence] [flag
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for packet-events
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_interchain-accounts_host_params.md
+++ b/docs/command/okp4d_query_interchain-accounts_host_params.md
@@ -13,7 +13,7 @@ okp4d query interchain-accounts host params [flags]
 ### Examples
 
 ```
-<appd> query interchain-accounts host params
+okp4d query interchain-accounts host params
 ```
 
 ### Options
@@ -21,7 +21,7 @@ okp4d query interchain-accounts host params [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for params
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_intertx_interchainaccounts.md
+++ b/docs/command/okp4d_query_intertx_interchainaccounts.md
@@ -11,7 +11,7 @@ okp4d query intertx interchainaccounts [connection-id] [owner-account] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for interchainaccounts
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_logic_params.md
+++ b/docs/command/okp4d_query_logic_params.md
@@ -11,7 +11,7 @@ okp4d query logic params [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for params
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_mint_annual-provisions.md
+++ b/docs/command/okp4d_query_mint_annual-provisions.md
@@ -11,7 +11,7 @@ okp4d query mint annual-provisions [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for annual-provisions
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_mint_inflation.md
+++ b/docs/command/okp4d_query_mint_inflation.md
@@ -11,7 +11,7 @@ okp4d query mint inflation [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for inflation
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_mint_params.md
+++ b/docs/command/okp4d_query_mint_params.md
@@ -11,7 +11,7 @@ okp4d query mint params [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for params
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_params_subspace.md
+++ b/docs/command/okp4d_query_params_subspace.md
@@ -11,7 +11,7 @@ okp4d query params subspace [subspace] [key] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for subspace
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_slashing_params.md
+++ b/docs/command/okp4d_query_slashing_params.md
@@ -6,7 +6,7 @@ Query the current slashing parameters
 
 Query genesis parameters for the slashing module:
 
-$ <appd> query slashing params
+$ okp4d query slashing params
 
 ```
 okp4d query slashing params [flags]
@@ -17,7 +17,7 @@ okp4d query slashing params [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for params
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_slashing_signing-info.md
+++ b/docs/command/okp4d_query_slashing_signing-info.md
@@ -6,7 +6,7 @@ Query a validator's signing information
 
 Use a validators' consensus public key to find the signing-info for that validator:
 
-$ <appd> query slashing signing-info '{"@type":"/cosmos.crypto.ed25519.PubKey","key":"OauFcTKbN5Lx3fJL689cikXBqe+hcp6Y+x0rYUdR9Jk="}'
+$ okp4d query slashing signing-info '{"@type":"/cosmos.crypto.ed25519.PubKey","key":"OauFcTKbN5Lx3fJL689cikXBqe+hcp6Y+x0rYUdR9Jk="}'
 
 ```
 okp4d query slashing signing-info [validator-conspub] [flags]
@@ -17,7 +17,7 @@ okp4d query slashing signing-info [validator-conspub] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for signing-info
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_slashing_signing-infos.md
+++ b/docs/command/okp4d_query_slashing_signing-infos.md
@@ -6,7 +6,7 @@ Query signing information of all validators
 
 signing infos of validators:
 
-$ <appd> query slashing signing-infos
+$ okp4d query slashing signing-infos
 
 ```
 okp4d query slashing signing-infos [flags]
@@ -19,7 +19,7 @@ okp4d query slashing signing-infos [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for signing-infos
       --limit uint        pagination limit of signing infos to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of signing infos to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of signing infos to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_delegation.md
+++ b/docs/command/okp4d_query_staking_delegation.md
@@ -7,7 +7,7 @@ Query a delegation based on address and validator address
 Query delegations for an individual delegator on an individual validator.
 
 Example:
-$ <appd> query staking delegation okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
+$ okp4d query staking delegation okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
 
 ```
 okp4d query staking delegation [delegator-addr] [validator-addr] [flags]
@@ -18,7 +18,7 @@ okp4d query staking delegation [delegator-addr] [validator-addr] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for delegation
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_delegations-to.md
+++ b/docs/command/okp4d_query_staking_delegations-to.md
@@ -7,7 +7,7 @@ Query all delegations made to one validator
 Query delegations on an individual validator.
 
 Example:
-$ <appd> query staking delegations-to okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
+$ okp4d query staking delegations-to okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
 
 ```
 okp4d query staking delegations-to [validator-addr] [flags]
@@ -20,7 +20,7 @@ okp4d query staking delegations-to [validator-addr] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for delegations-to
       --limit uint        pagination limit of validator delegations to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of validator delegations to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of validator delegations to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_delegations.md
+++ b/docs/command/okp4d_query_staking_delegations.md
@@ -7,7 +7,7 @@ Query all delegations made by one delegator
 Query delegations for an individual delegator on all validators.
 
 Example:
-$ <appd> query staking delegations okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
+$ okp4d query staking delegations okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
 
 ```
 okp4d query staking delegations [delegator-addr] [flags]
@@ -20,7 +20,7 @@ okp4d query staking delegations [delegator-addr] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for delegations
       --limit uint        pagination limit of delegations to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of delegations to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of delegations to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_historical-info.md
+++ b/docs/command/okp4d_query_staking_historical-info.md
@@ -7,7 +7,7 @@ Query historical info at given height
 Query historical info at given height.
 
 Example:
-$ <appd> query staking historical-info 5
+$ okp4d query staking historical-info 5
 
 ```
 okp4d query staking historical-info [height] [flags]
@@ -18,7 +18,7 @@ okp4d query staking historical-info [height] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for historical-info
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_params.md
+++ b/docs/command/okp4d_query_staking_params.md
@@ -7,7 +7,7 @@ Query the current staking parameters information
 Query values set as staking parameters.
 
 Example:
-$ <appd> query staking params
+$ okp4d query staking params
 
 ```
 okp4d query staking params [flags]
@@ -18,7 +18,7 @@ okp4d query staking params [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for params
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_pool.md
+++ b/docs/command/okp4d_query_staking_pool.md
@@ -7,7 +7,7 @@ Query the current staking pool values
 Query values for amounts stored in the staking pool.
 
 Example:
-$ <appd> query staking pool
+$ okp4d query staking pool
 
 ```
 okp4d query staking pool [flags]
@@ -18,7 +18,7 @@ okp4d query staking pool [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for pool
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_redelegation.md
+++ b/docs/command/okp4d_query_staking_redelegation.md
@@ -7,7 +7,7 @@ Query a redelegation record based on delegator and a source and destination vali
 Query a redelegation record for an individual delegator between a source and destination validator.
 
 Example:
-$ <appd> query staking redelegation okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p okp4valoper1l2rsakp388kuv9k8qzq6lrm9taddae7fpx59wm okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
+$ okp4d query staking redelegation okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p okp4valoper1l2rsakp388kuv9k8qzq6lrm9taddae7fpx59wm okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
 
 ```
 okp4d query staking redelegation [delegator-addr] [src-validator-addr] [dst-validator-addr] [flags]
@@ -18,7 +18,7 @@ okp4d query staking redelegation [delegator-addr] [src-validator-addr] [dst-vali
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for redelegation
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_redelegations-from.md
+++ b/docs/command/okp4d_query_staking_redelegations-from.md
@@ -7,7 +7,7 @@ Query all outgoing redelegatations from a validator
 Query delegations that are redelegating _from_ a validator.
 
 Example:
-$ <appd> query staking redelegations-from okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
+$ okp4d query staking redelegations-from okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
 
 ```
 okp4d query staking redelegations-from [validator-addr] [flags]
@@ -20,7 +20,7 @@ okp4d query staking redelegations-from [validator-addr] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for redelegations-from
       --limit uint        pagination limit of validator redelegations to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of validator redelegations to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of validator redelegations to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_redelegations.md
+++ b/docs/command/okp4d_query_staking_redelegations.md
@@ -7,7 +7,7 @@ Query all redelegations records for one delegator
 Query all redelegation records for an individual delegator.
 
 Example:
-$ <appd> query staking redelegation okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
+$ okp4d query staking redelegation okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
 
 ```
 okp4d query staking redelegations [delegator-addr] [flags]
@@ -20,7 +20,7 @@ okp4d query staking redelegations [delegator-addr] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for redelegations
       --limit uint        pagination limit of delegator redelegations to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of delegator redelegations to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of delegator redelegations to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_unbonding-delegation.md
+++ b/docs/command/okp4d_query_staking_unbonding-delegation.md
@@ -7,7 +7,7 @@ Query an unbonding-delegation record based on delegator and validator address
 Query unbonding delegations for an individual delegator on an individual validator.
 
 Example:
-$ <appd> query staking unbonding-delegation okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
+$ okp4d query staking unbonding-delegation okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
 
 ```
 okp4d query staking unbonding-delegation [delegator-addr] [validator-addr] [flags]
@@ -18,7 +18,7 @@ okp4d query staking unbonding-delegation [delegator-addr] [validator-addr] [flag
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for unbonding-delegation
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_unbonding-delegations-from.md
+++ b/docs/command/okp4d_query_staking_unbonding-delegations-from.md
@@ -7,7 +7,7 @@ Query all unbonding delegatations from a validator
 Query delegations that are unbonding _from_ a validator.
 
 Example:
-$ <appd> query staking unbonding-delegations-from okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
+$ okp4d query staking unbonding-delegations-from okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
 
 ```
 okp4d query staking unbonding-delegations-from [validator-addr] [flags]
@@ -20,7 +20,7 @@ okp4d query staking unbonding-delegations-from [validator-addr] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for unbonding-delegations-from
       --limit uint        pagination limit of unbonding delegations to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of unbonding delegations to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of unbonding delegations to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_unbonding-delegations.md
+++ b/docs/command/okp4d_query_staking_unbonding-delegations.md
@@ -7,7 +7,7 @@ Query all unbonding-delegations records for one delegator
 Query unbonding delegations for an individual delegator.
 
 Example:
-$ <appd> query staking unbonding-delegations okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
+$ okp4d query staking unbonding-delegations okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p
 
 ```
 okp4d query staking unbonding-delegations [delegator-addr] [flags]
@@ -20,7 +20,7 @@ okp4d query staking unbonding-delegations [delegator-addr] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for unbonding-delegations
       --limit uint        pagination limit of unbonding delegations to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of unbonding delegations to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of unbonding delegations to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_validator.md
+++ b/docs/command/okp4d_query_staking_validator.md
@@ -7,7 +7,7 @@ Query a validator
 Query details about an individual validator.
 
 Example:
-$ <appd> query staking validator okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
+$ okp4d query staking validator okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj
 
 ```
 okp4d query staking validator [validator-addr] [flags]
@@ -18,7 +18,7 @@ okp4d query staking validator [validator-addr] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for validator
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_validators.md
+++ b/docs/command/okp4d_query_staking_validators.md
@@ -7,7 +7,7 @@ Query for all validators
 Query details about all validators on a network.
 
 Example:
-$ <appd> query staking validators
+$ okp4d query staking validators
 
 ```
 okp4d query staking validators [flags]
@@ -20,7 +20,7 @@ okp4d query staking validators [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for validators
       --limit uint        pagination limit of validators to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of validators to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of validators to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_tendermint-validator-set.md
+++ b/docs/command/okp4d_query_tendermint-validator-set.md
@@ -11,7 +11,7 @@ okp4d query tendermint-validator-set [height] [flags]
 ```
   -h, --help            help for tendermint-validator-set
       --limit int       Query number of results returned per page (default 100)
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --page int        Query a specific page of paginated results (default 1)
 ```

--- a/docs/command/okp4d_query_tx.md
+++ b/docs/command/okp4d_query_tx.md
@@ -1,13 +1,13 @@
 ## okp4d query tx
 
-Query for a transaction by hash, "<addr>/<seq>" combination or comma-separated signatures in a committed block
+Query for a transaction by hash, "&lt;addr&gt;/&lt;seq&gt;" combination or comma-separated signatures in a committed block
 
 ### Synopsis
 
 Example:
-$ <appd> query tx <hash>
-$ <appd> query tx --type=acc_seq <addr>/<sequence>
-$ <appd> query tx --type=signature <sig1_base64>,<sig2_base64...>
+$ okp4d query tx &lt;hash&gt;
+$ okp4d query tx --type=acc_seq &lt;addr&gt;/&lt;sequence&gt;
+$ okp4d query tx --type=signature <sig1_base64>,<sig2_base64...>
 
 ```
 okp4d query tx --type=[hash|acc_seq|signature] [hash|acc_seq|signature] [flags]
@@ -18,7 +18,7 @@ okp4d query tx --type=[hash|acc_seq|signature] [hash|acc_seq|signature] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for tx
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --type string     The type to be used when querying tx, can be one of "hash", "acc_seq", "signature" (default "hash")
 ```

--- a/docs/command/okp4d_query_txs.md
+++ b/docs/command/okp4d_query_txs.md
@@ -10,7 +10,7 @@ to each module's documentation for the full set of events to query for. Each mod
 documents its respective events under 'xx_events.md'.
 
 Example:
-$ <appd> query txs --events 'message.sender=cosmos1...&message.action=withdraw_delegator_reward' --page 1 --limit 30
+$ okp4d query txs --events 'message.sender=cosmos1...&message.action=withdraw_delegator_reward' --page 1 --limit 30
 
 ```
 okp4d query txs [flags]
@@ -23,7 +23,7 @@ okp4d query txs [flags]
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for txs
       --limit int       Query number of transactions results per page returned (default 100)
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --page int        Query a specific page of paginated results (default 1)
 ```

--- a/docs/command/okp4d_query_upgrade_applied.md
+++ b/docs/command/okp4d_query_upgrade_applied.md
@@ -16,7 +16,7 @@ okp4d query upgrade applied [upgrade-name] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for applied
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_upgrade_module_versions.md
+++ b/docs/command/okp4d_query_upgrade_module_versions.md
@@ -17,7 +17,7 @@ okp4d query upgrade module_versions [optional module_name] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for module_versions
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_upgrade_plan.md
+++ b/docs/command/okp4d_query_upgrade_plan.md
@@ -15,7 +15,7 @@ okp4d query upgrade plan [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for plan
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_code-info.md
+++ b/docs/command/okp4d_query_wasm_code-info.md
@@ -15,7 +15,7 @@ okp4d query wasm code-info [code_id] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for code-info
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_code.md
+++ b/docs/command/okp4d_query_wasm_code.md
@@ -15,7 +15,7 @@ okp4d query wasm code [code_id] [output filename] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for code
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_contract-history.md
+++ b/docs/command/okp4d_query_wasm_contract-history.md
@@ -17,7 +17,7 @@ okp4d query wasm contract-history [bech32_address] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for contract-history
       --limit uint        pagination limit of contract history to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of contract history to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of contract history to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_wasm_contract-state_all.md
+++ b/docs/command/okp4d_query_wasm_contract-state_all.md
@@ -17,7 +17,7 @@ okp4d query wasm contract-state all [bech32_address] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for all
       --limit uint        pagination limit of contract state to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of contract state to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of contract state to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_wasm_contract-state_raw.md
+++ b/docs/command/okp4d_query_wasm_contract-state_raw.md
@@ -18,7 +18,7 @@ okp4d query wasm contract-state raw [bech32_address] [key] [flags]
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for raw
       --hex             hex encoded  key argument
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_contract-state_smart.md
+++ b/docs/command/okp4d_query_wasm_contract-state_smart.md
@@ -18,7 +18,7 @@ okp4d query wasm contract-state smart [bech32_address] [query] [flags]
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for smart
       --hex             hex encoded  query argument
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_contract.md
+++ b/docs/command/okp4d_query_wasm_contract.md
@@ -15,7 +15,7 @@ okp4d query wasm contract [bech32_address] [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for contract
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_list-code.md
+++ b/docs/command/okp4d_query_wasm_list-code.md
@@ -17,7 +17,7 @@ okp4d query wasm list-code [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for list-code
       --limit uint        pagination limit of list codes to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of list codes to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of list codes to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_wasm_list-contract-by-code.md
+++ b/docs/command/okp4d_query_wasm_list-contract-by-code.md
@@ -17,7 +17,7 @@ okp4d query wasm list-contract-by-code [code_id] [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for list-contract-by-code
       --limit uint        pagination limit of list contracts by code to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of list contracts by code to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of list contracts by code to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_wasm_params.md
+++ b/docs/command/okp4d_query_wasm_params.md
@@ -11,7 +11,7 @@ okp4d query wasm params [flags]
 ```
       --height int      Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help            help for params
-      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_pinned.md
+++ b/docs/command/okp4d_query_wasm_pinned.md
@@ -18,7 +18,7 @@ okp4d query wasm pinned [flags]
       --height int        Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help              help for pinned
       --limit uint        pagination limit of list codes to query for (default 100)
-      --node string       <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string       &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint       pagination offset of list codes to query for
   -o, --output string     Output format (text|json) (default "text")
       --page uint         pagination page of list codes to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_tx_authz_exec.md
+++ b/docs/command/okp4d_tx_authz_exec.md
@@ -6,8 +6,8 @@ execute tx on behalf of granter account
 
 execute tx on behalf of granter account:
 Example:
- $ <appd> tx authz exec tx.json --from grantee
- $ <appd> tx bank send <granter> <recipient> --from <granter> --chain-id <chain-id> --generate-only > tx.json && <appd> tx authz exec tx.json --from grantee
+ $ okp4d tx authz exec tx.json --from grantee
+ $ okp4d tx bank send &lt;granter&gt; &lt;recipient&gt; --from &lt;granter&gt; --chain-id &lt;chain-id&gt; --generate-only > tx.json && okp4d tx authz exec tx.json --from grantee
 
 ```
 okp4d tx authz exec [tx-json-file] --from [grantee] [flags]
@@ -32,7 +32,7 @@ okp4d tx authz exec [tx-json-file] --from [grantee] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_authz_grant.md
+++ b/docs/command/okp4d_tx_authz_grant.md
@@ -7,11 +7,11 @@ Grant authorization to an address
 create a new grant authorization to an address to execute a transaction on your behalf:
 
 Examples:
- $ <appd> tx authz grant cosmos1skjw.. send /cosmos.bank.v1beta1.MsgSend --spend-limit=1000stake --from=cosmos1skl..
- $ <appd> tx authz grant cosmos1skjw.. generic --msg-type=/cosmos.gov.v1.MsgVote --from=cosmos1sk..
+ $ okp4d tx authz grant cosmos1skjw.. send /cosmos.bank.v1beta1.MsgSend --spend-limit=1000stake --from=cosmos1skl..
+ $ okp4d tx authz grant cosmos1skjw.. generic --msg-type=/cosmos.gov.v1.MsgVote --from=cosmos1sk..
 
 ```
-okp4d tx authz grant <grantee> <authorization_type="send"|"generic"|"delegate"|"unbond"|"redelegate"> --from <granter> [flags]
+okp4d tx authz grant &lt;grantee&gt; <authorization_type="send"|"generic"|"delegate"|"unbond"|"redelegate"> --from &lt;granter&gt; [flags]
 ```
 
 ### Options
@@ -37,7 +37,7 @@ okp4d tx authz grant <grantee> <authorization_type="send"|"generic"|"delegate"|"
       --keyring-dir string           The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                       Use a connected Ledger device
       --msg-type string              The Msg method name for which we are creating a GenericAuthorization
-      --node string                  <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                  &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                  Note to add a description to the transaction (previously --memo)
       --offline                      Offline mode (does not allow any online functionality)
   -o, --output string                Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_authz_revoke.md
+++ b/docs/command/okp4d_tx_authz_revoke.md
@@ -6,7 +6,7 @@ revoke authorization
 
 revoke authorization from a granter to a grantee:
 Example:
- $ <appd> tx authz revoke cosmos1skj.. /cosmos.bank.v1beta1.MsgSend --from=cosmos1skj..
+ $ okp4d tx authz revoke cosmos1skj.. /cosmos.bank.v1beta1.MsgSend --from=cosmos1skj..
 
 ```
 okp4d tx authz revoke [grantee] [msg-type-url] --from=[granter] [flags]
@@ -31,7 +31,7 @@ okp4d tx authz revoke [grantee] [msg-type-url] --from=[granter] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_bank_multi-send.md
+++ b/docs/command/okp4d_tx_bank_multi-send.md
@@ -34,7 +34,7 @@ okp4d tx bank multi-send [from_key_or_address] [to_address_1, to_address_2, ...]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_bank_send.md
+++ b/docs/command/okp4d_tx_bank_send.md
@@ -32,7 +32,7 @@ okp4d tx bank send [from_key_or_address] [to_address] [amount] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_broadcast.md
+++ b/docs/command/okp4d_tx_broadcast.md
@@ -9,7 +9,7 @@ flag and signed with the sign command. Read a transaction from [file_path] and
 broadcast it to a node. If you supply a dash (-) argument in place of an input
 filename, the command reads from standard input.
 
-$ <appd> tx broadcast ./mytxn.json
+$ okp4d tx broadcast ./mytxn.json
 
 ```
 okp4d tx broadcast [file_path] [flags]
@@ -34,7 +34,7 @@ okp4d tx broadcast [file_path] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_crisis_invariant-broken.md
+++ b/docs/command/okp4d_tx_crisis_invariant-broken.md
@@ -25,7 +25,7 @@ okp4d tx crisis invariant-broken [module-name] [invariant-route] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_decode.md
+++ b/docs/command/okp4d_tx_decode.md
@@ -26,7 +26,7 @@ okp4d tx decode [protobuf-byte-string] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_distribution_fund-community-pool.md
+++ b/docs/command/okp4d_tx_distribution_fund-community-pool.md
@@ -7,7 +7,7 @@ Funds the community pool with the specified amount
 Funds the community pool with the specified amount
 
 Example:
-$ <appd> tx distribution fund-community-pool 100uatom --from mykey
+$ okp4d tx distribution fund-community-pool 100uatom --from mykey
 
 ```
 okp4d tx distribution fund-community-pool [amount] [flags]
@@ -32,7 +32,7 @@ okp4d tx distribution fund-community-pool [amount] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_distribution_set-withdraw-addr.md
+++ b/docs/command/okp4d_tx_distribution_set-withdraw-addr.md
@@ -7,7 +7,7 @@ change the default withdraw address for rewards associated with an address
 Set the withdraw address for rewards associated with a delegator address.
 
 Example:
-$ <appd> tx distribution set-withdraw-addr okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p --from mykey
+$ okp4d tx distribution set-withdraw-addr okp41gghjut3ccd8ay0zduzj64hwre2fxs9ld75ru9p --from mykey
 
 ```
 okp4d tx distribution set-withdraw-addr [withdraw-addr] [flags]
@@ -32,7 +32,7 @@ okp4d tx distribution set-withdraw-addr [withdraw-addr] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_distribution_withdraw-all-rewards.md
+++ b/docs/command/okp4d_tx_distribution_withdraw-all-rewards.md
@@ -8,7 +8,7 @@ Withdraw all rewards for a single delegator.
 Note that if you use this command with --broadcast-mode=sync or --broadcast-mode=async, the max-msgs flag will automatically be set to 0.
 
 Example:
-$ <appd> tx distribution withdraw-all-rewards --from mykey
+$ okp4d tx distribution withdraw-all-rewards --from mykey
 
 ```
 okp4d tx distribution withdraw-all-rewards [flags]
@@ -34,7 +34,7 @@ okp4d tx distribution withdraw-all-rewards [flags]
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --max-msgs int             Limit the number of messages per tx (0 for unlimited)
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_distribution_withdraw-rewards.md
+++ b/docs/command/okp4d_tx_distribution_withdraw-rewards.md
@@ -8,8 +8,8 @@ Withdraw rewards from a given delegation address,
 and optionally withdraw validator commission if the delegation address given is a validator operator.
 
 Example:
-$ <appd> tx distribution withdraw-rewards okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj --from mykey
-$ <appd> tx distribution withdraw-rewards okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj --from mykey --commission
+$ okp4d tx distribution withdraw-rewards okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj --from mykey
+$ okp4d tx distribution withdraw-rewards okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj --from mykey --commission
 
 ```
 okp4d tx distribution withdraw-rewards [validator-addr] [flags]
@@ -35,7 +35,7 @@ okp4d tx distribution withdraw-rewards [validator-addr] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_encode.md
+++ b/docs/command/okp4d_tx_encode.md
@@ -5,7 +5,7 @@ Encode transactions generated offline
 ### Synopsis
 
 Encode transactions created with the --generate-only flag and signed with the sign command.
-Read a transaction from <file>, serialize it to the Protobuf wire protocol, and output it as base64.
+Read a transaction from &lt;file&gt;, serialize it to the Protobuf wire protocol, and output it as base64.
 If you supply a dash (-) argument in place of an input filename, the command reads from standard input.
 
 ```
@@ -31,7 +31,7 @@ okp4d tx encode [file] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_feegrant_grant.md
+++ b/docs/command/okp4d_tx_feegrant_grant.md
@@ -8,9 +8,9 @@ Grant authorization to pay fees from your address. Note, the'--from' flag is
 				ignored as it is implied from [granter].
 
 Examples:
-<appd> tx feegrant grant cosmos1skjw... cosmos1skjw... --spend-limit 100stake --expiration 2022-01-30T15:04:05Z or
-<appd> tx feegrant grant cosmos1skjw... cosmos1skjw... --spend-limit 100stake --period 3600 --period-limit 10stake --expiration 2022-01-30T15:04:05Z or
-<appd> tx feegrant grant cosmos1skjw... cosmos1skjw... --spend-limit 100stake --expiration 2022-01-30T15:04:05Z 
+okp4d tx feegrant grant cosmos1skjw... cosmos1skjw... --spend-limit 100stake --expiration 2022-01-30T15:04:05Z or
+okp4d tx feegrant grant cosmos1skjw... cosmos1skjw... --spend-limit 100stake --period 3600 --period-limit 10stake --expiration 2022-01-30T15:04:05Z or
+okp4d tx feegrant grant cosmos1skjw... cosmos1skjw... --spend-limit 100stake --expiration 2022-01-30T15:04:05Z 
 	--allowed-messages "/cosmos.gov.v1beta1.MsgSubmitProposal,/cosmos.gov.v1beta1.MsgVote"
 
 ```
@@ -38,7 +38,7 @@ okp4d tx feegrant grant [granter_key_or_address] [grantee] [flags]
       --keyring-backend string     Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string         The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                     Use a connected Ledger device
-      --node string                <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                Note to add a description to the transaction (previously --memo)
       --offline                    Offline mode (does not allow any online functionality)
   -o, --output string              Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_feegrant_revoke.md
+++ b/docs/command/okp4d_tx_feegrant_revoke.md
@@ -8,7 +8,7 @@ revoke fee grant from a granter to a grantee. Note, the'--from' flag is
 			ignored as it is implied from [granter].
 
 Example:
- $ <appd> tx feegrant revoke cosmos1skj.. cosmos1skj..
+ $ okp4d tx feegrant revoke cosmos1skj.. cosmos1skj..
 
 ```
 okp4d tx feegrant revoke [granter] [grantee] [flags]
@@ -33,7 +33,7 @@ okp4d tx feegrant revoke [granter] [grantee] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_deposit.md
+++ b/docs/command/okp4d_tx_gov_deposit.md
@@ -5,10 +5,10 @@ Deposit tokens for an active proposal
 ### Synopsis
 
 Submit a deposit for an active proposal. You can
-find the proposal-id by running "<appd> query gov proposals".
+find the proposal-id by running "okp4d query gov proposals".
 
 Example:
-$ <appd> tx gov deposit 1 10stake --from mykey
+$ okp4d tx gov deposit 1 10stake --from mykey
 
 ```
 okp4d tx gov deposit [proposal-id] [deposit] [flags]
@@ -33,7 +33,7 @@ okp4d tx gov deposit [proposal-id] [deposit] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_draft-proposal.md
+++ b/docs/command/okp4d_tx_gov_draft-proposal.md
@@ -25,7 +25,7 @@ okp4d tx gov draft-proposal [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal.md
@@ -8,7 +8,7 @@ Submit a legacy proposal along with an initial deposit.
 Proposal title, description, type and deposit can be given directly or through a proposal JSON file.
 
 Example:
-$ <appd> tx gov submit-legacy-proposal --proposal="path/to/proposal.json" --from mykey
+$ okp4d tx gov submit-legacy-proposal --proposal="path/to/proposal.json" --from mykey
 
 Where proposal.json contains:
 
@@ -21,7 +21,7 @@ Where proposal.json contains:
 
 Which is equivalent to:
 
-$ <appd> tx gov submit-legacy-proposal --title="Test Proposal" --description="My awesome proposal" --type="Text" --deposit="10test" --from mykey
+$ okp4d tx gov submit-legacy-proposal --title="Test Proposal" --description="My awesome proposal" --type="Text" --deposit="10test" --from mykey
 
 ```
 okp4d tx gov submit-legacy-proposal [flags]
@@ -48,7 +48,7 @@ okp4d tx gov submit-legacy-proposal [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_cancel-software-upgrade.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_cancel-software-upgrade.md
@@ -31,7 +31,7 @@ okp4d tx gov submit-legacy-proposal cancel-software-upgrade [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_clear-contract-admin.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_clear-contract-admin.md
@@ -27,7 +27,7 @@ okp4d tx gov submit-legacy-proposal clear-contract-admin [contract_addr_bech32] 
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_community-pool-spend.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_community-pool-spend.md
@@ -8,7 +8,7 @@ Submit a community pool spend proposal along with an initial deposit.
 The proposal details must be supplied via a JSON file.
 
 Example:
-$ <appd> tx gov submit-proposal community-pool-spend <path/to/proposal.json> --from=<key_or_address>
+$ okp4d tx gov submit-proposal community-pool-spend <path/to/proposal.json> --from=<key_or_address>
 
 Where proposal.json contains:
 
@@ -43,7 +43,7 @@ okp4d tx gov submit-legacy-proposal community-pool-spend [proposal-file] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_execute-contract.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_execute-contract.md
@@ -28,7 +28,7 @@ okp4d tx gov submit-legacy-proposal execute-contract [contract_addr_bech32] [jso
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_ibc-upgrade.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_ibc-upgrade.md
@@ -42,7 +42,7 @@ okp4d tx gov submit-legacy-proposal ibc-upgrade [name] [height] [path/to/upgrade
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_instantiate-contract.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_instantiate-contract.md
@@ -31,7 +31,7 @@ okp4d tx gov submit-legacy-proposal instantiate-contract [code_id_int64] [json_e
       --label string             A human-readable name for this contract in lists
       --ledger                   Use a connected Ledger device
       --no-admin                 You must set this explicitly if you don't want an admin
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_migrate-contract.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_migrate-contract.md
@@ -27,7 +27,7 @@ okp4d tx gov submit-legacy-proposal migrate-contract [contract_addr_bech32] [new
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_param-change.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_param-change.md
@@ -17,7 +17,7 @@ Proper vetting of a parameter change proposal should prevent this from happening
 regardless.
 
 Example:
-$ <appd> tx gov submit-proposal param-change <path/to/proposal.json> --from=<key_or_address>
+$ okp4d tx gov submit-proposal param-change <path/to/proposal.json> --from=<key_or_address>
 
 Where proposal.json contains:
 
@@ -57,7 +57,7 @@ okp4d tx gov submit-legacy-proposal param-change [proposal-file] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_pin-codes.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_pin-codes.md
@@ -27,7 +27,7 @@ okp4d tx gov submit-legacy-proposal pin-codes [code-ids] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_set-contract-admin.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_set-contract-admin.md
@@ -27,7 +27,7 @@ okp4d tx gov submit-legacy-proposal set-contract-admin [contract_addr_bech32] [n
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_software-upgrade.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_software-upgrade.md
@@ -35,7 +35,7 @@ okp4d tx gov submit-legacy-proposal software-upgrade [name] (--upgrade-height [h
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --no-validate              Skip validation of the upgrade info
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_sudo-contract.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_sudo-contract.md
@@ -27,7 +27,7 @@ okp4d tx gov submit-legacy-proposal sudo-contract [contract_addr_bech32] [json_e
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_unpin-codes.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_unpin-codes.md
@@ -27,7 +27,7 @@ okp4d tx gov submit-legacy-proposal unpin-codes [code-ids] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_update-client.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_update-client.md
@@ -33,7 +33,7 @@ okp4d tx gov submit-legacy-proposal update-client [subject-client-id] [substitut
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_update-instantiate-config.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_update-instantiate-config.md
@@ -7,7 +7,7 @@ Submit an update instantiate config proposal.
 Submit an update instantiate config  proposal for multiple code ids.
 
 Example: 
-$ <appd> tx gov submit-proposal update-instantiate-config 1:nobody 2:everybody 3:okp41l2rsakp388kuv9k8qzq6lrm9taddae7fpx59wm,okp41vx8knpllrj7n963p9ttd80w47kpacrhuts497x
+$ okp4d tx gov submit-proposal update-instantiate-config 1:nobody 2:everybody 3:okp41l2rsakp388kuv9k8qzq6lrm9taddae7fpx59wm,okp41vx8knpllrj7n963p9ttd80w47kpacrhuts497x
 
 ```
 okp4d tx gov submit-legacy-proposal update-instantiate-config [code-id:permission]... [flags]
@@ -34,7 +34,7 @@ okp4d tx gov submit-legacy-proposal update-instantiate-config [code-id:permissio
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_wasm-store.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_wasm-store.md
@@ -30,7 +30,7 @@ okp4d tx gov submit-legacy-proposal wasm-store [wasm file] --title [text] --desc
       --keyring-backend string            Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string                The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                            Use a connected Ledger device
-      --node string                       <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                       &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                       Note to add a description to the transaction (previously --memo)
       --offline                           Offline mode (does not allow any online functionality)
   -o, --output string                     Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-proposal.md
+++ b/docs/command/okp4d_tx_gov_submit-proposal.md
@@ -8,7 +8,7 @@ Submit a proposal along with some messages, metadata and deposit.
 They should be defined in a JSON file.
 
 Example:
-$ <appd> tx gov submit-proposal path/to/proposal.json
+$ okp4d tx gov submit-proposal path/to/proposal.json
 
 Where proposal.json contains:
 
@@ -49,7 +49,7 @@ okp4d tx gov submit-proposal [path/to/proposal.json] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_vote.md
+++ b/docs/command/okp4d_tx_gov_vote.md
@@ -5,10 +5,10 @@ Vote for an active proposal, options: yes/no/no_with_veto/abstain
 ### Synopsis
 
 Submit a vote for an active proposal. You can
-find the proposal-id by running "<appd> query gov proposals".
+find the proposal-id by running "okp4d query gov proposals".
 
 Example:
-$ <appd> tx gov vote 1 yes --from mykey
+$ okp4d tx gov vote 1 yes --from mykey
 
 ```
 okp4d tx gov vote [proposal-id] [option] [flags]
@@ -34,7 +34,7 @@ okp4d tx gov vote [proposal-id] [option] [flags]
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --metadata string          Specify metadata of the vote
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_weighted-vote.md
+++ b/docs/command/okp4d_tx_gov_weighted-vote.md
@@ -5,10 +5,10 @@ Vote for an active proposal, options: yes/no/no_with_veto/abstain
 ### Synopsis
 
 Submit a vote for an active proposal. You can
-find the proposal-id by running "<appd> query gov proposals".
+find the proposal-id by running "okp4d query gov proposals".
 
 Example:
-$ <appd> tx gov weighted-vote 1 yes=0.6,no=0.3,abstain=0.05,no_with_veto=0.05 --from mykey
+$ okp4d tx gov weighted-vote 1 yes=0.6,no=0.3,abstain=0.05,no_with_veto=0.05 --from mykey
 
 ```
 okp4d tx gov weighted-vote [proposal-id] [weighted-options] [flags]
@@ -34,7 +34,7 @@ okp4d tx gov weighted-vote [proposal-id] [weighted-options] [flags]
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --metadata string          Specify metadata of the weighted vote
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_create-group-policy.md
+++ b/docs/command/okp4d_tx_group_create-group-policy.md
@@ -10,7 +10,7 @@ okp4d tx group create-group-policy [admin] [group-id] [metadata] [decision-polic
 
 ```
 
-<appd> tx group create-group-policy [admin] [group-id] [metadata] policy.json
+okp4d tx group create-group-policy [admin] [group-id] [metadata] policy.json
 
 where policy.json contains:
 
@@ -54,7 +54,7 @@ Here, we can use percentage decision policy when needed, where 0 < percentage <=
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_create-group-with-policy.md
+++ b/docs/command/okp4d_tx_group_create-group-with-policy.md
@@ -17,7 +17,7 @@ okp4d tx group create-group-with-policy [admin] [group-metadata] [group-policy-m
 
 ```
 
-<appd> tx group create-group-with-policy [admin] [group-metadata] [group-policy-metadata] members.json policy.json
+okp4d tx group create-group-with-policy [admin] [group-metadata] [group-policy-metadata] members.json policy.json
 
 where members.json contains:
 
@@ -69,7 +69,7 @@ and policy.json contains:
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_create-group.md
+++ b/docs/command/okp4d_tx_group_create-group.md
@@ -15,7 +15,7 @@ okp4d tx group create-group [admin] [metadata] [members-json-file] [flags]
 
 ```
 
-<appd> tx group create-group [admin] [metadata] [members-json-file]
+okp4d tx group create-group [admin] [metadata] [members-json-file]
 
 Where members.json contains:
 
@@ -54,7 +54,7 @@ Where members.json contains:
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_draft-proposal.md
+++ b/docs/command/okp4d_tx_group_draft-proposal.md
@@ -25,7 +25,7 @@ okp4d tx group draft-proposal [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_exec.md
+++ b/docs/command/okp4d_tx_group_exec.md
@@ -25,7 +25,7 @@ okp4d tx group exec [proposal-id] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_leave-group.md
+++ b/docs/command/okp4d_tx_group_leave-group.md
@@ -35,7 +35,7 @@ okp4d tx group leave-group [member-address] [group-id] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_submit-proposal.md
+++ b/docs/command/okp4d_tx_group_submit-proposal.md
@@ -16,7 +16,7 @@ okp4d tx group submit-proposal [proposal_json_file] [flags]
 
 ```
 
-<appd> tx group submit-proposal path/to/proposal.json
+okp4d tx group submit-proposal path/to/proposal.json
 	
 	Where proposal.json contains:
 
@@ -56,7 +56,7 @@ okp4d tx group submit-proposal [proposal_json_file] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_update-group-admin.md
+++ b/docs/command/okp4d_tx_group_update-group-admin.md
@@ -25,7 +25,7 @@ okp4d tx group update-group-admin [admin] [group-id] [new-admin] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_update-group-members.md
+++ b/docs/command/okp4d_tx_group_update-group-members.md
@@ -10,7 +10,7 @@ okp4d tx group update-group-members [admin] [group-id] [members-json-file] [flag
 
 ```
 
-<appd> tx group update-group-members [admin] [group-id] [members-json-file]
+okp4d tx group update-group-members [admin] [group-id] [members-json-file]
 
 Where members.json contains:
 
@@ -52,7 +52,7 @@ Set a member's weight to "0" to delete it.
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_update-group-metadata.md
+++ b/docs/command/okp4d_tx_group_update-group-metadata.md
@@ -25,7 +25,7 @@ okp4d tx group update-group-metadata [admin] [group-id] [metadata] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_update-group-policy-admin.md
+++ b/docs/command/okp4d_tx_group_update-group-policy-admin.md
@@ -25,7 +25,7 @@ okp4d tx group update-group-policy-admin [admin] [group-policy-account] [new-adm
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_update-group-policy-decision-policy.md
+++ b/docs/command/okp4d_tx_group_update-group-policy-decision-policy.md
@@ -25,7 +25,7 @@ okp4d tx group update-group-policy-decision-policy [admin] [group-policy-account
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_update-group-policy-metadata.md
+++ b/docs/command/okp4d_tx_group_update-group-policy-metadata.md
@@ -25,7 +25,7 @@ okp4d tx group update-group-policy-metadata [admin] [group-policy-account] [new-
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_vote.md
+++ b/docs/command/okp4d_tx_group_vote.md
@@ -42,7 +42,7 @@ okp4d tx group vote [proposal-id] [voter] [vote-option] [metadata] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_withdraw-proposal.md
+++ b/docs/command/okp4d_tx_group_withdraw-proposal.md
@@ -35,7 +35,7 @@ okp4d tx group withdraw-proposal [proposal-id] [group-policy-admin-or-proposer] 
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc-fee_pay-packet-fee.md
+++ b/docs/command/okp4d_tx_ibc-fee_pay-packet-fee.md
@@ -13,7 +13,7 @@ okp4d tx ibc-fee pay-packet-fee [src-port] [src-channel] [sequence] [flags]
 ### Examples
 
 ```
-<appd> tx ibc-fee pay-packet-fee transfer channel-0 1 --recv-fee 10stake --ack-fee 10stake --timeout-fee 10stake
+okp4d tx ibc-fee pay-packet-fee transfer channel-0 1 --recv-fee 10stake --ack-fee 10stake --timeout-fee 10stake
 ```
 
 ### Options
@@ -36,7 +36,7 @@ okp4d tx ibc-fee pay-packet-fee [src-port] [src-channel] [sequence] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc-fee_register-counterparty-payee.md
+++ b/docs/command/okp4d_tx_ibc-fee_register-counterparty-payee.md
@@ -13,7 +13,7 @@ okp4d tx ibc-fee register-counterparty-payee [port-id] [channel-id] [relayer] [c
 ### Examples
 
 ```
-<appd> tx ibc-fee register-counterparty-payee transfer channel-0 cosmos1rsp837a4kvtgp2m4uqzdge0zzu6efqgucm0qdh osmo1v5y0tz01llxzf4c2afml8s3awue0ymju22wxx2
+okp4d tx ibc-fee register-counterparty-payee transfer channel-0 cosmos1rsp837a4kvtgp2m4uqzdge0zzu6efqgucm0qdh osmo1v5y0tz01llxzf4c2afml8s3awue0ymju22wxx2
 ```
 
 ### Options
@@ -35,7 +35,7 @@ okp4d tx ibc-fee register-counterparty-payee [port-id] [channel-id] [relayer] [c
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc-fee_register-payee.md
+++ b/docs/command/okp4d_tx_ibc-fee_register-payee.md
@@ -13,7 +13,7 @@ okp4d tx ibc-fee register-payee [port-id] [channel-id] [relayer] [payee]  [flags
 ### Examples
 
 ```
-<appd> tx ibc-fee register-payee transfer channel-0 cosmos1rsp837a4kvtgp2m4uqzdge0zzu6efqgucm0qdh cosmos153lf4zntqt33a4v0sm5cytrxyqn78q7kz8j8x5
+okp4d tx ibc-fee register-payee transfer channel-0 cosmos1rsp837a4kvtgp2m4uqzdge0zzu6efqgucm0qdh cosmos153lf4zntqt33a4v0sm5cytrxyqn78q7kz8j8x5
 ```
 
 ### Options
@@ -35,7 +35,7 @@ okp4d tx ibc-fee register-payee [port-id] [channel-id] [relayer] [payee]  [flags
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc-transfer_transfer.md
+++ b/docs/command/okp4d_tx_ibc-transfer_transfer.md
@@ -18,7 +18,7 @@ okp4d tx ibc-transfer transfer [src-port] [src-channel] [receiver] [amount] [fla
 ### Examples
 
 ```
-<appd> tx ibc-transfer transfer [src-port] [src-channel] [receiver] [amount]
+okp4d tx ibc-transfer transfer [src-port] [src-channel] [receiver] [amount]
 ```
 
 ### Options
@@ -42,7 +42,7 @@ okp4d tx ibc-transfer transfer [src-port] [src-channel] [receiver] [amount] [fla
       --keyring-dir string              The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                          Use a connected Ledger device
       --memo string                     Memo to be sent along with the packet.
-      --node string                     <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                     &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                     Note to add a description to the transaction (previously --memo)
       --offline                         Offline mode (does not allow any online functionality)
   -o, --output string                   Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc_client_create.md
+++ b/docs/command/okp4d_tx_ibc_client_create.md
@@ -15,7 +15,7 @@ okp4d tx ibc client create [path/to/client_state.json] [path/to/consensus_state.
 ### Examples
 
 ```
-<appd> tx ibc client create [path/to/client_state.json] [path/to/consensus_state.json] --from node0 --home ../node0/<app>cli --chain-id $CID
+okp4d tx ibc client create [path/to/client_state.json] [path/to/consensus_state.json] --from node0 --home ../node0/&lt;app&gt;cli --chain-id $CID
 ```
 
 ### Options
@@ -37,7 +37,7 @@ okp4d tx ibc client create [path/to/client_state.json] [path/to/consensus_state.
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc_client_misbehaviour.md
+++ b/docs/command/okp4d_tx_ibc_client_misbehaviour.md
@@ -13,7 +13,7 @@ okp4d tx ibc client misbehaviour [path/to/misbehaviour.json] [flags]
 ### Examples
 
 ```
-<appd> tx ibc client misbehaviour [path/to/misbehaviour.json] --from node0 --home ../node0/<app>cli --chain-id $CID
+okp4d tx ibc client misbehaviour [path/to/misbehaviour.json] --from node0 --home ../node0/&lt;app&gt;cli --chain-id $CID
 ```
 
 ### Options
@@ -35,7 +35,7 @@ okp4d tx ibc client misbehaviour [path/to/misbehaviour.json] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc_client_update.md
+++ b/docs/command/okp4d_tx_ibc_client_update.md
@@ -13,7 +13,7 @@ okp4d tx ibc client update [client-id] [path/to/header.json] [flags]
 ### Examples
 
 ```
-<appd> tx ibc client update [client-id] [path/to/header.json] --from node0 --home ../node0/<app>cli --chain-id $CID
+okp4d tx ibc client update [client-id] [path/to/header.json] --from node0 --home ../node0/&lt;app&gt;cli --chain-id $CID
 ```
 
 ### Options
@@ -35,7 +35,7 @@ okp4d tx ibc client update [client-id] [path/to/header.json] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc_client_upgrade.md
+++ b/docs/command/okp4d_tx_ibc_client_upgrade.md
@@ -15,7 +15,7 @@ okp4d tx ibc client upgrade [client-identifier] [path/to/client_state.json] [pat
 ### Examples
 
 ```
-<appd> tx ibc client upgrade [client-identifier] [path/to/client_state.json] [path/to/consensus_state.json] [client-state-proof] [consensus-state-proof] --from node0 --home ../node0/<app>cli --chain-id $CID
+okp4d tx ibc client upgrade [client-identifier] [path/to/client_state.json] [path/to/consensus_state.json] [client-state-proof] [consensus-state-proof] --from node0 --home ../node0/&lt;app&gt;cli --chain-id $CID
 ```
 
 ### Options
@@ -37,7 +37,7 @@ okp4d tx ibc client upgrade [client-identifier] [path/to/client_state.json] [pat
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_intertx_register.md
+++ b/docs/command/okp4d_tx_intertx_register.md
@@ -26,7 +26,7 @@ okp4d tx intertx register [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_intertx_submit.md
+++ b/docs/command/okp4d_tx_intertx_submit.md
@@ -26,7 +26,7 @@ okp4d tx intertx submit [path/to/sdk_msg.json] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_multi-sign.md
+++ b/docs/command/okp4d_tx_multi-sign.md
@@ -10,7 +10,7 @@ Read one or more signatures from one or more [signature] file, generate a multis
 multisig key [name], and attach the key name to the transaction read from [file].
 
 Example:
-$ <appd> tx multisign transaction.json k1k2k3 k1sig.json k2sig.json k3sig.json
+$ okp4d tx multisign transaction.json k1k2k3 k1sig.json k2sig.json k3sig.json
 
 If --signature-only flag is on, output a JSON representation
 of only the generated signature.
@@ -47,7 +47,7 @@ okp4d tx multi-sign [file] [name] [[signature]...] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_sign-batch.md
+++ b/docs/command/okp4d_tx_sign-batch.md
@@ -50,7 +50,7 @@ okp4d tx sign-batch [file] ([file2]...) [flags]
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --multisig string          Address or key name of the multisig account on behalf of which the transaction shall be signed
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_sign.md
+++ b/docs/command/okp4d_tx_sign.md
@@ -45,7 +45,7 @@ okp4d tx sign [file] [flags]
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --multisig string          Address or key name of the multisig account on behalf of which the transaction shall be signed
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_slashing_unjail.md
+++ b/docs/command/okp4d_tx_slashing_unjail.md
@@ -6,7 +6,7 @@ unjail validator previously jailed for downtime
 
 unjail a jailed validator:
 
-$ <appd> tx slashing unjail --from mykey
+$ okp4d tx slashing unjail --from mykey
 
 
 ```
@@ -32,7 +32,7 @@ okp4d tx slashing unjail [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_staking_cancel-unbond.md
+++ b/docs/command/okp4d_tx_staking_cancel-unbond.md
@@ -7,7 +7,7 @@ Cancel unbonding delegation and delegate back to the validator
 Cancel Unbonding Delegation and delegate back to the validator.
 
 Example:
-$ <appd> tx staking cancel-unbond okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 100stake 2 --from mykey
+$ okp4d tx staking cancel-unbond okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 100stake 2 --from mykey
 
 ```
 okp4d tx staking cancel-unbond [validator-addr] [amount] [creation-height] [flags]
@@ -16,7 +16,7 @@ okp4d tx staking cancel-unbond [validator-addr] [amount] [creation-height] [flag
 ### Examples
 
 ```
-$ <appd> tx staking cancel-unbond okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 100stake 2 --from mykey
+$ okp4d tx staking cancel-unbond okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 100stake 2 --from mykey
 ```
 
 ### Options
@@ -38,7 +38,7 @@ $ <appd> tx staking cancel-unbond okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmq
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_staking_create-validator.md
+++ b/docs/command/okp4d_tx_staking_create-validator.md
@@ -34,7 +34,7 @@ okp4d tx staking create-validator [flags]
       --ledger                              Use a connected Ledger device
       --min-self-delegation string          The minimum self delegation required on the validator
       --moniker string                      The validator's name
-      --node string                         <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                         &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --node-id string                      The node's ID
       --note string                         Note to add a description to the transaction (previously --memo)
       --offline                             Offline mode (does not allow any online functionality)

--- a/docs/command/okp4d_tx_staking_delegate.md
+++ b/docs/command/okp4d_tx_staking_delegate.md
@@ -7,7 +7,7 @@ Delegate liquid tokens to a validator
 Delegate an amount of liquid coins to a validator from your wallet.
 
 Example:
-$ <appd> tx staking delegate okp4valoper1l2rsakp388kuv9k8qzq6lrm9taddae7fpx59wm 1000stake --from mykey
+$ okp4d tx staking delegate okp4valoper1l2rsakp388kuv9k8qzq6lrm9taddae7fpx59wm 1000stake --from mykey
 
 ```
 okp4d tx staking delegate [validator-addr] [amount] [flags]
@@ -32,7 +32,7 @@ okp4d tx staking delegate [validator-addr] [amount] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_staking_edit-validator.md
+++ b/docs/command/okp4d_tx_staking_edit-validator.md
@@ -30,7 +30,7 @@ okp4d tx staking edit-validator [flags]
       --ledger                       Use a connected Ledger device
       --min-self-delegation string   The minimum self delegation required on the validator
       --new-moniker string           The validator's name (default "[do-not-modify]")
-      --node string                  <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                  &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                  Note to add a description to the transaction (previously --memo)
       --offline                      Offline mode (does not allow any online functionality)
   -o, --output string                Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_staking_redelegate.md
+++ b/docs/command/okp4d_tx_staking_redelegate.md
@@ -7,7 +7,7 @@ Redelegate illiquid tokens from one validator to another
 Redelegate an amount of illiquid staking tokens from one validator to another.
 
 Example:
-$ <appd> tx staking redelegate okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj okp4valoper1l2rsakp388kuv9k8qzq6lrm9taddae7fpx59wm 100stake --from mykey
+$ okp4d tx staking redelegate okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj okp4valoper1l2rsakp388kuv9k8qzq6lrm9taddae7fpx59wm 100stake --from mykey
 
 ```
 okp4d tx staking redelegate [src-validator-addr] [dst-validator-addr] [amount] [flags]
@@ -32,7 +32,7 @@ okp4d tx staking redelegate [src-validator-addr] [dst-validator-addr] [amount] [
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_staking_unbond.md
+++ b/docs/command/okp4d_tx_staking_unbond.md
@@ -7,7 +7,7 @@ Unbond shares from a validator
 Unbond an amount of bonded shares from a validator.
 
 Example:
-$ <appd> tx staking unbond okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 100stake --from mykey
+$ okp4d tx staking unbond okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 100stake --from mykey
 
 ```
 okp4d tx staking unbond [validator-addr] [amount] [flags]
@@ -32,7 +32,7 @@ okp4d tx staking unbond [validator-addr] [amount] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_validate-signatures.md
+++ b/docs/command/okp4d_tx_validate-signatures.md
@@ -37,7 +37,7 @@ okp4d tx validate-signatures [file] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_vesting_create-cliff-vesting-account.md
+++ b/docs/command/okp4d_tx_vesting_create-cliff-vesting-account.md
@@ -33,7 +33,7 @@ okp4d tx vesting create-cliff-vesting-account [to_address] [amount] [cliff_time]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_vesting_create-periodic-vesting-account.md
+++ b/docs/command/okp4d_tx_vesting_create-periodic-vesting-account.md
@@ -45,7 +45,7 @@ okp4d tx vesting create-periodic-vesting-account [to_address] [periods_json_file
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_vesting_create-permanent-locked-account.md
+++ b/docs/command/okp4d_tx_vesting_create-permanent-locked-account.md
@@ -31,7 +31,7 @@ okp4d tx vesting create-permanent-locked-account [to_address] [amount] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_vesting_create-vesting-account.md
+++ b/docs/command/okp4d_tx_vesting_create-vesting-account.md
@@ -34,7 +34,7 @@ okp4d tx vesting create-vesting-account [to_address] [amount] [end_time] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_clear-contract-admin.md
+++ b/docs/command/okp4d_tx_wasm_clear-contract-admin.md
@@ -25,7 +25,7 @@ okp4d tx wasm clear-contract-admin [contract_addr_bech32] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_execute.md
+++ b/docs/command/okp4d_tx_wasm_execute.md
@@ -26,7 +26,7 @@ okp4d tx wasm execute [contract_addr_bech32] [json_encoded_send_args] --amount [
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_instantiate.md
+++ b/docs/command/okp4d_tx_wasm_instantiate.md
@@ -29,7 +29,7 @@ okp4d tx wasm instantiate [code_id_int64] [json_encoded_init_args] --label [text
       --label string             A human-readable name for this contract in lists
       --ledger                   Use a connected Ledger device
       --no-admin                 You must set this explicitly if you don't want an admin
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_migrate.md
+++ b/docs/command/okp4d_tx_wasm_migrate.md
@@ -25,7 +25,7 @@ okp4d tx wasm migrate [contract_addr_bech32] [new_code_id_int64] [json_encoded_m
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_set-contract-admin.md
+++ b/docs/command/okp4d_tx_wasm_set-contract-admin.md
@@ -25,7 +25,7 @@ okp4d tx wasm set-contract-admin [contract_addr_bech32] [new_admin_addr_bech32] 
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_store.md
+++ b/docs/command/okp4d_tx_wasm_store.md
@@ -29,7 +29,7 @@ okp4d tx wasm store [wasm file] [flags]
       --keyring-backend string                Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string                    The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                                Use a connected Ledger device
-      --node string                           <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                           &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                           Note to add a description to the transaction (previously --memo)
       --offline                               Offline mode (does not allow any online functionality)
   -o, --output string                         Output format (text|json) (default "json")


### PR DESCRIPTION
#### 🤕 What's wrong
Docusaurus doesn't build if markdown's files with html tag is not fully good formatted. Since commands documentation is generated from comments, some comments contains string with `<>`. 
For exemple : `<appd> query bank balances`. Docusaurus will not build since it will consider <appd> as a html tag. 
Another exemple: `okp4d tx bank send <granter> <recipient> --from <granter> --chain-id <chain-id> --generate-only`. All var are consider as html tag 🥲.

#### 💡 Solution 

`Sed`, `sed`, `sed` 😁. Ok is not beautiful but it's work ! I've add the sed commands to replace all `<appd>` string by `okp4d`. And another sed command to replace all strings that is between two `<>` with corresponding html code` &gt;` and `&lt;`. Those commands are executed on doc-command generation. 

The documentation has been updated in consequence.

Add in CI the workflow triggering for commands documentation like the proto docs.

#### 🔗 Related PR
Needed by  https://github.com/okp4/docs/pull/161 