### PR TITLE
Add Makefile targets for initializing & starting chain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,32 +72,11 @@ jobs:
 
       - name: Initialize blockchain
         run: |
-          okp4d init okp4-node \
-            --chain-id=okp4-devnet-1 \
-            --home ./target/deployment/devnet
-
-          sed -ie "s/\"stake\"/\"uknow\"/g" target/deployment/devnet/config/genesis.json
-
-          okp4d keys add validator \
-              --home ./target/deployment/devnet \
-              --keyring-backend test
-
-          okp4d add-genesis-account validator 1000000000uknow \
-              --home ./target/deployment/devnet \
-              --keyring-backend test
-
-          okp4d gentx validator 1000000uknow --node-id $(okp4d tendermint show-node-id --home ./target/deployment/devnet) \
-              --chain-id okp4-devnet-1 \
-              --home ./target/deployment/devnet \
-              --keyring-backend test
-
-          okp4d collect-gentxs \
-              --home ./target/deployment/devnet
+          make chain-init
 
       - name: Start the blockchain
         run: |
-          okp4d start --moniker okp4-node \
-            --home ./target/deployment/devnet &
+          make chain-start&
 
       - name: Wait for blockchain to start
         uses: ifaxity/wait-on-action@v1

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@ COLOR_RED    = $(shell tput -Txterm setaf 1)
 COLOR_RESET  = $(shell tput -Txterm sgr0)
 
 # Blockchain constants
-CHAIN      := localnet
-CHAIN_HOME := ./target/deployment/${CHAIN}
+CHAIN         := localnet
+CHAIN_HOME    := ./target/deployment/${CHAIN}
+CHAIN_MONIKER := local-node
 
 BUILD_TAGS += netgo
 BUILD_TAGS := $(strip $(BUILD_TAGS))
@@ -174,8 +175,8 @@ test-go: build ## Pass the test for the go source code
 
 ## Chain:
 chain-init: build ## Initialize the blockchain with default settings.
-	@echo "${COLOR_CYAN} 🛠️ Initializing chain ${COLOR_RESET}${CHAIN}${COLOR_CYAN} under ${COLOR_YELLOW}${CHAIN_HOME}${COLOR_RESET}"; \
-	rm -rf "${CHAIN_HOME}"; \
+	@echo "${COLOR_CYAN} 🛠️ Initializing chain ${COLOR_RESET}${CHAIN}${COLOR_CYAN} under ${COLOR_YELLOW}${CHAIN_HOME}${COLOR_RESET}"
+	@rm -rf "${CHAIN_HOME}"; \
 	okp4d init okp4-node \
 	  --chain-id=okp4-${CHAIN} \
 	  --home "${CHAIN_HOME}"; \
@@ -203,6 +204,11 @@ chain-init: build ## Initialize the blockchain with default settings.
 	\
 	okp4d collect-gentxs \
 	  --home "${CHAIN_HOME}"
+
+chain-start: build ## Start the blockchain with existing configuration (see chain-init)
+	@echo "${COLOR_CYAN} 🛠️ Starting chain ${COLOR_RESET}${CHAIN}${COLOR_CYAN} with configuration ${COLOR_YELLOW}${CHAIN_HOME}${COLOR_RESET}"
+	@okp4d start --moniker ${CHAIN_MONIKER} \
+	  --home ${CHAIN_HOME}
 
 ## Clean:
 clean: ## Remove all the files from the target folder

--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ Targets:
   Test:
     test                Pass all the tests
     test-go             Pass the test for the go source code
+  Chain:
+    chain-init          Initialize the blockchain with default settings.
+    chain-start         Start the blockchain with existing configuration (see chain-init)
   Clean:
     clean               Remove all the files from the target folder
   Proto:


### PR DESCRIPTION
This PR adds the following targets to the makefile:
- `chain-init`: to initialize a chain in a local environment
- `chain-start`: to start the blockchain in a local environment

This is to simplify the testing of the blockchain in a local environment. In addition, the workflow `test` has been updated to support these new targets.