### PR TITLE
Refactor/improve predicate

### DIFF
--- a/x/logic/interpreter/interpreter.go
+++ b/x/logic/interpreter/interpreter.go
@@ -25,7 +25,7 @@ func NewInstrumentedInterpreter(
 	var i prolog.Interpreter
 
 	for _, o := range predicates {
-		if err := Register(ctx, &i, o, inc); err != nil {
+		if err := Register(&i, o, inc); err != nil {
 			return nil, fmt.Errorf("error registering predicate '%s': %w", o, err)
 		}
 	}

--- a/x/logic/predicate/block.go
+++ b/x/logic/predicate/block.go
@@ -7,36 +7,34 @@ import (
 	"github.com/okp4/okp4d/x/logic/util"
 )
 
-// BlockHeight is higher order function that given a context returns the following predicate:
+// BlockHeight is a predicate which unifies the given term with the current block height. The signature is:
 //
 //	block_height(?Height)
 //
 // where Height represents the current chain height at the time of the query.
-// The predicate is non-deterministic, producing a different height each time it is called.
-func BlockHeight(ctx context.Context) func(*engine.VM, engine.Term, engine.Cont, *engine.Env) *engine.Promise {
-	return func(vm *engine.VM, height engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
+func BlockHeight(vm *engine.VM, height engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
+	return engine.Delay(func(ctx context.Context) *engine.Promise {
 		sdkContext, err := util.UnwrapSDKContext(ctx)
 		if err != nil {
 			return engine.Error(err)
 		}
 
 		return engine.Unify(vm, height, engine.Integer(sdkContext.BlockHeight()), cont, env)
-	}
+	})
 }
 
-// BlockTime is higher order function that given a context returns the following predicate:
+// BlockTime is a predicate which unifies the given term with the current block time. The signature is:
 //
 //	block_time(?Time)
 //
 // where Time represents the current chain time at the time of the query.
-// The predicate is non-deterministic, producing a different time each time it is called.
-func BlockTime(ctx context.Context) func(*engine.VM, engine.Term, engine.Cont, *engine.Env) *engine.Promise {
-	return func(vm *engine.VM, time engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
+func BlockTime(vm *engine.VM, time engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
+	return engine.Delay(func(ctx context.Context) *engine.Promise {
 		sdkContext, err := util.UnwrapSDKContext(ctx)
 		if err != nil {
 			return engine.Error(err)
 		}
 
 		return engine.Unify(vm, time, engine.Integer(sdkContext.BlockTime().Unix()), cont, env)
-	}
+	})
 }

--- a/x/logic/predicate/block_test.go
+++ b/x/logic/predicate/block_test.go
@@ -39,8 +39,8 @@ func TestBlock(t *testing.T) {
 
 				convey.Convey("and a vm", func() {
 					vm := testutil.NewVMMust(ctx)
-					vm.Register1(engine.NewAtom("block_height"), BlockHeight(ctx))
-					vm.Register1(engine.NewAtom("block_time"), BlockTime(ctx))
+					vm.Register1(engine.NewAtom("block_height"), BlockHeight)
+					vm.Register1(engine.NewAtom("block_time"), BlockTime)
 					testutil.CompileMust(ctx, vm, fmt.Sprintf("test :- %s.", tc.implication))
 
 					convey.Convey("When the predicate is called", func() {

--- a/x/logic/predicate/chain.go
+++ b/x/logic/predicate/chain.go
@@ -7,19 +7,18 @@ import (
 	"github.com/okp4/okp4d/x/logic/util"
 )
 
-// ChainID is higher order function that given a context returns the following predicate:
+// ChainID is a predicate which unifies the given term with the current chain ID. The signature is:
 //
 //	chain_id(?ChainID)
 //
 // where ChainID represents the current chain ID at the time of the query.
-// The predicate is deterministic, producing the same chain ID each time it is called.
-func ChainID(ctx context.Context) func(*engine.VM, engine.Term, engine.Cont, *engine.Env) *engine.Promise {
-	return func(vm *engine.VM, chainID engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
+func ChainID(vm *engine.VM, chainID engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
+	return engine.Delay(func(ctx context.Context) *engine.Promise {
 		sdkContext, err := util.UnwrapSDKContext(ctx)
 		if err != nil {
 			return engine.Error(err)
 		}
 
 		return engine.Unify(vm, chainID, engine.CharList(sdkContext.ChainID()), cont, env)
-	}
+	})
 }

--- a/x/logic/predicate/chain_test.go
+++ b/x/logic/predicate/chain_test.go
@@ -34,7 +34,7 @@ func TestChainID(t *testing.T) {
 
 				convey.Convey("and a vm", func() {
 					vm := testutil.NewVMMust(ctx)
-					vm.Register1(engine.NewAtom("chain_id"), ChainID(ctx))
+					vm.Register1(engine.NewAtom("chain_id"), ChainID)
 					testutil.CompileMust(ctx, vm, fmt.Sprintf("test :- %s.", tc.implication))
 
 					convey.Convey("When the predicate is called", func() {


### PR DESCRIPTION
Rewrite the predicates so that they no longer use a (ugly) wrapper function and instead directly access the context through the `delay` function, as suggested in https://github.com/ichiban/prolog/issues/280.