### PR TITLE
🏦 Add spendable_coins predicate

### DIFF
--- a/x/logic/interpreter/registry.go
+++ b/x/logic/interpreter/registry.go
@@ -112,6 +112,7 @@ var Registry = map[string]RegistryEntry{
 	"block_height/1":            {predicate.BlockHeight, 1},
 	"block_time/1":              {predicate.BlockTime, 1},
 	"bank_balances/2":           {predicate.BankBalances, 1},
+	"bank_spendable_coins/2":    {predicate.BankSpendableCoins, 1},
 }
 
 // RegistryNames is the list of the predicate names in the Registry.

--- a/x/logic/predicate/bank.go
+++ b/x/logic/predicate/bank.go
@@ -102,7 +102,8 @@ func BankSpendableCoins(vm *engine.VM, account, balances engine.Term, cont engin
 		allBalances := bankKeeper.GetAccountsBalances(sdkContext)
 		promises := make([]func(ctx context.Context) *engine.Promise, 0, len(allBalances))
 		for _, balance := range allBalances {
-			bech32Addr, err = sdk.AccAddressFromBech32(balance.Address)
+			address := balance.Address
+			bech32Addr, err = sdk.AccAddressFromBech32(address)
 			if err != nil {
 				return engine.Error(fmt.Errorf("bank_spendable_coins/2: %w", err))
 			}
@@ -113,7 +114,7 @@ func BankSpendableCoins(vm *engine.VM, account, balances engine.Term, cont engin
 				func(ctx context.Context) *engine.Promise {
 					return engine.Unify(
 						vm,
-						Tuple(engine.NewAtom(bech32Addr.String()), CoinsToTerm(coins)),
+						Tuple(engine.NewAtom(address), CoinsToTerm(coins)),
 						Tuple(account, balances),
 						cont,
 						env,

--- a/x/logic/predicate/bank.go
+++ b/x/logic/predicate/bank.go
@@ -16,7 +16,7 @@ import (
 //
 // where:
 //   - Account represents the account address (in Bech32 format).
-//   - Coins represents the balances of the account as a list of pairs of coin denomination and amount.
+//   - Balances represents the balances of the account as a list of pairs of coin denomination and amount.
 //
 // Example:
 //
@@ -80,7 +80,7 @@ func BankBalances(vm *engine.VM, account, balances engine.Term, cont engine.Cont
 //
 // where:
 //   - Account represents the account address (in Bech32 format).
-//   - Coins represents the spendable coins of the account as a list of pairs of coin denomination and amount.
+//   - Balances represents the spendable coins of the account as a list of pairs of coin denomination and amount.
 //
 // Example:
 //

--- a/x/logic/predicate/bank.go
+++ b/x/logic/predicate/bank.go
@@ -74,6 +74,24 @@ func BankBalances(vm *engine.VM, account, balances engine.Term, cont engine.Cont
 	})
 }
 
+// BankSpendableCoins is a predicate which unifies the given terms with the list of spendable coins of the given account.
+//
+//	bank_spendable_coins(?Account, ?Balances)
+//
+// where:
+//   - Account represents the account address (in Bech32 format).
+//   - Coins represents the spendable coins of the account as a list of pairs of coin denomination and amount.
+//
+// Example:
+//
+//	# Query the spendable coins of the account.
+//	- bank_spendable_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', X).
+//
+// # Query the spendable coins of all accounts. The result is a list of pairs of account address and balances.
+// - bank_spendable_coins(X, Y).
+//
+// # Query the first spendable coin of the given account by unifying the denomination and amount with the given terms.
+// - bank_spendable_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A), _]).
 func BankSpendableCoins(vm *engine.VM, account, balances engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
 	return engine.Delay(func(ctx context.Context) *engine.Promise {
 		sdkContext, err := util.UnwrapSDKContext(ctx)

--- a/x/logic/predicate/bank_test.go
+++ b/x/logic/predicate/bank_test.go
@@ -1,3 +1,4 @@
+//nolint:gocognit
 package predicate
 
 import (
@@ -229,7 +230,8 @@ func TestBank(t *testing.T) {
 						),
 					},
 				},
-				program:    `bank_spendable_has_sufficient_coin(A, C, S) :- bank_spendable_coins(A, R), member(C, R), -(_, V) = C, compare(>, V, S).`,
+				program: `bank_spendable_has_sufficient_coin(A, C, S) :- bank_spendable_coins(A, R), member(C, R),
+-(_, V) = C, compare(>, V, S).`,
 				query:      `bank_spendable_has_sufficient_coin('okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38', C, 600).`,
 				wantResult: []types.TermResults{{"C": "uakt-4099"}, {"C": "uatom-693"}, {"C": "uband-4282"}, {"C": "ukava-836"}},
 			},

--- a/x/logic/predicate/util.go
+++ b/x/logic/predicate/util.go
@@ -8,14 +8,24 @@ import (
 	"github.com/okp4/okp4d/x/logic/types"
 )
 
-// BalancesSorted returns the list of balances for the given address, sorted by coin denomination.
-func BalancesSorted(sdkContext sdk.Context, bankKeeper types.BankKeeper, bech32Addr sdk.AccAddress) sdk.Coins {
-	fetchedBalances := bankKeeper.GetAllBalances(sdkContext, bech32Addr)
-	sort.SliceStable(fetchedBalances, func(i, j int) bool {
-		return fetchedBalances[i].Denom < fetchedBalances[j].Denom
+// BalancesSorted returns given balances sorted by coin denomination.
+func BalancesSorted(balances sdk.Coins) sdk.Coins {
+	sort.SliceStable(balances, func(i, j int) bool {
+		return balances[i].Denom < balances[j].Denom
 	})
+	return balances
+}
 
-	return fetchedBalances
+// AllBalancesSorted returns the list of balances for the given address, sorted by coin denomination.
+func AllBalancesSorted(sdkContext sdk.Context, bankKeeper types.BankKeeper, bech32Addr sdk.AccAddress) sdk.Coins {
+	fetchedBalances := bankKeeper.GetAllBalances(sdkContext, bech32Addr)
+	return BalancesSorted(fetchedBalances)
+}
+
+// SpendableCoinsSorted returns the list of spendable coins for the given address, sorted by coin denomination.
+func SpendableCoinsSorted(sdkContext sdk.Context, bankKeeper types.BankKeeper, bech32Addr sdk.AccAddress) sdk.Coins {
+	fetchedBalances := bankKeeper.SpendableCoins(sdkContext, bech32Addr)
+	return BalancesSorted(fetchedBalances)
 }
 
 // CoinsToTerm converts the given coins to a term of the form:

--- a/x/logic/predicate/util.go
+++ b/x/logic/predicate/util.go
@@ -8,24 +8,25 @@ import (
 	"github.com/okp4/okp4d/x/logic/types"
 )
 
-// BalancesSorted returns given balances sorted by coin denomination.
-func BalancesSorted(balances sdk.Coins) sdk.Coins {
+// SortBalances by coin denomination.
+func SortBalances(balances sdk.Coins) {
 	sort.SliceStable(balances, func(i, j int) bool {
 		return balances[i].Denom < balances[j].Denom
 	})
-	return balances
 }
 
 // AllBalancesSorted returns the list of balances for the given address, sorted by coin denomination.
 func AllBalancesSorted(sdkContext sdk.Context, bankKeeper types.BankKeeper, bech32Addr sdk.AccAddress) sdk.Coins {
 	fetchedBalances := bankKeeper.GetAllBalances(sdkContext, bech32Addr)
-	return BalancesSorted(fetchedBalances)
+	SortBalances(fetchedBalances)
+	return fetchedBalances
 }
 
 // SpendableCoinsSorted returns the list of spendable coins for the given address, sorted by coin denomination.
 func SpendableCoinsSorted(sdkContext sdk.Context, bankKeeper types.BankKeeper, bech32Addr sdk.AccAddress) sdk.Coins {
 	fetchedBalances := bankKeeper.SpendableCoins(sdkContext, bech32Addr)
-	return BalancesSorted(fetchedBalances)
+	SortBalances(fetchedBalances)
+	return fetchedBalances
 }
 
 // CoinsToTerm converts the given coins to a term of the form:


### PR DESCRIPTION
#### 📝 Description 

In continuity of https://github.com/okp4/okp4d/pull/261, this PR implement the `bank_spendable_coins/2` predicate following #264 issue.

#### ⚙️ Behavior (from #264)

```prolog
bank_spendable_coins(?Account, ?Balances)
```

Where:

- `Account` represents the account address (in Bech32 format).
- `Balances` represents the balances of the account as a list of pairs of coin denomination and amount which are spendable (i.e. not locked).


#### 👉 Example 

```bash
$ okp4d query logic ask "bank_spendable_coins(X, Y)." --output json | jq
{                                                                                                                                                   
  "height": "8042",
  "gas_used": "14750",
  "answer": {
    "success": true,
    "has_more": true,
    "variables": [
      "X",
      "Y"
    ],
    "results": [
      {
        "substitutions": [
          {
            "variable": "X",
            "term": {
              "name": "okp41jv65s3grqf6v6jl3dp4t6c9t9rk99cd82rp54y",
              "arguments": []
            }
          },
          {
            "variable": "Y",
            "term": {
              "name": "[uknow-999000000]",
              "arguments": []
            }
          }
        ]
      }
    ]
  }
}
```

#### ✅ Acceptance Criteria

- [x] The predicate is implemented according to the described behavior and examples
- [x] The predicate passes all test cases
- [x] Any related documentation is updated

Closes #264 