### PR TITLE
🏦 Feat: add bank_locked_coins predicate

### DIFF
--- a/x/logic/interpreter/registry.go
+++ b/x/logic/interpreter/registry.go
@@ -113,6 +113,7 @@ var Registry = map[string]RegistryEntry{
 	"block_time/1":              {predicate.BlockTime, 1},
 	"bank_balances/2":           {predicate.BankBalances, 1},
 	"bank_spendable_coins/2":    {predicate.BankSpendableCoins, 1},
+	"bank_locked_coins/2":       {predicate.BankLockedCoins, 1},
 }
 
 // RegistryNames is the list of the predicate names in the Registry.

--- a/x/logic/predicate/bank.go
+++ b/x/logic/predicate/bank.go
@@ -29,9 +29,15 @@ import (
 // # Query the first balance of the given account by unifying the denomination and amount with the given terms.
 // - bank_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A), _]).
 func BankBalances(vm *engine.VM, account, balances engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
-	return fetchBalances("bank_balances/2", account, balances, vm, env, cont, func(ctx sdk.Context, bankKeeper types.BankKeeper, address sdk.AccAddress) sdk.Coins {
-		return AllBalancesSorted(ctx, bankKeeper, address)
-	})
+	return fetchBalances("bank_balances/2",
+		account,
+		balances,
+		vm,
+		env,
+		cont,
+		func(ctx sdk.Context, bankKeeper types.BankKeeper, address sdk.AccAddress) sdk.Coins {
+			return AllBalancesSorted(ctx, bankKeeper, address)
+		})
 }
 
 // BankSpendableCoins is a predicate which unifies the given terms with the list of spendable coins of the given account.
@@ -53,15 +59,45 @@ func BankBalances(vm *engine.VM, account, balances engine.Term, cont engine.Cont
 // # Query the first spendable coin of the given account by unifying the denomination and amount with the given terms.
 // - bank_spendable_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A), _]).
 func BankSpendableCoins(vm *engine.VM, account, balances engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
-	return fetchBalances("bank_spendable_coins/2", account, balances, vm, env, cont, func(ctx sdk.Context, bankKeeper types.BankKeeper, address sdk.AccAddress) sdk.Coins {
-		return SpendableCoinsSorted(ctx, bankKeeper, address)
-	})
+	return fetchBalances("bank_spendable_coins/2",
+		account,
+		balances,
+		vm,
+		env,
+		cont,
+		func(ctx sdk.Context, bankKeeper types.BankKeeper, address sdk.AccAddress) sdk.Coins {
+			return SpendableCoinsSorted(ctx, bankKeeper, address)
+		})
 }
 
+// BankLockedCoins is a predicate which unifies the given terms with the list of locked coins of the given account.
+//
+//	bank_locked_coins(?Account, ?Balances)
+//
+// where:
+//   - Account represents the account address (in Bech32 format).
+//   - Balances represents the locked coins of the account as a list of pairs of coin denomination and amount.
+//
+// Example:
+//
+//	# Query the locked coins of the account.
+//	- bank_locked_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', X).
+//
+// # Query the locked coins of all accounts. The result is a list of pairs of account address and balances.
+// - bank_locked_coins(X, Y).
+//
+// # Query the first locked coin of the given account by unifying the denomination and amount with the given terms.
+// - bank_locked_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A), _]).
 func BankLockedCoins(vm *engine.VM, account, balances engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
-	return fetchBalances("bank_locked_coins/2", account, balances, vm, env, cont, func(ctx sdk.Context, bankKeeper types.BankKeeper, address sdk.AccAddress) sdk.Coins {
-		return LockedCoinsSorted(ctx, bankKeeper, address)
-	})
+	return fetchBalances("bank_locked_coins/2",
+		account,
+		balances,
+		vm,
+		env,
+		cont,
+		func(ctx sdk.Context, bankKeeper types.BankKeeper, address sdk.AccAddress) sdk.Coins {
+			return LockedCoinsSorted(ctx, bankKeeper, address)
+		})
 }
 
 func getBech32(env *engine.Env, account engine.Term) (sdk.AccAddress, error) {

--- a/x/logic/predicate/bank_test.go
+++ b/x/logic/predicate/bank_test.go
@@ -26,6 +26,7 @@ func TestBank(t *testing.T) {
 		cases := []struct {
 			balances       []bank.Balance
 			spendableCoins []bank.Balance
+			lockedCoins    []bank.Balance
 			program        string
 			query          string
 			wantResult     []types.TermResults
@@ -268,6 +269,150 @@ func TestBank(t *testing.T) {
 				wantResult:     []types.TermResults{{"X": "[uknow-100]"}},
 				wantError:      fmt.Errorf("bank_spendable_coins/2: decoding bech32 failed: invalid bech32 string length 3"),
 			},
+
+			{
+				balances: []bank.Balance{
+					{
+						Address: "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(1000))),
+					},
+				},
+				spendableCoins: []bank.Balance{
+					{
+						Address: "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(100))),
+					},
+				},
+				lockedCoins: []bank.Balance{
+					{
+						Address: "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(900))),
+					},
+				},
+				query:      `bank_locked_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', X).`,
+				wantResult: []types.TermResults{{"X": "[uknow-900]"}},
+			},
+			{
+				lockedCoins: []bank.Balance{
+					{
+						Address: "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(100))),
+					},
+				},
+				query:      `bank_locked_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [X]).`,
+				wantResult: []types.TermResults{{"X": "uatom-100"}},
+			},
+			{
+				lockedCoins: []bank.Balance{
+					{
+						Address: "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(420)), sdk.NewCoin("uatom", sdk.NewInt(589))),
+					},
+				},
+				query:      `bank_locked_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [X, Y]).`,
+				wantResult: []types.TermResults{{"X": "uatom-589", "Y": "uknow-420"}},
+			},
+			{
+				lockedCoins: []bank.Balance{
+					{
+						Address: "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(420)), sdk.NewCoin("uatom", sdk.NewInt(589))),
+					},
+				},
+				query:      `bank_locked_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A) | _]).`,
+				wantResult: []types.TermResults{{"D": "uatom", "A": "589"}},
+			},
+			{
+				lockedCoins: []bank.Balance{
+					{
+						Address: "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(420)), sdk.NewCoin("uatom", sdk.NewInt(493))),
+					},
+					{
+						Address: "okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(589)), sdk.NewCoin("uatom", sdk.NewInt(693))),
+					},
+				},
+				query:      `bank_locked_coins('okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38', [_, X]).`,
+				wantResult: []types.TermResults{{"X": "uknow-589"}},
+			},
+			{
+				lockedCoins: []bank.Balance{
+					{
+						Address: "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(420)), sdk.NewCoin("uatom", sdk.NewInt(493))),
+					},
+					{
+						Address: "okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(589)), sdk.NewCoin("uatom", sdk.NewInt(693))),
+					},
+				},
+				program:    `bank_locked_has_coin(A, D, V) :- bank_locked_coins(A, R), member(D-V, R).`,
+				query:      `bank_locked_has_coin('okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38', 'uknow', V).`,
+				wantResult: []types.TermResults{{"V": "589"}},
+			},
+			{
+				lockedCoins: []bank.Balance{
+					{
+						Address: "okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38",
+						Coins: sdk.NewCoins(
+							sdk.NewCoin("uknow", sdk.NewInt(589)),
+							sdk.NewCoin("uatom", sdk.NewInt(693)),
+							sdk.NewCoin("uband", sdk.NewInt(4282)),
+							sdk.NewCoin("uakt", sdk.NewInt(4099)),
+							sdk.NewCoin("ukava", sdk.NewInt(836)),
+							sdk.NewCoin("uscrt", sdk.NewInt(599)),
+						),
+					},
+				},
+				program: `bank_locked_has_sufficient_coin(A, C, S) :- bank_locked_coins(A, R), member(C, R),
+-(_, V) = C, compare(>, V, S).`,
+				query:      `bank_locked_has_sufficient_coin('okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38', C, 600).`,
+				wantResult: []types.TermResults{{"C": "uakt-4099"}, {"C": "uatom-693"}, {"C": "uband-4282"}, {"C": "ukava-836"}},
+			},
+			{
+				balances: []bank.Balance{
+					{
+						Address: "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(1220))),
+					},
+					{
+						Address: "okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(8000))),
+					},
+				},
+				spendableCoins: []bank.Balance{
+					{
+						Address: "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(420))),
+					},
+					{
+						Address: "okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(589))),
+					},
+				},
+				lockedCoins: []bank.Balance{
+					{
+						Address: "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(800))),
+					},
+					{
+						Address: "okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38",
+						Coins:   sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(7411))),
+					},
+				},
+				query: `bank_locked_coins(Accounts, SpendableCoins).`,
+				wantResult: []types.TermResults{
+					{"Accounts": "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm", "SpendableCoins": "[uknow-420]"},
+					{"Accounts": "okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38", "SpendableCoins": "[uatom-589]"},
+				},
+			},
+			{
+				lockedCoins: []bank.Balance{},
+				query:       `bank_locked_coins('foo', X).`,
+				wantResult:  []types.TermResults{{"X": "[uknow-100]"}},
+				wantError:   fmt.Errorf("bank_locked_coins/2: decoding bech32 failed: invalid bech32 string length 3"),
+			},
 		}
 		for nc, tc := range cases {
 			Convey(fmt.Sprintf("Given the query #%d: %s", nc, tc.query), func() {
@@ -292,6 +437,13 @@ func TestBank(t *testing.T) {
 							bankKeeper.
 								EXPECT().
 								SpendableCoins(ctx, sdk.MustAccAddressFromBech32(balance.Address)).
+								AnyTimes().
+								Return(balance.Coins)
+						}
+						for _, balance := range tc.lockedCoins {
+							bankKeeper.
+								EXPECT().
+								LockedCoins(ctx, sdk.MustAccAddressFromBech32(balance.Address)).
 								AnyTimes().
 								Return(balance.Coins)
 						}

--- a/x/logic/predicate/bank_test.go
+++ b/x/logic/predicate/bank_test.go
@@ -401,10 +401,10 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(7411))),
 					},
 				},
-				query: `bank_locked_coins(Accounts, SpendableCoins).`,
+				query: `bank_locked_coins(Accounts, LockedCoins).`,
 				wantResult: []types.TermResults{
-					{"Accounts": "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm", "SpendableCoins": "[uknow-420]"},
-					{"Accounts": "okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38", "SpendableCoins": "[uatom-589]"},
+					{"Accounts": "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm", "LockedCoins": "[uknow-800]"},
+					{"Accounts": "okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38", "LockedCoins": "[uatom-7411]"},
 				},
 			},
 			{
@@ -457,6 +457,7 @@ func TestBank(t *testing.T) {
 							interpreter := testutil.NewInterpreterMust(ctx)
 							interpreter.Register2(engine.NewAtom("bank_balances"), BankBalances)
 							interpreter.Register2(engine.NewAtom("bank_spendable_coins"), BankSpendableCoins)
+							interpreter.Register2(engine.NewAtom("bank_locked_coins"), BankLockedCoins)
 
 							err := interpreter.Compile(ctx, tc.program)
 							So(err, ShouldBeNil)

--- a/x/logic/predicate/util.go
+++ b/x/logic/predicate/util.go
@@ -32,7 +32,8 @@ func SpendableCoinsSorted(sdkContext sdk.Context, bankKeeper types.BankKeeper, b
 // LockedCoinsSorted returns the list of spendable coins for the given address, sorted by coin denomination.
 func LockedCoinsSorted(sdkContext sdk.Context, bankKeeper types.BankKeeper, bech32Addr sdk.AccAddress) sdk.Coins {
 	fetchedBalances := bankKeeper.LockedCoins(sdkContext, bech32Addr)
-	return BalancesSorted(fetchedBalances)
+	SortBalances(fetchedBalances)
+	return fetchedBalances
 }
 
 // CoinsToTerm converts the given coins to a term of the form:

--- a/x/logic/predicate/util.go
+++ b/x/logic/predicate/util.go
@@ -29,6 +29,12 @@ func SpendableCoinsSorted(sdkContext sdk.Context, bankKeeper types.BankKeeper, b
 	return fetchedBalances
 }
 
+// LockedCoinsSorted returns the list of spendable coins for the given address, sorted by coin denomination.
+func LockedCoinsSorted(sdkContext sdk.Context, bankKeeper types.BankKeeper, bech32Addr sdk.AccAddress) sdk.Coins {
+	fetchedBalances := bankKeeper.LockedCoins(sdkContext, bech32Addr)
+	return BalancesSorted(fetchedBalances)
+}
+
 // CoinsToTerm converts the given coins to a term of the form:
 //
 //	[-(Denom, Amount), -(Denom, Amount), ...]

--- a/x/logic/testutil/expected_keepers_mocks.go
+++ b/x/logic/testutil/expected_keepers_mocks.go
@@ -132,7 +132,7 @@ func (mr *MockBankKeeperMockRecorder) SpendableCoins(ctx, addr interface{}) *gom
 // LockedCoins mocks base method.
 func (m *MockBankKeeper) LockedCoins(ctx types.Context, addr types.AccAddress) types.Coins {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SpendableCoins", ctx, addr)
+	ret := m.ctrl.Call(m, "LockedCoins", ctx, addr)
 	ret0, _ := ret[0].(types.Coins)
 	return ret0
 }

--- a/x/logic/testutil/expected_keepers_mocks.go
+++ b/x/logic/testutil/expected_keepers_mocks.go
@@ -128,3 +128,17 @@ func (mr *MockBankKeeperMockRecorder) SpendableCoins(ctx, addr interface{}) *gom
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpendableCoins", reflect.TypeOf((*MockBankKeeper)(nil).SpendableCoins), ctx, addr)
 }
+
+// LockedCoins mocks base method.
+func (m *MockBankKeeper) LockedCoins(ctx types.Context, addr types.AccAddress) types.Coins {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SpendableCoins", ctx, addr)
+	ret0, _ := ret[0].(types.Coins)
+	return ret0
+}
+
+// LockedCoins indicates an expected call of LockedCoins.
+func (mr *MockBankKeeperMockRecorder) LockedCoins(ctx, addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LockedCoins", reflect.TypeOf((*MockBankKeeper)(nil).LockedCoins), ctx, addr)
+}

--- a/x/logic/types/expected_keepers.go
+++ b/x/logic/types/expected_keepers.go
@@ -17,4 +17,5 @@ type BankKeeper interface {
 	GetAllBalances(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 	GetAccountsBalances(ctx sdk.Context) []bank.Balance
 	SpendableCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+	LockedCoins(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
 }


### PR DESCRIPTION
#### 📝 Description 

In continuity of https://github.com/okp4/okp4d/pull/261, this PR implement the `bank_locked_coins/2` predicate following #263 issue.

#### ⚙️ Behavior (from #263)

```prolog
bank_locked_coins(?Account, ?Balances)
```

Where:

- `Account` represents the account address (in Bech32 format).
- `Balances` represents the balances of the account as a list of pairs of coin denomination and amount which are locked (i.e. not spendable).


#### 👉 Example 

```bash
$ okp4d query logic ask "bank_locked_coins(X, Y)." --output json | jq
{                                                                                                                                                   
  "height": "8042",
  "gas_used": "14750",
  "answer": {
    "success": true,
    "has_more": true,
    "variables": [
      "X",
      "Y"
    ],
    "results": [
      {
        "substitutions": [
          {
            "variable": "X",
            "term": {
              "name": "okp41jv65s3grqf6v6jl3dp4t6c9t9rk99cd82rp54y",
              "arguments": []
            }
          },
          {
            "variable": "Y",
            "term": {
              "name": "[uknow-999000000]",
              "arguments": []
            }
          }
        ]
      }
    ]
  }
}
```

#### ✅ Acceptance Criteria

- [x] The predicate is implemented according to the described behavior and examples
- [x] The predicate passes all test cases
- [x] Any related documentation is updated

#### ⚠️ Note

Based on @amimart [proposition](https://github.com/okp4/okp4d/pull/266#discussion_r1080974073), discussion was acted to rename `bank_spendable_coins` and `bank_locked_coins` to `bank_spandable_balances` and `bank_locked_balances` to be aligned to the public grpc API. **This is not a part of this PR, a [next PR](https://github.com/okp4/okp4d/pull/268) will be immediately create to do this modification :)** 

Closes #263 