### PR TITLE
✏️ Refactor: rename bank predicate

### DIFF
--- a/x/logic/interpreter/registry.go
+++ b/x/logic/interpreter/registry.go
@@ -113,7 +113,7 @@ var Registry = map[string]RegistryEntry{
 	"block_time/1":              {predicate.BlockTime, 1},
 	"bank_balances/2":           {predicate.BankBalances, 1},
 	"bank_spendable_balances/2": {predicate.BankSpendableBalances, 1},
-	"bank_locked_coins/2":       {predicate.BankLockedCoins, 1},
+	"bank_locked_balances/2":    {predicate.BankLockedBalances, 1},
 }
 
 // RegistryNames is the list of the predicate names in the Registry.

--- a/x/logic/interpreter/registry.go
+++ b/x/logic/interpreter/registry.go
@@ -112,7 +112,7 @@ var Registry = map[string]RegistryEntry{
 	"block_height/1":            {predicate.BlockHeight, 1},
 	"block_time/1":              {predicate.BlockTime, 1},
 	"bank_balances/2":           {predicate.BankBalances, 1},
-	"bank_spendable_coins/2":    {predicate.BankSpendableCoins, 1},
+	"bank_spendable_balances/2": {predicate.BankSpendableBalances, 1},
 	"bank_locked_coins/2":       {predicate.BankLockedCoins, 1},
 }
 

--- a/x/logic/predicate/bank.go
+++ b/x/logic/predicate/bank.go
@@ -43,26 +43,26 @@ func BankBalances(vm *engine.VM, account, balances engine.Term, cont engine.Cont
 		})
 }
 
-// BankSpendableCoins is a predicate which unifies the given terms with the list of spendable coins of the given account.
+// BankSpendableBalances is a predicate which unifies the given terms with the list of spendable coins of the given account.
 //
-//	bank_spendable_coins(?Account, ?Balances)
+//	bank_spendable_balances(?Account, ?Balances)
 //
 // where:
 //   - Account represents the account address (in Bech32 format).
-//   - Balances represents the spendable coins of the account as a list of pairs of coin denomination and amount.
+//   - Balances represents the spendable balances of the account as a list of pairs of coin denomination and amount.
 //
 // Example:
 //
-//	# Query the spendable coins of the account.
-//	- bank_spendable_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', X).
+//	# Query the spendable balances of the account.
+//	- bank_spendable_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', X).
 //
-// # Query the spendable coins of all accounts. The result is a list of pairs of account address and balances.
-// - bank_spendable_coins(X, Y).
+// # Query the spendable balances of all accounts. The result is a list of pairs of account address and balances.
+// - bank_spendable_balances(X, Y).
 //
-// # Query the first spendable coin of the given account by unifying the denomination and amount with the given terms.
-// - bank_spendable_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A), _]).
-func BankSpendableCoins(vm *engine.VM, account, balances engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
-	return fetchBalances("bank_spendable_coins/2",
+// # Query the first spendable balances of the given account by unifying the denomination and amount with the given terms.
+// - bank_spendable_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A), _]).
+func BankSpendableBalances(vm *engine.VM, account, balances engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
+	return fetchBalances("bank_spendable_balances/2",
 		account,
 		balances,
 		vm,

--- a/x/logic/predicate/bank.go
+++ b/x/logic/predicate/bank.go
@@ -73,26 +73,26 @@ func BankSpendableBalances(vm *engine.VM, account, balances engine.Term, cont en
 		})
 }
 
-// BankLockedCoins is a predicate which unifies the given terms with the list of locked coins of the given account.
+// BankLockedBalances is a predicate which unifies the given terms with the list of locked coins of the given account.
 //
-//	bank_locked_coins(?Account, ?Balances)
+//	bank_locked_balances(?Account, ?Balances)
 //
 // where:
 //   - Account represents the account address (in Bech32 format).
-//   - Balances represents the locked coins of the account as a list of pairs of coin denomination and amount.
+//   - Balances represents the locked balances of the account as a list of pairs of coin denomination and amount.
 //
 // Example:
 //
 //	# Query the locked coins of the account.
-//	- bank_locked_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', X).
+//	- bank_locked_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', X).
 //
-// # Query the locked coins of all accounts. The result is a list of pairs of account address and balances.
-// - bank_locked_coins(X, Y).
+// # Query the locked balances of all accounts. The result is a list of pairs of account address and balances.
+// - bank_locked_balances(X, Y).
 //
-// # Query the first locked coin of the given account by unifying the denomination and amount with the given terms.
-// - bank_locked_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A), _]).
-func BankLockedCoins(vm *engine.VM, account, balances engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
-	return fetchBalances("bank_locked_coins/2",
+// # Query the first locked balances of the given account by unifying the denomination and amount with the given terms.
+// - bank_locked_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A), _]).
+func BankLockedBalances(vm *engine.VM, account, balances engine.Term, cont engine.Cont, env *engine.Env) *engine.Promise {
+	return fetchBalances("bank_locked_balances/2",
 		account,
 		balances,
 		vm,

--- a/x/logic/predicate/bank_test.go
+++ b/x/logic/predicate/bank_test.go
@@ -289,7 +289,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(900))),
 					},
 				},
-				query:      `bank_locked_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', X).`,
+				query:      `bank_locked_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', X).`,
 				wantResult: []types.TermResults{{"X": "[uknow-900]"}},
 			},
 			{
@@ -299,7 +299,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(100))),
 					},
 				},
-				query:      `bank_locked_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [X]).`,
+				query:      `bank_locked_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [X]).`,
 				wantResult: []types.TermResults{{"X": "uatom-100"}},
 			},
 			{
@@ -309,7 +309,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(420)), sdk.NewCoin("uatom", sdk.NewInt(589))),
 					},
 				},
-				query:      `bank_locked_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [X, Y]).`,
+				query:      `bank_locked_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [X, Y]).`,
 				wantResult: []types.TermResults{{"X": "uatom-589", "Y": "uknow-420"}},
 			},
 			{
@@ -319,7 +319,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(420)), sdk.NewCoin("uatom", sdk.NewInt(589))),
 					},
 				},
-				query:      `bank_locked_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A) | _]).`,
+				query:      `bank_locked_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A) | _]).`,
 				wantResult: []types.TermResults{{"D": "uatom", "A": "589"}},
 			},
 			{
@@ -333,7 +333,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(589)), sdk.NewCoin("uatom", sdk.NewInt(693))),
 					},
 				},
-				query:      `bank_locked_coins('okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38', [_, X]).`,
+				query:      `bank_locked_balances('okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38', [_, X]).`,
 				wantResult: []types.TermResults{{"X": "uknow-589"}},
 			},
 			{
@@ -347,7 +347,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(589)), sdk.NewCoin("uatom", sdk.NewInt(693))),
 					},
 				},
-				program:    `bank_locked_has_coin(A, D, V) :- bank_locked_coins(A, R), member(D-V, R).`,
+				program:    `bank_locked_has_coin(A, D, V) :- bank_locked_balances(A, R), member(D-V, R).`,
 				query:      `bank_locked_has_coin('okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38', 'uknow', V).`,
 				wantResult: []types.TermResults{{"V": "589"}},
 			},
@@ -365,7 +365,7 @@ func TestBank(t *testing.T) {
 						),
 					},
 				},
-				program: `bank_locked_has_sufficient_coin(A, C, S) :- bank_locked_coins(A, R), member(C, R),
+				program: `bank_locked_has_sufficient_coin(A, C, S) :- bank_locked_balances(A, R), member(C, R),
 -(_, V) = C, compare(>, V, S).`,
 				query:      `bank_locked_has_sufficient_coin('okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38', C, 600).`,
 				wantResult: []types.TermResults{{"C": "uakt-4099"}, {"C": "uatom-693"}, {"C": "uband-4282"}, {"C": "ukava-836"}},
@@ -401,7 +401,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(7411))),
 					},
 				},
-				query: `bank_locked_coins(Accounts, LockedCoins).`,
+				query: `bank_locked_balances(Accounts, LockedCoins).`,
 				wantResult: []types.TermResults{
 					{"Accounts": "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm", "LockedCoins": "[uknow-800]"},
 					{"Accounts": "okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38", "LockedCoins": "[uatom-7411]"},
@@ -409,9 +409,9 @@ func TestBank(t *testing.T) {
 			},
 			{
 				lockedCoins: []bank.Balance{},
-				query:       `bank_locked_coins('foo', X).`,
+				query:       `bank_locked_balances('foo', X).`,
 				wantResult:  []types.TermResults{{"X": "[uknow-100]"}},
-				wantError:   fmt.Errorf("bank_locked_coins/2: decoding bech32 failed: invalid bech32 string length 3"),
+				wantError:   fmt.Errorf("bank_locked_balances/2: decoding bech32 failed: invalid bech32 string length 3"),
 			},
 		}
 		for nc, tc := range cases {
@@ -457,7 +457,7 @@ func TestBank(t *testing.T) {
 							interpreter := testutil.NewInterpreterMust(ctx)
 							interpreter.Register2(engine.NewAtom("bank_balances"), BankBalances)
 							interpreter.Register2(engine.NewAtom("bank_spendable_balances"), BankSpendableBalances)
-							interpreter.Register2(engine.NewAtom("bank_locked_coins"), BankLockedCoins)
+							interpreter.Register2(engine.NewAtom("bank_locked_balances"), BankLockedBalances)
 
 							err := interpreter.Compile(ctx, tc.program)
 							So(err, ShouldBeNil)

--- a/x/logic/predicate/bank_test.go
+++ b/x/logic/predicate/bank_test.go
@@ -155,7 +155,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(100))),
 					},
 				},
-				query:      `bank_spendable_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', X).`,
+				query:      `bank_spendable_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', X).`,
 				wantResult: []types.TermResults{{"X": "[uknow-100]"}},
 			},
 			{
@@ -165,7 +165,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(100))),
 					},
 				},
-				query:      `bank_spendable_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [X]).`,
+				query:      `bank_spendable_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [X]).`,
 				wantResult: []types.TermResults{{"X": "uatom-100"}},
 			},
 			{
@@ -175,7 +175,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(420)), sdk.NewCoin("uatom", sdk.NewInt(589))),
 					},
 				},
-				query:      `bank_spendable_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [X, Y]).`,
+				query:      `bank_spendable_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [X, Y]).`,
 				wantResult: []types.TermResults{{"X": "uatom-589", "Y": "uknow-420"}},
 			},
 			{
@@ -185,7 +185,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(420)), sdk.NewCoin("uatom", sdk.NewInt(589))),
 					},
 				},
-				query:      `bank_spendable_coins('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A) | _]).`,
+				query:      `bank_spendable_balances('okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm', [-(D, A) | _]).`,
 				wantResult: []types.TermResults{{"D": "uatom", "A": "589"}},
 			},
 			{
@@ -199,7 +199,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(589)), sdk.NewCoin("uatom", sdk.NewInt(693))),
 					},
 				},
-				query:      `bank_spendable_coins('okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38', [_, X]).`,
+				query:      `bank_spendable_balances('okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38', [_, X]).`,
 				wantResult: []types.TermResults{{"X": "uknow-589"}},
 			},
 			{
@@ -213,7 +213,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uknow", sdk.NewInt(589)), sdk.NewCoin("uatom", sdk.NewInt(693))),
 					},
 				},
-				program:    `bank_spendable_has_coin(A, D, V) :- bank_spendable_coins(A, R), member(D-V, R).`,
+				program:    `bank_spendable_has_coin(A, D, V) :- bank_spendable_balances(A, R), member(D-V, R).`,
 				query:      `bank_spendable_has_coin('okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38', 'uknow', V).`,
 				wantResult: []types.TermResults{{"V": "589"}},
 			},
@@ -231,7 +231,7 @@ func TestBank(t *testing.T) {
 						),
 					},
 				},
-				program: `bank_spendable_has_sufficient_coin(A, C, S) :- bank_spendable_coins(A, R), member(C, R),
+				program: `bank_spendable_has_sufficient_coin(A, C, S) :- bank_spendable_balances(A, R), member(C, R),
 -(_, V) = C, compare(>, V, S).`,
 				query:      `bank_spendable_has_sufficient_coin('okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38', C, 600).`,
 				wantResult: []types.TermResults{{"C": "uakt-4099"}, {"C": "uatom-693"}, {"C": "uband-4282"}, {"C": "ukava-836"}},
@@ -257,7 +257,7 @@ func TestBank(t *testing.T) {
 						Coins:   sdk.NewCoins(sdk.NewCoin("uatom", sdk.NewInt(589))),
 					},
 				},
-				query: `bank_spendable_coins(Accounts, SpendableCoins).`,
+				query: `bank_spendable_balances(Accounts, SpendableCoins).`,
 				wantResult: []types.TermResults{
 					{"Accounts": "okp41ffd5wx65l407yvm478cxzlgygw07h79sq0m3fm", "SpendableCoins": "[uknow-420]"},
 					{"Accounts": "okp41wze8mn5nsgl9qrgazq6a92fvh7m5e6pslyrz38", "SpendableCoins": "[uatom-589]"},
@@ -265,9 +265,9 @@ func TestBank(t *testing.T) {
 			},
 			{
 				spendableCoins: []bank.Balance{},
-				query:          `bank_spendable_coins('foo', X).`,
+				query:          `bank_spendable_balances('foo', X).`,
 				wantResult:     []types.TermResults{{"X": "[uknow-100]"}},
-				wantError:      fmt.Errorf("bank_spendable_coins/2: decoding bech32 failed: invalid bech32 string length 3"),
+				wantError:      fmt.Errorf("bank_spendable_balances/2: decoding bech32 failed: invalid bech32 string length 3"),
 			},
 
 			{
@@ -456,7 +456,7 @@ func TestBank(t *testing.T) {
 						Convey("and a vm", func() {
 							interpreter := testutil.NewInterpreterMust(ctx)
 							interpreter.Register2(engine.NewAtom("bank_balances"), BankBalances)
-							interpreter.Register2(engine.NewAtom("bank_spendable_coins"), BankSpendableCoins)
+							interpreter.Register2(engine.NewAtom("bank_spendable_balances"), BankSpendableBalances)
 							interpreter.Register2(engine.NewAtom("bank_locked_coins"), BankLockedCoins)
 
 							err := interpreter.Compile(ctx, tc.program)


### PR DESCRIPTION
As mentioned [here](https://github.com/okp4/okp4d/pull/266#discussion_r1080974073), this PR is intended to rename the bank predicates to be consistent with the public [GRPC API](https://buf.build/cosmos/cosmos-sdk/docs/44fbb0df9cea049d588e76bf930177d777552cf3:cosmos.bank.v1beta1#cosmos.bank.v1beta1.Query.SpendableBalances). 

- rename `bank_spendable_coins/2` to `bank_spendable_balances/2`
- rename `bank_locked_coins/2` to `bank_locked_balances/2`

#### 🔗 Related links : 
- Related discussion : https://github.com/okp4/okp4d/pull/266#discussion_r1080974073
- ⚠️ Waiting this PR before merge : #267 