### PR TITLE
feat: memoize params

### DIFF
--- a/x/logic/keeper/params.go
+++ b/x/logic/keeper/params.go
@@ -5,13 +5,31 @@ import (
 	"github.com/okp4/okp4d/x/logic/types"
 )
 
-// GetParams get all parameters as types.Params.
-func (k Keeper) GetParams(ctx sdk.Context) (params types.Params) {
-	k.paramstore.GetParamSet(ctx, &params)
-	return
+// memoizedParams is a minimalistic cache for the params.
+// should be used only in go-routine-safe contexts.
+var memoizedParams = struct {
+	v     types.Params
+	isSet bool
+}{
+	v: types.DefaultParams(),
 }
 
-// SetParams set the params.
+// GetParams get all parameters as types.Params.
+// The returned value is memoized so that it can be used without querying the store, and consuming gas.
+func (k Keeper) GetParams(ctx sdk.Context) types.Params {
+	if !memoizedParams.isSet {
+		k.paramstore.GetParamSet(ctx, &memoizedParams.v)
+		memoizedParams.isSet = true
+	}
+
+	return memoizedParams.v
+}
+
+// SetParams set the cachedParams.
+// The params are also memoized so that they can be used without querying the store again.
 func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramstore.SetParamSet(ctx, &params)
+
+	memoizedParams.v = params
+	memoizedParams.isSet = true
 }


### PR DESCRIPTION
## Purpose

This PR introduces a memoization mechanism for the `params` of the `logic` module. This is relevant as it reduces the amount of gas consumed when requesting the store for params, because each execution of logical queries (`Ask`) would incur the cost of reading the store, which is unnecessary in this particular case,  IMHO.

*Note*: I would have liked to be able to load the params of the logic module at chain startup. Unfortunately, afaik, this seems rather delicate, so the memoization is done at the first call to the logic keeper.