### PR TITLE
⬆️ Prepare upgrade handlers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install OKP4 blockchain
         run: |
-          make install
+          make build && make install
 
       - name: Initialize blockchain
         run: |

--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,13 @@ COLOR_RED    = $(shell tput -Txterm setaf 1)
 COLOR_RESET  = $(shell tput -Txterm sgr0)
 
 # Blockchain constants
-CHAIN         := localnet
-CHAIN_HOME    := ./target/deployment/${CHAIN}
-CHAIN_MONIKER := local-node
+CHAIN     		:= localnet
+CHAIN_HOME    	:= ./target/deployment/${CHAIN}
+CHAIN_MONIKER 	:= local-node
+CHAIN_BINARY 	:= ./${DIST_FOLDER}/${BINARY_NAME}
+
+DAEMON_NAME 	:= okp4d
+DAEMON_HOME 	:= `pwd`/${CHAIN_HOME}/.okp4app
 
 BUILD_TAGS += netgo
 BUILD_TAGS := $(strip $(BUILD_TAGS))
@@ -206,8 +210,9 @@ test-go: build ## Pass the test for the go source code
 ## Chain:
 chain-init: build ## Initialize the blockchain with default settings.
 	@echo "${COLOR_CYAN} 🛠️ Initializing chain ${COLOR_RESET}${CHAIN}${COLOR_CYAN} under ${COLOR_YELLOW}${CHAIN_HOME}${COLOR_RESET}"
+
 	@rm -rf "${CHAIN_HOME}"; \
-	okp4d init okp4-node \
+	${CHAIN_BINARY} init okp4-node \
 	  --chain-id=okp4-${CHAIN} \
 	  --home "${CHAIN_HOME}"; \
 	\
@@ -216,28 +221,28 @@ chain-init: build ## Initialize the blockchain with default settings.
 	MNEMONIC_VALIDATOR="island position immense mom cross enemy grab little deputy tray hungry detect state helmet \
 	  tomorrow trap expect admit inhale present vault reveal scene atom"; \
 	echo $$MNEMONIC_VALIDATOR \
-	  | okp4d keys add validator \
+	  | ${CHAIN_BINARY} keys add validator \
 	      --recover \
 	      --keyring-backend test \
 	      --home "${CHAIN_HOME}"; \
 	\
-	okp4d add-genesis-account validator 1000000000uknow \
+	${CHAIN_BINARY} add-genesis-account validator 1000000000uknow \
 	  --keyring-backend test \
 	  --home "${CHAIN_HOME}"; \
 	\
-	NODE_ID=`okp4d tendermint show-node-id --home ${CHAIN_HOME}`; \
-	okp4d gentx validator 1000000uknow \
+	NODE_ID=`${CHAIN_BINARY} tendermint show-node-id --home ${CHAIN_HOME}`; \
+	${CHAIN_BINARY} gentx validator 1000000uknow \
 	  --node-id $$NODE_ID \
 	  --chain-id=okp4-${CHAIN} \
 	  --keyring-backend test \
       --home "${CHAIN_HOME}"; \
 	\
-	okp4d collect-gentxs \
+	${CHAIN_BINARY} collect-gentxs \
 	  --home "${CHAIN_HOME}"
 
 chain-start: build ## Start the blockchain with existing configuration (see chain-init)
-	@echo "${COLOR_CYAN} 🛠️ Starting chain ${COLOR_RESET}${CHAIN}${COLOR_CYAN} with configuration ${COLOR_YELLOW}${CHAIN_HOME}${COLOR_RESET}"
-	@okp4d start --moniker ${CHAIN_MONIKER} \
+	@echo "${COLOR_CYAN} 🛠️ Starting chain ${COLOR_RESET}${CHAIN}${COLOR_CYAN} with configuration ${COLOR_YELLOW}${CHAIN_HOME}${COLOR_RESET}"; \
+	${CHAIN_BINARY} start --moniker ${CHAIN_MONIKER} \
 	  --home ${CHAIN_HOME}
 
 chain-stop: ## Stop the blockchain

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CHAIN_MONIKER 	:= local-node
 CHAIN_BINARY 	:= ./${DIST_FOLDER}/${BINARY_NAME}
 
 DAEMON_NAME 	:= okp4d
-DAEMON_HOME 	:= `pwd`/${CHAIN_HOME}/.okp4app
+DAEMON_HOME 	:= `pwd`/${CHAIN_HOME}
 
 BUILD_TAGS += netgo
 BUILD_TAGS := $(strip $(BUILD_TAGS))
@@ -208,7 +208,7 @@ test-go: build ## Pass the test for the go source code
 	@go test -v -covermode=count -coverprofile ./target/coverage.out ./...
 
 ## Chain:
-chain-init: build ## Initialize the blockchain with default settings.
+chain-init: ## Initialize the blockchain with default settings.
 	@echo "${COLOR_CYAN} 🛠️ Initializing chain ${COLOR_RESET}${CHAIN}${COLOR_CYAN} under ${COLOR_YELLOW}${CHAIN_HOME}${COLOR_RESET}"
 
 	@rm -rf "${CHAIN_HOME}"; \
@@ -248,6 +248,58 @@ chain-start: build ## Start the blockchain with existing configuration (see chai
 chain-stop: ## Stop the blockchain
 	@echo "${COLOR_CYAN} ✋️ Stopping chain ${COLOR_RESET}${CHAIN}${COLOR_CYAN} with configuration ${COLOR_YELLOW}${CHAIN_HOME}${COLOR_RESET}"
 	@killall okp4d
+
+chain-upgrade: build
+	@echo "${COLOR_CYAN} ⬆️ Upgrade the chain ${COLOR_RESET}${CHAIN}${COLOR_CYAN} from ${COLOR_YELLOW}${FROM_VERSION}${COLOR_RESET}${COLOR_CYAN} to ${COLOR_YELLOW}${TO_VERSION}${COLOR_RESET}"
+	@killall cosmovisor || \
+	rm -rf ${TARGET_FOLDER}/${FROM_VERSION}; \
+	git clone -b ${FROM_VERSION} https://github.com/okp4/okp4d.git ${TARGET_FOLDER}/${FROM_VERSION}; \
+	echo "${COLOR_CYAN} 🏗 Build the ${COLOR_YELLOW}${FROM_VERSION}${COLOR_RESET}${COLOR_CYAN} binary...${COLOR_RESET}"; \
+	cd ${TARGET_FOLDER}/${FROM_VERSION}; \
+	make build; \
+	BINARY_OLD=${TARGET_FOLDER}/${FROM_VERSION}/${DIST_FOLDER}/${DAEMON_NAME}; \
+	cd ../../; \
+	echo $$BINARY_OLD; \
+	make chain-init CHAIN_BINARY=$$BINARY_OLD; \
+	\
+	echo "${COLOR_CYAN} 👩‍🚀 Prepare cosmovisor ${COLOR_RESET}"; \
+	export DAEMON_NAME=${DAEMON_NAME}; \
+	export DAEMON_HOME=${DAEMON_HOME}; \
+	\
+	echo '{"messages": [{"@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade","authority": "okp410d07y265gmmuvt4z0w9aw880jnsr700jh7kd2g","plan": {"name": "","time": "0001-01-01T00:00:00Z","height": "10","info": "","upgraded_client_state": null}}],"metadata": "ipfs://CID","deposit": "1uknow"}' | \
+		jq --arg name "${TO_VERSION}" '.messages[].plan.name = $$name' > ${TARGET_FOLDER}/proposal.json; \
+	cat <<< $$(jq '.app_state.gov.voting_params.voting_period = "20s"' ${CHAIN_HOME}/config/genesis.json) > ${CHAIN_HOME}/config/genesis.json; \
+	\
+ 	cosmovisor init $$BINARY_OLD; \
+ 	cosmovisor run start --moniker ${CHAIN_MONIKER} \
+ 		--home ${CHAIN_HOME} \
+ 		--log_level trace & \
+	sleep 10;\
+ 	$$BINARY_OLD tx gov submit-proposal ${TARGET_FOLDER}/proposal.json \
+ 		--from validator \
+ 		--yes \
+ 		--home ${CHAIN_HOME} \
+ 		--chain-id okp4-${CHAIN} \
+ 		--keyring-backend test \
+ 		-b block; \
+ 	\
+ 	$$BINARY_OLD tx gov deposit 1 10000000uknow \
+     		--from validator \
+     		--yes \
+     		--home ${CHAIN_HOME} \
+     		--chain-id okp4-${CHAIN} \
+     		--keyring-backend test \
+     		-b block; \
+	\
+ 	$$BINARY_OLD tx gov vote 1 yes \
+     		--from validator \
+     		--yes \
+     		--home ${CHAIN_HOME} \
+     		--chain-id okp4-${CHAIN} \
+     		--keyring-backend test \
+     		-b block; \
+	mkdir -p ${DAEMON_HOME}/cosmovisor/upgrades/${TO_VERSION}/bin && cp ${CHAIN_BINARY} ${DAEMON_HOME}/cosmovisor/upgrades/${TO_VERSION}/bin; \
+	wait
 
 ## Clean:
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ chain-stop: ## Stop the blockchain
 	@echo "${COLOR_CYAN} ✋️ Stopping chain ${COLOR_RESET}${CHAIN}${COLOR_CYAN} with configuration ${COLOR_YELLOW}${CHAIN_HOME}${COLOR_RESET}"
 	@killall okp4d
 
-chain-upgrade: build
+chain-upgrade: build ## Test the chain upgrade from the given FROM_VERSION to the given TO_VERSION
 	@echo "${COLOR_CYAN} ⬆️ Upgrade the chain ${COLOR_RESET}${CHAIN}${COLOR_CYAN} from ${COLOR_YELLOW}${FROM_VERSION}${COLOR_RESET}${COLOR_CYAN} to ${COLOR_YELLOW}${TO_VERSION}${COLOR_RESET}"
 	@killall cosmovisor || \
 	rm -rf ${TARGET_FOLDER}/${FROM_VERSION}; \

--- a/README.md
+++ b/README.md
@@ -127,10 +127,7 @@ OKP4 blockchain and hosted in the [okp4/contracts](https://github.com/okp4/contr
 The project comes with a convenient `Makefile` that helps you to build, install, lint and test the project.
 
 ```text
-$ make help
-
-Usage:
-  make <target>
+$ make <target>
 
 Targets:
   Lint:
@@ -154,6 +151,7 @@ Targets:
     chain-init          Initialize the blockchain with default settings.
     chain-start         Start the blockchain with existing configuration (see chain-init)
     chain-stop          Stop the blockchain
+    chain-upgrade       Test the chain upgrade from the given FROM_VERSION to the given TO_VERSION
   Clean:
     clean               Remove all the files from the target folder
   Proto:
@@ -171,7 +169,6 @@ Targets:
     release-assets      Generate release assets
   Help:
     help                Show this help.
-
 
 This Makefile depends on docker. To install it, please follow the instructions:
 - for macOS: https://docs.docker.com/docker-for-mac/install/

--- a/app/app.go
+++ b/app/app.go
@@ -827,6 +827,8 @@ func New(
 	app.ScopedICAControllerKeeper = scopedICAControllerKeeper
 	app.ScopedInterTxKeeper = scopedInterTxKeeper
 
+	app.setupUpgradeHandlers()
+
 	if loadLatest {
 		if err := app.LoadLatestVersion(); err != nil {
 			tmos.Exit(err.Error())

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -24,7 +24,7 @@ func (app *App) setupUpgradeHandlers() {
 	}
 
 	var storeUpgrades *storetypes.StoreUpgrades
-	switch upgradeInfo.Name {
+	switch upgradeInfo.Name { //nolint:gocritic // next upgrade will need switch case
 	case v4.UpgradeName:
 		storeUpgrades = v4.StoreUpgrades
 	}
@@ -33,5 +33,4 @@ func (app *App) setupUpgradeHandlers() {
 		// configure store loader that checks if version == upgradeHeight and applies store upgrades
 		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, storeUpgrades))
 	}
-
 }

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"fmt"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	v4 "github.com/okp4/okp4d/app/upgrades/v4"
+)
+
+func (app *App) setupUpgradeHandlers() {
+	app.UpgradeKeeper.SetUpgradeHandler(
+		v4.UpgradeName,
+		v4.CreateUpgradeHandler(app.mm, app.configurator),
+	)
+
+	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
+	if err != nil {
+		panic(fmt.Errorf("failed to read upgrade info from disk: %w", err))
+	}
+
+	if app.UpgradeKeeper.IsSkipHeight(upgradeInfo.Height) {
+		return
+	}
+
+	var storeUpgrades *storetypes.StoreUpgrades
+	switch upgradeInfo.Name {
+	case v4.UpgradeName:
+		storeUpgrades = v4.StoreUpgrades
+	}
+
+	if storeUpgrades != nil {
+		// configure store loader that checks if version == upgradeHeight and applies store upgrades
+		app.SetStoreLoader(upgradetypes.UpgradeStoreLoader(upgradeInfo.Height, storeUpgrades))
+	}
+
+}

--- a/app/upgrades/v4/upgrade.go
+++ b/app/upgrades/v4/upgrade.go
@@ -1,0 +1,26 @@
+package v4
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+const UpgradeName = "v4.0.0"
+
+var StoreUpgrades = &storetypes.StoreUpgrades{
+	Added: []string{"logic"},
+}
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		logger := ctx.Logger().With("upgrade", UpgradeName)
+
+		logger.Debug("running module migrations...")
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}

--- a/app/upgrades/v4/upgrade.go
+++ b/app/upgrades/v4/upgrade.go
@@ -9,9 +9,7 @@ import (
 
 const UpgradeName = "v4.0.0"
 
-var StoreUpgrades = &storetypes.StoreUpgrades{
-	Added: []string{"logic"},
-}
+var StoreUpgrades *storetypes.StoreUpgrades // No store root upgrade.
 
 func CreateUpgradeHandler(
 	mm *module.Manager,

--- a/x/logic/keeper/migrations.go
+++ b/x/logic/keeper/migrations.go
@@ -1,0 +1,18 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	v2 "github.com/okp4/okp4d/x/logic/migrations/v2"
+)
+
+type Migrator struct {
+	keeper Keeper
+}
+
+func NewMigrator(keeper Keeper) Migrator {
+	return Migrator{keeper: keeper}
+}
+
+func (m Migrator) Migrate1to2(ctx sdk.Context) error {
+	return v2.MigrateStore(ctx, m.keeper.paramstore, m.keeper.cdc)
+}

--- a/x/logic/migrations/v2/migrations.go
+++ b/x/logic/migrations/v2/migrations.go
@@ -1,0 +1,21 @@
+package v2
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/okp4/okp4d/x/logic/types"
+)
+
+func MigrateStore(ctx sdk.Context, paramstore paramtypes.Subspace, cdc codec.BinaryCodec) error {
+	logger := ctx.Logger().With("migration", "logic")
+
+	logger.Debug("start module migration")
+
+	// Add default params keys / values
+	logger.Debug("set params default values")
+	params := types.DefaultParams()
+	paramstore.SetParamSet(ctx, &params)
+
+	return nil
+}

--- a/x/logic/module.go
+++ b/x/logic/module.go
@@ -128,6 +128,12 @@ func (am AppModule) LegacyQuerierHandler(_ *codec.LegacyAmino) sdk.Querier {
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServiceServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServiceServer(cfg.QueryServer(), am.keeper)
+
+	migrator := keeper.NewMigrator(am.keeper)
+
+	if err := cfg.RegisterMigration(types.ModuleName, 1, migrator.Migrate1to2); err != nil {
+		panic(fmt.Errorf("failed to migrate %s to v2: %w", types.ModuleName, err))
+	}
 }
 
 // RegisterInvariants registers the invariants of the module. If an invariant deviates from its predicted value,
@@ -153,7 +159,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 
 // ConsensusVersion is a sequence number for state-breaking change of the module. It should be incremented on each
 // consensus-breaking change introduced by the module. To avoid wrong/empty versions, the initial version should be set to 1.
-func (AppModule) ConsensusVersion() uint64 { return 1 }
+func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 // BeginBlock contains the logic that is automatically triggered at the beginning of each block.
 func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}

--- a/x/logic/types/params.go
+++ b/x/logic/types/params.go
@@ -18,7 +18,7 @@ var (
 var (
 	DefaultRegisteredPredicates = make([]string, 0)
 	DefaultBootstrap            = ""
-	DefaultMaxGas               = math.NewUint(uint64(100))
+	DefaultMaxGas               = math.NewUint(uint64(10000))
 	DefaultMaxSize              = math.NewUint(uint64(5000))
 	DefaultMaxResultCount       = math.NewUint(uint64(1))
 )

--- a/x/logic/types/params.go
+++ b/x/logic/types/params.go
@@ -18,7 +18,7 @@ var (
 var (
 	DefaultRegisteredPredicates = make([]string, 0)
 	DefaultBootstrap            = ""
-	DefaultMaxGas               = math.NewUint(uint64(10000))
+	DefaultMaxGas               = math.NewUint(uint64(100000))
 	DefaultMaxSize              = math.NewUint(uint64(5000))
 	DefaultMaxResultCount       = math.NewUint(uint64(1))
 )


### PR DESCRIPTION
A PR to bring some functionalities to prepare upgrades of the chain.

- [x] Add an upgrade handler
- [x] Add migration script for chain
- [x] Add migration script for logic module
- [x] Add a make script to test chain upgrade
- [x] Add documentation for the make script
- [x] Increase the max gas limits

#### ⬆️ Upgrade handler 

Add necessary upgrade handlers to prepare chain upgrade and migration.

#### 🧠 Logic module

The logic module introduce new params and remove the foo/bar params. A migration has been configured to set the new params with its defaults values. Logic modules consensus version has been incremented to v2. A migration folder structure has been set with its related migration. 

#### ⚙️ Build

A new make command has been added to test chain upgrade : 
```bash
make chain-upgrade FROM_VERSION=v3.0.0 TO_VERSION=v4.0.0   
```

This command will build the current go project, download the old version from GitHub tag `FROM_VERSION`, build and start this version with cosmovisor. Vote proposal will be submitted and voted to make an upgrade after 10 block. Then the new binary is prepared to be updated when chain reach the block 10. Chain restart and migration name `TO_VERSION` is done (if necessary). 

#### 🔗 Resources 
Nice article that help to understand migration process in cosmos chain : https://medium.com/web3-surfers/cosmos-dev-series-cosmos-sdk-based-blockchain-upgrade-b5e99181554c