### PR TITLE
fix(logic): ensure keepers in interpreter exec ctx

### DIFF
--- a/x/logic/keeper/grpc_query_ask.go
+++ b/x/logic/keeper/grpc_query_ask.go
@@ -6,7 +6,6 @@ import (
 	sdkerrors "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/okp4/okp4d/x/logic/types"
-	"golang.org/x/net/context"
 )
 
 func (k Keeper) Ask(ctx goctx.Context, req *types.QueryServiceAskRequest) (response *types.QueryServiceAskResponse, err error) {
@@ -39,7 +38,7 @@ func (k Keeper) Ask(ctx goctx.Context, req *types.QueryServiceAskRequest) (respo
 
 	//nolint:contextcheck
 	return k.execute(
-		context.WithValue(sdkCtx, sdk.SdkContextKey, sdkCtx),
+		sdkCtx,
 		req.Program,
 		req.Query)
 }


### PR DESCRIPTION
This is a proposal to fix an issue related to the presence of the bank & account keepers in prolog interpreter executions.

It ensures those keepers are present in the `sdk.Context` once unwrapped. It introduce an helper func `enhanceContext` to prepare the context before execution in which new elements may be added in the future.