### PR TITLE
Feat/logic wasm querier

### DIFF
--- a/app/wasm/query.go
+++ b/app/wasm/query.go
@@ -12,7 +12,7 @@ import (
 )
 
 // customQuery represents the wasm custom query structure, it is intended to allow wasm contracts to execute queries
-// against the logic modules.
+// against the logic module.
 type customQuery struct {
 	Ask *logicwasm.AskQuery `json:"ask,omitempty"`
 }

--- a/app/wasm/query.go
+++ b/app/wasm/query.go
@@ -35,9 +35,9 @@ func makeCustomQuerier(logicQuerier logicwasm.LogicQuerier) wasmkeeper.CustomQue
 		}
 
 		if query.Ask != nil {
-			return logicQuerier.Ask(ctx, query.Ask)
+			return logicQuerier.Ask(ctx, *query.Ask)
 		}
 
-		return nil, sdkerrors.Wrap(wasmtypes.ErrInvalidMsg, "Unknown Custom query variant")
+		return nil, sdkerrors.Wrap(wasmtypes.ErrInvalidMsg, "Unknown custom query variant")
 	}
 }

--- a/app/wasm/query.go
+++ b/app/wasm/query.go
@@ -1,0 +1,43 @@
+package wasm
+
+import (
+	"encoding/json"
+
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	logickeeper "github.com/okp4/okp4d/x/logic/keeper"
+	logicwasm "github.com/okp4/okp4d/x/logic/wasm"
+)
+
+// customQuery represents the wasm custom query structure, it is intended to allow wasm contracts to execute queries
+// against the logic modules.
+type customQuery struct {
+	Ask *logicwasm.AskQuery `json:"ask,omitempty"`
+}
+
+// CustomQueryPlugins creates a wasm QueryPlugins containing the custom querier managing wasm contracts queries to the
+// logic module.
+func CustomQueryPlugins(logicKeeper logickeeper.Keeper) *wasmkeeper.QueryPlugins {
+	return &wasmkeeper.QueryPlugins{
+		Custom: makeCustomQuerier(
+			logicwasm.MakeLogicQuerier(logicKeeper),
+		),
+	}
+}
+
+func makeCustomQuerier(logicQuerier logicwasm.LogicQuerier) wasmkeeper.CustomQuerier {
+	return func(ctx sdk.Context, request json.RawMessage) ([]byte, error) {
+		var query customQuery
+		if err := json.Unmarshal(request, &query); err != nil {
+			return nil, sdkerrors.Wrap(sdkerrors.ErrJSONUnmarshal, err.Error())
+		}
+
+		if query.Ask != nil {
+			return logicQuerier.Ask(ctx, query.Ask)
+		}
+
+		return nil, sdkerrors.Wrap(wasmtypes.ErrInvalidMsg, "Unknown Custom query variant")
+	}
+}

--- a/x/logic/wasm/query.go
+++ b/x/logic/wasm/query.go
@@ -8,8 +8,8 @@ import (
 	"github.com/okp4/okp4d/x/logic/types"
 )
 
-// AskQuery contains parameters to the Ask gRPC logic query, it is redefined to prevent eventual breaking change in the
-// logic module definitions with wasm usages.
+// AskQuery contains Ask gRPC request parameters, it is redefined to keep control in case of eventual breaking change
+// in the logic module definition.
 type AskQuery struct {
 	Program string `json:"program"`
 	Query   string `json:"query"`
@@ -28,7 +28,7 @@ func MakeLogicQuerier(keeper keeper.Keeper) LogicQuerier {
 	}
 }
 
-// Ask is a proxy method with the gRPC one, returning the result in the json format.
+// Ask is a proxy method with the gRPC request, returning the result in the json format.
 func (querier LogicQuerier) Ask(ctx sdk.Context, query *AskQuery) ([]byte, error) {
 	resp, err := querier.k.Ask(ctx, &types.QueryServiceAskRequest{
 		Program: query.Program,

--- a/x/logic/wasm/query.go
+++ b/x/logic/wasm/query.go
@@ -1,0 +1,42 @@
+package wasm
+
+import (
+	"encoding/json"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/okp4/okp4d/x/logic/keeper"
+	"github.com/okp4/okp4d/x/logic/types"
+)
+
+// AskQuery contains parameters to the Ask gRPC logic query, it is redefined to prevent eventual breaking change in the
+// logic module definitions with wasm usages.
+type AskQuery struct {
+	Program string `json:"program"`
+	Query   string `json:"query"`
+}
+
+// LogicQuerier ease the bridge between the logic module with the wasm CustomQuerier to allow wasm contracts to query
+// the logic module.
+type LogicQuerier struct {
+	k keeper.Keeper
+}
+
+// MakeLogicQuerier creates a new LogicQuerier based on the logic keeper.
+func MakeLogicQuerier(keeper keeper.Keeper) LogicQuerier {
+	return LogicQuerier{
+		k: keeper,
+	}
+}
+
+// Ask is a proxy method with the gRPC one, returning the result in the json format.
+func (querier LogicQuerier) Ask(ctx sdk.Context, query *AskQuery) ([]byte, error) {
+	resp, err := querier.k.Ask(ctx, &types.QueryServiceAskRequest{
+		Program: query.Program,
+		Query:   query.Query,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(resp)
+}

--- a/x/logic/wasm/types.go
+++ b/x/logic/wasm/types.go
@@ -1,0 +1,100 @@
+package wasm
+
+import "github.com/okp4/okp4d/x/logic/types"
+
+// AskQuery implements the wasm custom Ask query JSON schema, it basically redefined the Ask gRPC request parameters
+// to keep control in case of eventual breaking change in the logic module definition, and to decouple the
+// serialization logic.
+type AskQuery struct {
+	Program string `json:"program"`
+	Query   string `json:"query"`
+}
+
+// AskResponse implements the Ask query response JSON schema in a wasm custom query purpose, it redefines the existing
+// generated type from proto to ensure a dedicated serialization logic.
+type AskResponse struct {
+	Height  uint64  `json:"height"`
+	GasUsed uint64  `json:"gas_used"`
+	Answer  *Answer `json:"answer,omitempty"`
+}
+
+func (to *AskResponse) from(from types.QueryServiceAskResponse) {
+	to.Height = from.Height
+	to.GasUsed = from.GasUsed
+	to.Answer = nil
+	if from.Answer != nil {
+		answer := new(Answer)
+		answer.from(*from.Answer)
+		to.Answer = answer
+	}
+}
+
+// Answer denotes the Answer element JSON representation in an AskResponse for wasm custom query purpose, it redefines
+// the existing generated type from proto to ensure a dedicated serialization logic.
+type Answer struct {
+	Success   bool     `json:"success"`
+	HasMore   bool     `json:"has_more"`
+	Variables []string `json:"variables"`
+	Results   []Result `json:"results"`
+}
+
+func (to *Answer) from(from types.Answer) {
+	to.Success = from.Success
+	to.HasMore = from.HasMore
+	to.Variables = from.Variables
+	if to.Variables == nil {
+		to.Variables = make([]string, 0)
+	}
+	to.Results = make([]Result, 0, len(from.Results))
+	for _, fromResult := range from.Results {
+		result := new(Result)
+		result.from(fromResult)
+		to.Results = append(to.Results, *result)
+	}
+}
+
+// Result denotes the Result element JSON representation in an AskResponse for wasm custom query purpose, it redefines
+// the existing generated type from proto to ensure a dedicated serialization logic.
+type Result struct {
+	Substitutions []Substitution `json:"substitutions"`
+}
+
+func (to *Result) from(from types.Result) {
+	to.Substitutions = make([]Substitution, 0, len(from.Substitutions))
+	for _, fromSubstitution := range from.Substitutions {
+		substitution := new(Substitution)
+		substitution.from(fromSubstitution)
+		to.Substitutions = append(to.Substitutions, *substitution)
+	}
+}
+
+// Substitution denotes the Substitution element JSON representation in an AskResponse for wasm custom query purpose, it redefines
+// the existing generated type from proto to ensure a dedicated serialization logic.
+type Substitution struct {
+	Variable string `json:"variable"`
+	Term     Term   `json:"term"`
+}
+
+func (to *Substitution) from(from types.Substitution) {
+	to.Variable = from.Variable
+	term := new(Term)
+	term.from(from.Term)
+	to.Term = *term
+}
+
+// Term denotes the Term element JSON representation in an AskResponse for wasm custom query purpose, it redefines
+// the existing generated type from proto to ensure a dedicated serialization logic.
+type Term struct {
+	Name      string `json:"name"`
+	Arguments []Term `json:"arguments"`
+}
+
+func (to *Term) from(from types.Term) {
+	to.Name = from.Name
+	to.Arguments = make([]Term, 0, len(from.Arguments))
+	for _, fromTerm := range from.Arguments {
+		term := new(Term)
+		term.from(fromTerm)
+		to.Arguments = append(to.Arguments, *term)
+	}
+}


### PR DESCRIPTION
## 💡 Purpose

Wire the logic module into the wasm `QueryPlugins` through the `CustomQuerier` to allow querying the logic module from wasm contracts.

## 🧠 Design

An util `LogicQuerier` has been introduced in the logic module to ease integration with wasm `CustomQuerier` by managing the query resolution and the response marshaling. It redefined the `Ask` request parameters instead of reusing the gRPC `QueryServiceAskRequest` struct to avoid a strong coupling with the module definition and gain in control in case of breaking change in the module definition.

The `Ask` response has also been redefined, to ensure a control on how it is serialized to json and avoid surprises on contracts side.

The app define the wasm `QueryPlugins` containing a `CustomQuerier` which allow in this implementation to query the logic module Ask request from a wasm contract.

## ☹️ Caveats

By redefining query & response types we introduce duplication which is defendable regarding the gain of control, but it induce a mapping layer bringing a non functional overhead we need to experience.