### PR TITLE
Chore: ⬆️ prepare handler for 4.1.0 upgrade

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -30,7 +30,7 @@ func (app *App) setupUpgradeHandlers() {
 	}
 
 	var storeUpgrades *storetypes.StoreUpgrades
-	switch upgradeInfo.Name { //nolint:gocritic // next upgrade will need switch case
+	switch upgradeInfo.Name {
 	case v4.UpgradeName:
 		storeUpgrades = v4.StoreUpgrades
 	case v41.UpgradeName:

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -6,12 +6,18 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	v4 "github.com/okp4/okp4d/app/upgrades/v4"
+	v41 "github.com/okp4/okp4d/app/upgrades/v41"
 )
 
 func (app *App) setupUpgradeHandlers() {
 	app.UpgradeKeeper.SetUpgradeHandler(
 		v4.UpgradeName,
 		v4.CreateUpgradeHandler(app.mm, app.configurator),
+	)
+
+	app.UpgradeKeeper.SetUpgradeHandler(
+		v41.UpgradeName,
+		v41.CreateUpgradeHandler(app.mm, app.configurator),
 	)
 
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
@@ -27,6 +33,8 @@ func (app *App) setupUpgradeHandlers() {
 	switch upgradeInfo.Name { //nolint:gocritic // next upgrade will need switch case
 	case v4.UpgradeName:
 		storeUpgrades = v4.StoreUpgrades
+	case v41.UpgradeName:
+		storeUpgrades = v41.StoreUpgrades
 	}
 
 	if storeUpgrades != nil {

--- a/app/upgrades/v41/upgrade.go
+++ b/app/upgrades/v41/upgrade.go
@@ -1,0 +1,24 @@
+package v41
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+const UpgradeName = "v4.1.0"
+
+var StoreUpgrades *storetypes.StoreUpgrades // No store root upgrade.
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		logger := ctx.Logger().With("upgrade", UpgradeName)
+
+		logger.Debug("running module migrations...")
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}


### PR DESCRIPTION
### ⬆️ Add update handler

For the next coming release, this PR add the update handler o the chain. This handler will do not execute migration since there is no migration for this release. 

### 🧪 Tests

This update has been successfully tested (with an empty chain) with this command tool : 

```cli
make chain-upgrade FROM_VERSION=v4.0.0 TO_VERSION=v4.1.0
```

New predicates introduced in this release are working ;)  