### PR TITLE
Fix logic async gas consumption

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/ichiban/prolog v0.15.1
+	github.com/ichiban/prolog v1.1.0
 	github.com/ignite/cli v0.25.2
 	github.com/nuts-foundation/go-did v0.4.0
 	github.com/prometheus/client_golang v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -863,8 +863,8 @@ github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHL
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/ichiban/prolog v0.15.1 h1:7XgoTPkAHIj8Ot7IwXwof7P90xo/pojn4iok/VuaLFI=
-github.com/ichiban/prolog v0.15.1/go.mod h1:RmvNfGaSktvEVZ7nmpn0gkWa5u0Y3zQcK0G+Pl+ul+s=
+github.com/ichiban/prolog v1.1.0 h1:WAY8lg3qA2UKMySYSDFjArmKI/LuaEZV43ZQWlLGRMQ=
+github.com/ichiban/prolog v1.1.0/go.mod h1:RmvNfGaSktvEVZ7nmpn0gkWa5u0Y3zQcK0G+Pl+ul+s=
 github.com/ignite/cli v0.25.2 h1:6VF4Ygx67gtQpJmzmXQTqvZvb+Qy+bzao+zxlqSEWro=
 github.com/ignite/cli v0.25.2/go.mod h1:zVKEE1Qox7DbluU+bFNw3EyWfDrMzmUkS66lfrNicrw=
 github.com/ignite/modules v0.0.0-20220912090139-7c325cae763a h1:0P8qg4YS0hb8jomZedhbooEKE3JZhRNAewV8+8otr6k=

--- a/x/logic/keeper/grpc_query_ask.go
+++ b/x/logic/keeper/grpc_query_ask.go
@@ -34,13 +34,6 @@ func (k Keeper) Ask(ctx goctx.Context, req *types.QueryServiceAskRequest) (respo
 
 			panic(r)
 		}
-		if sdkCtx.GasMeter().IsOutOfGas() {
-			response, err = nil, sdkerrors.Wrapf(
-				types.LimitExceeded, "out of gas: %s (%d/%d)",
-				types.ModuleName, sdkCtx.GasMeter().GasConsumed(), sdkCtx.GasMeter().Limit())
-
-			return
-		}
 	}()
 	sdkCtx.GasMeter().ConsumeGas(sdkCtx.GasMeter().GasConsumed(), types.ModuleName)
 

--- a/x/logic/keeper/interpreter.go
+++ b/x/logic/keeper/interpreter.go
@@ -73,6 +73,10 @@ func (k Keeper) execute(ctx goctx.Context, program, query string) (*types.QueryS
 		results = append(results, types.Result{Substitutions: m.ToSubstitutions()})
 	}
 
+	if sols.Err() != nil && sdkCtx.GasMeter().IsOutOfGas() {
+		panic(sdk.ErrorOutOfGas{Descriptor: "Prolog interpreter execution"})
+	}
+
 	return &types.QueryServiceAskResponse{
 		Height:  uint64(sdkCtx.BlockHeight()),
 		GasUsed: sdkCtx.GasMeter().GasConsumed(),

--- a/x/logic/meter/safe.go
+++ b/x/logic/meter/safe.go
@@ -1,7 +1,6 @@
 package meter
 
 import (
-	"runtime"
 	"sync"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -25,20 +24,6 @@ func WithSafeMeter(gasMeter sdk.GasMeter) sdk.GasMeter {
 // ConsumeGas consumes the given amount of gas from the decorated gas meter.
 func (m *safeMeterDecorater) ConsumeGas(amount uint64, descriptor string) {
 	m.mutex.Lock()
-	defer func() {
-		if r := recover(); r != nil {
-			if _, ok := r.(sdk.ErrorOutOfGas); ok {
-				// Since predicate is called into a goroutine, when out of gas is thrown, the main caller
-				// (grpc: https://github.com/okp4/okp4d/blob/main/x/logic/keeper/grpc_query_ask.go#L25-L36, or querier)
-				// cannot recover ErrOutOfGas. To avoid the chain panicking, we need to exit without panic.
-				// Goexit runs all deferred calls before terminating the goroutine. Because Goexit
-				// is not a panic, any recover calls in those deferred functions will return nil.
-				// This is a temporary solution before implementing a context cancellation.
-				runtime.Goexit()
-			}
-			panic(r)
-		}
-	}()
 	defer m.mutex.Unlock()
 
 	m.gasMeter.ConsumeGas(amount, descriptor)

--- a/x/logic/predicate/address_test.go
+++ b/x/logic/predicate/address_test.go
@@ -100,7 +100,7 @@ func TestBech32(t *testing.T) {
 			},
 			{
 				query:       `bech32_address(-('okp4', 'foo'), Bech32).`,
-				wantError:   fmt.Errorf("bech32_address/2: address should be a Pair with a List of bytes in arity 2, give engine.Variable"),
+				wantError:   fmt.Errorf("bech32_address/2: address should be a Pair with a List of bytes in arity 2, give engine.Atom"),
 				wantSuccess: false,
 			},
 			{


### PR DESCRIPTION
## Context

When prolog executing query through the logic `Ask` gRPC query, the prolog predicates are executed in a separate goroutine. In case this goroutine panic we are not able to recover from it, so the https://github.com/okp4/okp4d/pull/312 introduced a change in the gas consumption handling, making the goroutine stop instead of panic. This works on async parts, but may be problematic on synchronous parts.

## Description

Since https://github.com/ichiban/prolog/pull/290 released in the [v1.1.0 version](https://github.com/ichiban/prolog/releases/tag/v1.1.0) any panics occurring while executing predicates are recovered and an error is returned back to the interpreter client through the `Solutions.Err()` func. The panic being recovered, this PR adds a check on gas consumption to panic again with the `ErrorOutOfGas` error letting the gRPC `Ask` query handle it.
