### PR TITLE
⬆️ Upgrade handler v5 for cosmos v0.47.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ chain-upgrade: build ## Test the chain upgrade from the given FROM_VERSION to th
  	cosmovisor init $$BINARY_OLD; \
  	cosmovisor run start --moniker ${CHAIN_MONIKER} \
  		--home ${CHAIN_HOME} \
- 		--log_level trace & \
+ 		--log_level debug & \
 	sleep 10;\
  	$$BINARY_OLD tx gov submit-proposal $$PROPOSAL \
  		--from validator \

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -23,7 +23,7 @@ func (app *App) setupUpgradeHandlers() {
 
 	app.UpgradeKeeper.SetUpgradeHandler(
 		v5.UpgradeName,
-		v5.CreateUpgradeHandler(app, app.mm, app.configurator),
+		v5.CreateUpgradeHandler(app.ParamsKeeper, &app.ConsensusParamsKeeper, app.mm, app.configurator),
 	)
 
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -7,6 +7,7 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	v4 "github.com/okp4/okp4d/app/upgrades/v4"
 	v41 "github.com/okp4/okp4d/app/upgrades/v41"
+	v5 "github.com/okp4/okp4d/app/upgrades/v5"
 )
 
 func (app *App) setupUpgradeHandlers() {
@@ -18,6 +19,11 @@ func (app *App) setupUpgradeHandlers() {
 	app.UpgradeKeeper.SetUpgradeHandler(
 		v41.UpgradeName,
 		v41.CreateUpgradeHandler(app.mm, app.configurator),
+	)
+
+	app.UpgradeKeeper.SetUpgradeHandler(
+		v5.UpgradeName,
+		v5.CreateUpgradeHandler(app.mm, app.configurator),
 	)
 
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()
@@ -35,6 +41,8 @@ func (app *App) setupUpgradeHandlers() {
 		storeUpgrades = v4.StoreUpgrades
 	case v41.UpgradeName:
 		storeUpgrades = v41.StoreUpgrades
+	case v5.UpgradeName:
+		storeUpgrades = v5.StoreUpgrades
 	}
 
 	if storeUpgrades != nil {

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -23,7 +23,7 @@ func (app *App) setupUpgradeHandlers() {
 
 	app.UpgradeKeeper.SetUpgradeHandler(
 		v5.UpgradeName,
-		v5.CreateUpgradeHandler(app.mm, app.configurator),
+		v5.CreateUpgradeHandler(app, app.mm, app.configurator),
 	)
 
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()

--- a/app/upgrades/v5/upgrade.go
+++ b/app/upgrades/v5/upgrade.go
@@ -1,22 +1,37 @@
 package v5
 
 import (
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"github.com/okp4/okp4d/app"
 )
 
 const UpgradeName = "v5.0.0"
 
 var StoreUpgrades *storetypes.StoreUpgrades // No store root upgrade.
 
+// CreateUpgradeHandler is the handler that will perform migration from v4.1.0 to v5.0.0.
+// This migration include following update that need migration :
+//   - Migrate Tendermint consensus parameters from x/params moduel to a dedicated
+//     x/consensus module.
+//     -
 func CreateUpgradeHandler(
+	app *app.App,
 	mm *module.Manager,
 	configurator module.Configurator,
 ) upgradetypes.UpgradeHandler {
+
+	baseAppLegacySS := app.ParamsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramstypes.ConsensusParamsKeyTable())
+
 	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		logger := ctx.Logger().With("upgrade", UpgradeName)
+
+		logger.Debug("migrate consensus params keeper")
+		baseapp.MigrateParams(ctx, baseAppLegacySS, &app.ConsensusParamsKeeper)
 
 		logger.Debug("running module migrations...")
 		return mm.RunMigrations(ctx, configurator, vm)

--- a/app/upgrades/v5/upgrade.go
+++ b/app/upgrades/v5/upgrade.go
@@ -49,7 +49,6 @@ func CreateUpgradeHandler(
 	mm *module.Manager,
 	configurator module.Configurator,
 ) upgradetypes.UpgradeHandler {
-
 	// Set param key table for params module migration
 	for _, subspace := range paramsKeeper.GetSubspaces() {
 		subspace := subspace

--- a/app/upgrades/v5/upgrade.go
+++ b/app/upgrades/v5/upgrade.go
@@ -1,0 +1,24 @@
+package v5
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+)
+
+const UpgradeName = "v5.0.0"
+
+var StoreUpgrades *storetypes.StoreUpgrades // No store root upgrade.
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+) upgradetypes.UpgradeHandler {
+	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		logger := ctx.Logger().With("upgrade", UpgradeName)
+
+		logger.Debug("running module migrations...")
+		return mm.RunMigrations(ctx, configurator, vm)
+	}
+}

--- a/app/upgrades/v5/upgrade.go
+++ b/app/upgrades/v5/upgrade.go
@@ -1,37 +1,104 @@
 package v5
 
 import (
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	consensusparamkeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
+	consensustypes "github.com/cosmos/cosmos-sdk/x/consensus/types"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
-	"github.com/okp4/okp4d/app"
+	icacontrollertypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/controller/types"
+	icahosttypes "github.com/cosmos/ibc-go/v7/modules/apps/27-interchain-accounts/host/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
 )
 
 const UpgradeName = "v5.0.0"
 
-var StoreUpgrades *storetypes.StoreUpgrades // No store root upgrade.
+var StoreUpgrades = &storetypes.StoreUpgrades{
+	Added: []string{
+		consensustypes.ModuleName,
+		crisistypes.ModuleName,
+	},
+}
 
 // CreateUpgradeHandler is the handler that will perform migration from v4.1.0 to v5.0.0.
+// Bump cosmos-sdk form 0.46.6 to 0.47.1.
 // This migration include following update that need migration :
 //   - Migrate Tendermint consensus parameters from x/params moduel to a dedicated
 //     x/consensus module.
-//     -
+//   - Register StoreUpgrade (`consensus` and `crisis` module adding)
+//
+// Migrate all modules :
+//   - Logic module with new params + move params from x/params to x/logic module state.
+//   - Mint module by move params from x/params to x/mint module state.
 func CreateUpgradeHandler(
-	app *app.App,
+	paramsKeeper paramskeeper.Keeper,
+	consensusParamsKeeper *consensusparamkeeper.Keeper,
 	mm *module.Manager,
 	configurator module.Configurator,
 ) upgradetypes.UpgradeHandler {
 
-	baseAppLegacySS := app.ParamsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramstypes.ConsensusParamsKeyTable())
+	// Set param key table for params module migration
+	for _, subspace := range paramsKeeper.GetSubspaces() {
+		subspace := subspace
+
+		var keyTable paramstypes.KeyTable
+		switch subspace.Name() {
+		case authtypes.ModuleName:
+			keyTable = authtypes.ParamKeyTable() //nolint:staticcheck
+		case banktypes.ModuleName:
+			keyTable = banktypes.ParamKeyTable() //nolint:staticcheck
+		case stakingtypes.ModuleName:
+			keyTable = stakingtypes.ParamKeyTable()
+		// Mint module no needs to set his ParamsKeyTable since our migration script already set it
+		// case minttypes.ModuleName:
+		//	keyTable = minttypes.ParamKeyTable()
+		case distrtypes.ModuleName:
+			keyTable = distrtypes.ParamKeyTable() //nolint:staticcheck
+		case slashingtypes.ModuleName:
+			keyTable = slashingtypes.ParamKeyTable() //nolint:staticcheck
+		case govtypes.ModuleName:
+			keyTable = govv1.ParamKeyTable() //nolint:staticcheck
+		case crisistypes.ModuleName:
+			keyTable = crisistypes.ParamKeyTable() //nolint:staticcheck
+			// ibc types
+		case ibctransfertypes.ModuleName:
+			keyTable = ibctransfertypes.ParamKeyTable()
+		case icahosttypes.SubModuleName:
+			keyTable = icahosttypes.ParamKeyTable()
+		case icacontrollertypes.SubModuleName:
+			keyTable = icacontrollertypes.ParamKeyTable()
+			// wasm
+		case wasmtypes.ModuleName:
+			keyTable = wasmtypes.ParamKeyTable() //nolint:staticcheck
+		default:
+			continue
+		}
+
+		if !subspace.HasKeyTable() {
+			subspace.WithKeyTable(keyTable)
+		}
+	}
+
+	baseAppLegacySS := paramsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramstypes.ConsensusParamsKeyTable())
 
 	return func(ctx sdk.Context, plan upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		logger := ctx.Logger().With("upgrade", UpgradeName)
 
 		logger.Debug("migrate consensus params keeper")
-		baseapp.MigrateParams(ctx, baseAppLegacySS, &app.ConsensusParamsKeeper)
+		baseapp.MigrateParams(ctx, baseAppLegacySS, consensusParamsKeeper)
 
 		logger.Debug("running module migrations...")
 		return mm.RunMigrations(ctx, configurator, vm)


### PR DESCRIPTION
#### 🦅 Migrations

This PR follow #282 to apply all necessary migrations since new feature development on the logic module, and for the update of cosmos-sdk from 0.46.6 to 0.47.1. 

#### 📋 Todo

- [x] Consensus upgrade handler : https://github.com/cosmos/cosmos-sdk/blob/main/UPGRADING.md#new-proposalproposer-field
- [ ] ~~Proposal upgrade handler (optional) https://github.com/cosmos/cosmos-sdk/blob/main/UPGRADING.md#new-proposalproposer-field~~ Optional
- [x] Migrate `x/logic` module with new params naming and migration of `x/params` to module state
- [x] Migrate our custom `x/mint` module from `x/params` to module state
- [x] All cosmos-sdk migration (principally linked to the removing of `x/params` ): set ParamsKeyTable of all cosmos-module allowing migration from `x/params` to module state.