### PR TITLE
🧪 Add more tests on logic module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,7 +406,6 @@ mock: ## Generate all the mocks (for tests)
 	@mockgen -source=x/vesting/types/expected_keepers.go -package testutil -destination x/vesting/testutil/expected_keepers_mocks.go
 	@mockgen -source=x/logic/types/expected_keepers.go -package testutil -destination x/logic/testutil/expected_keepers_mocks.go
 	@mockgen -destination x/logic/testutil/gas_mocks.go -package testutil github.com/cosmos/cosmos-sdk/store/types GasMeter
-	@mockgen -destination x/logic/testutil/fs_mocks.go -package testutil -source=x/logic/fs/fs.go
 
 ## Release:
 .PHONY: release-assets

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -47,9 +47,8 @@ func TestGRPCAsk(t *testing.T) {
 
 		for nc, tc := range cases {
 			Convey(
-				fmt.Sprintf("Given test case #%d with program: %v and query: %v",
-					nc, tc.program, tc.query), func() {
-
+				fmt.Sprintf("Given test case #%d with program: %v and query: %v", nc, tc.program, tc.query),
+				func() {
 					encCfg := moduletestutil.MakeTestEncodingConfig(logic.AppModuleBasic{})
 					key := storetypes.NewKVStoreKey(types.StoreKey)
 					testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	gocontext "context"
 	"fmt"
+	"io/fs"
 	"testing"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -13,7 +14,6 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/golang/mock/gomock"
 	"github.com/okp4/okp4d/x/logic"
-	"github.com/okp4/okp4d/x/logic/fs"
 	"github.com/okp4/okp4d/x/logic/keeper"
 	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
 	"github.com/okp4/okp4d/x/logic/types"

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -1,0 +1,102 @@
+package keeper_test
+
+import (
+	gocontext "context"
+	"fmt"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/golang/mock/gomock"
+	"github.com/okp4/okp4d/x/logic"
+	"github.com/okp4/okp4d/x/logic/fs"
+	"github.com/okp4/okp4d/x/logic/keeper"
+	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGRPCAsk(t *testing.T) {
+	Convey("Given a test cases", t, func() {
+		cases := []struct {
+			program        string
+			query          string
+			expectedAsnwer types.Answer
+		}{
+			{
+				program: "father(bob, alice).",
+				query:   "father(bob, X).",
+				expectedAsnwer: types.Answer{
+					Success:   true,
+					HasMore:   false,
+					Variables: []string{"X"},
+					Results: []types.Result{types.Result{Substitutions: []types.Substitution{types.Substitution{
+						Variable: "X",
+						Term: types.Term{
+							Name:      "alice",
+							Arguments: nil,
+						},
+					}}}},
+				},
+			},
+		}
+
+		for nc, tc := range cases {
+			Convey(
+				fmt.Sprintf("Given test case #%d with program: %v and query: %v",
+					nc, tc.program, tc.query), func() {
+
+					encCfg := moduletestutil.MakeTestEncodingConfig(logic.AppModuleBasic{})
+					key := storetypes.NewKVStoreKey(types.StoreKey)
+					testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+
+					// gomock initializations
+					ctrl := gomock.NewController(t)
+					accountKeeper := logictestutil.NewMockAccountKeeper(ctrl)
+					bankKeeper := logictestutil.NewMockBankKeeper(ctrl)
+					fsProvider := logictestutil.NewMockFS(ctrl)
+
+					logicKeeper := keeper.NewKeeper(
+						encCfg.Codec,
+						key,
+						key,
+						authtypes.NewModuleAddress(govtypes.ModuleName),
+						accountKeeper,
+						bankKeeper,
+						func(ctx gocontext.Context) fs.FS {
+							return fsProvider
+						},
+					)
+					err := logicKeeper.SetParams(testCtx.Ctx, types.DefaultParams())
+
+					So(err, ShouldBeNil)
+
+					Convey("and given a query with program and query to grpc", func() {
+						queryHelper := baseapp.NewQueryServerTestHelper(testCtx.Ctx, encCfg.InterfaceRegistry)
+						types.RegisterQueryServiceServer(queryHelper, logicKeeper)
+
+						queryClient := types.NewQueryServiceClient(queryHelper)
+
+						query := types.QueryServiceAskRequest{
+							Program: tc.program,
+							Query:   tc.query,
+						}
+
+						Convey("when the grpc query ask is called", func() {
+							result, err := queryClient.Ask(gocontext.Background(), &query)
+
+							Convey("Then it should return the expected answer", func() {
+								So(err, ShouldBeNil)
+								So(result, ShouldNotBeNil)
+								So(*result.Answer, ShouldResemble, tc.expectedAsnwer)
+							})
+						})
+					})
+				})
+		}
+	})
+}

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -34,7 +34,7 @@ func TestGRPCAsk(t *testing.T) {
 					Success:   true,
 					HasMore:   false,
 					Variables: []string{"X"},
-					Results: []types.Result{types.Result{Substitutions: []types.Substitution{types.Substitution{
+					Results: []types.Result{{Substitutions: []types.Substitution{{
 						Variable: "X",
 						Term: types.Term{
 							Name:      "alice",

--- a/x/logic/keeper/grpc_query_params_test.go
+++ b/x/logic/keeper/grpc_query_params_test.go
@@ -1,9 +1,94 @@
 package keeper_test
 
 import (
+	gocontext "context"
+	"fmt"
 	"testing"
+
+	"cosmossdk.io/math"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/golang/mock/gomock"
+	"github.com/okp4/okp4d/x/logic"
+	"github.com/okp4/okp4d/x/logic/fs"
+	"github.com/okp4/okp4d/x/logic/keeper"
+	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestParamsQuery(t *testing.T) {
-	// TODO implement me
+func TestGRPCParams(t *testing.T) {
+	Convey("Given a test cases", t, func() {
+		cases := []struct {
+			params types.Params
+		}{
+			{
+				params: types.NewParams(
+					types.NewInterpreter(
+						types.WithBootstrap("bootstrap"),
+						types.WithPredicatesBlacklist([]string{"halt/1"}),
+						types.WithPredicatesWhitelist([]string{"source_file/1"}),
+					),
+					types.NewLimits(
+						types.WithMaxGas(math.NewUint(1)),
+						types.WithMaxSize(math.NewUint(2)),
+						types.WithMaxResultCount(math.NewUint(3)),
+						types.WithMaxUserOutputSize(math.NewUint(4)),
+					),
+				),
+			},
+		}
+
+		for nc, tc := range cases {
+			Convey(
+				fmt.Sprintf("Given test case #%d with params: %v",
+					nc, tc.params), func() {
+
+					encCfg := moduletestutil.MakeTestEncodingConfig(logic.AppModuleBasic{})
+					key := storetypes.NewKVStoreKey(types.StoreKey)
+					testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+
+					// gomock initializations
+					ctrl := gomock.NewController(t)
+					accountKeeper := logictestutil.NewMockAccountKeeper(ctrl)
+					bankKeeper := logictestutil.NewMockBankKeeper(ctrl)
+					fsProvider := logictestutil.NewMockFS(ctrl)
+
+					logicKeeper := keeper.NewKeeper(
+						encCfg.Codec,
+						key,
+						key,
+						authtypes.NewModuleAddress(govtypes.ModuleName),
+						accountKeeper,
+						bankKeeper,
+						func(ctx gocontext.Context) fs.FS {
+							return fsProvider
+						},
+					)
+
+					Convey("and given params to the keeper", func() {
+						err := logicKeeper.SetParams(testCtx.Ctx, tc.params)
+						So(err, ShouldBeNil)
+
+						queryHelper := baseapp.NewQueryServerTestHelper(testCtx.Ctx, encCfg.InterfaceRegistry)
+						types.RegisterQueryServiceServer(queryHelper, logicKeeper)
+
+						queryClient := types.NewQueryServiceClient(queryHelper)
+
+						Convey("when the grpc query params is called", func() {
+							params, err := queryClient.Params(gocontext.Background(), &types.QueryServiceParamsRequest{})
+
+							Convey("Then it should return the expected params set to the keeper", func() {
+								So(err, ShouldBeNil)
+								So(params.Params, ShouldResemble, tc.params)
+							})
+						})
+					})
+				})
+		}
+	})
 }

--- a/x/logic/keeper/grpc_query_params_test.go
+++ b/x/logic/keeper/grpc_query_params_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	gocontext "context"
 	"fmt"
+	"io/fs"
 	"testing"
 
 	"cosmossdk.io/math"
@@ -14,7 +15,6 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/golang/mock/gomock"
 	"github.com/okp4/okp4d/x/logic"
-	"github.com/okp4/okp4d/x/logic/fs"
 	"github.com/okp4/okp4d/x/logic/keeper"
 	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
 	"github.com/okp4/okp4d/x/logic/types"

--- a/x/logic/keeper/grpc_query_params_test.go
+++ b/x/logic/keeper/grpc_query_params_test.go
@@ -32,6 +32,8 @@ func TestGRPCParams(t *testing.T) {
 						types.WithBootstrap("bootstrap"),
 						types.WithPredicatesBlacklist([]string{"halt/1"}),
 						types.WithPredicatesWhitelist([]string{"source_file/1"}),
+						types.WithVirtualFilesBlacklist([]string{"file1"}),
+						types.WithVirtualFilesWhitelist([]string{"file2"}),
 					),
 					types.NewLimits(
 						types.WithMaxGas(math.NewUint(1)),

--- a/x/logic/keeper/grpc_query_params_test.go
+++ b/x/logic/keeper/grpc_query_params_test.go
@@ -45,9 +45,7 @@ func TestGRPCParams(t *testing.T) {
 
 		for nc, tc := range cases {
 			Convey(
-				fmt.Sprintf("Given test case #%d with params: %v",
-					nc, tc.params), func() {
-
+				fmt.Sprintf("Given test case #%d with params: %v", nc, tc.params), func() {
 					encCfg := moduletestutil.MakeTestEncodingConfig(logic.AppModuleBasic{})
 					key := storetypes.NewKVStoreKey(types.StoreKey)
 					testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))

--- a/x/logic/keeper/msg_server_test.go
+++ b/x/logic/keeper/msg_server_test.go
@@ -1,0 +1,92 @@
+package keeper_test
+
+import (
+	gocontext "context"
+	"fmt"
+	"testing"
+
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/golang/mock/gomock"
+	"github.com/okp4/okp4d/x/logic"
+	"github.com/okp4/okp4d/x/logic/fs"
+	"github.com/okp4/okp4d/x/logic/keeper"
+	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUpdateParams(t *testing.T) {
+	Convey("Given a test cases", t, func() {
+		cases := []struct {
+			name      string
+			request   *types.MsgUpdateParams
+			expectErr bool
+		}{
+			{
+				name: "set invalid authority",
+				request: &types.MsgUpdateParams{
+					Authority: "foo",
+				},
+				expectErr: true,
+			},
+			{
+				name: "set full valid params",
+				request: &types.MsgUpdateParams{
+					Authority: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+					Params:    types.DefaultParams(),
+				},
+				expectErr: false,
+			},
+		}
+
+		for nc, tc := range cases {
+			Convey(
+				fmt.Sprintf("Given test case #%d: %v, with request: %v",
+					nc, tc.name, tc.request), func() {
+
+					encCfg := moduletestutil.MakeTestEncodingConfig(logic.AppModuleBasic{})
+					key := storetypes.NewKVStoreKey(types.StoreKey)
+					testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+
+					// gomock initializations
+					ctrl := gomock.NewController(t)
+					accountKeeper := logictestutil.NewMockAccountKeeper(ctrl)
+					bankKeeper := logictestutil.NewMockBankKeeper(ctrl)
+					fsProvider := logictestutil.NewMockFS(ctrl)
+
+					logicKeeper := keeper.NewKeeper(
+						encCfg.Codec,
+						key,
+						key,
+						authtypes.NewModuleAddress(govtypes.ModuleName),
+						accountKeeper,
+						bankKeeper,
+						func(ctx gocontext.Context) fs.FS {
+							return fsProvider
+						},
+					)
+
+					msgServer := keeper.NewMsgServerImpl(*logicKeeper)
+
+					Convey("when call msg server to update params", func() {
+						res, err := msgServer.UpdateParams(testCtx.Ctx, tc.request)
+
+						Convey("then it should return the expected result", func() {
+							if tc.expectErr {
+								So(err, ShouldNotBeNil)
+								So(res, ShouldBeNil)
+							} else {
+								So(err, ShouldBeNil)
+								So(res, ShouldNotBeNil)
+							}
+						})
+					})
+
+				})
+		}
+	})
+}

--- a/x/logic/keeper/msg_server_test.go
+++ b/x/logic/keeper/msg_server_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	gocontext "context"
 	"fmt"
+	"io/fs"
 	"testing"
 
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -12,7 +13,6 @@ import (
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/golang/mock/gomock"
 	"github.com/okp4/okp4d/x/logic"
-	"github.com/okp4/okp4d/x/logic/fs"
 	"github.com/okp4/okp4d/x/logic/keeper"
 	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
 	"github.com/okp4/okp4d/x/logic/types"

--- a/x/logic/keeper/msg_server_test.go
+++ b/x/logic/keeper/msg_server_test.go
@@ -45,9 +45,7 @@ func TestUpdateParams(t *testing.T) {
 
 		for nc, tc := range cases {
 			Convey(
-				fmt.Sprintf("Given test case #%d: %v, with request: %v",
-					nc, tc.name, tc.request), func() {
-
+				fmt.Sprintf("Given test case #%d: %v, with request: %v", nc, tc.name, tc.request), func() {
 					encCfg := moduletestutil.MakeTestEncodingConfig(logic.AppModuleBasic{})
 					key := storetypes.NewKVStoreKey(types.StoreKey)
 					testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
@@ -85,7 +83,6 @@ func TestUpdateParams(t *testing.T) {
 							}
 						})
 					})
-
 				})
 		}
 	})

--- a/x/logic/types/params.go
+++ b/x/logic/types/params.go
@@ -89,6 +89,20 @@ func WithPredicatesBlacklist(blacklist []string) InterpreterOption {
 	}
 }
 
+// WithVirtualFilesWhitelist sets the whitelist of predicates.
+func WithVirtualFilesWhitelist(whitelist []string) InterpreterOption {
+	return func(i *Interpreter) {
+		i.VirtualFilesFilter.Whitelist = whitelist
+	}
+}
+
+// WithVirtualFilesBlacklist sets the blacklist of predicates.
+func WithVirtualFilesBlacklist(blacklist []string) InterpreterOption {
+	return func(i *Interpreter) {
+		i.VirtualFilesFilter.Blacklist = blacklist
+	}
+}
+
 // WithBootstrap sets the bootstrap program.
 func WithBootstrap(bootstrap string) InterpreterOption {
 	return func(i *Interpreter) {

--- a/x/logic/types/params.go
+++ b/x/logic/types/params.go
@@ -33,7 +33,7 @@ func NewParams(interpreter Interpreter, limits Limits) Params {
 
 // DefaultParams returns a default set of parameters.
 func DefaultParams() Params {
-	return NewParams(NewInterpreter(), DefaultLimits())
+	return NewParams(NewInterpreter(), NewLimits())
 }
 
 // Validate validates the set of params.
@@ -116,18 +116,57 @@ func validateInterpreter(i interface{}) error {
 	return nil
 }
 
-// NewLimits creates a new Limits object.
-func NewLimits(maxGas, maxSize, maxResultCount *math.Uint) Limits {
-	return Limits{
-		MaxGas:         maxGas,
-		MaxSize:        maxSize,
-		MaxResultCount: maxResultCount,
+// LimitsOption is a functional option for configuring the Limits.
+type LimitsOption func(*Limits)
+
+// WithMaxGas sets the max gas limits for interpreter.
+func WithMaxGas(maxGas math.Uint) LimitsOption {
+	return func(i *Limits) {
+		i.MaxGas = &maxGas
 	}
 }
 
-// DefaultLimits return a Limits object with default params.
-func DefaultLimits() Limits {
-	return NewLimits(&DefaultMaxGas, &DefaultMaxSize, &DefaultMaxResultCount)
+// WithMaxSize sets the max size limits accepted for a prolog program.
+func WithMaxSize(maxSize math.Uint) LimitsOption {
+	return func(i *Limits) {
+		i.MaxSize = &maxSize
+	}
+}
+
+// WithMaxResultCount sets the maximum number of results that can be requested for a query.
+func WithMaxResultCount(maxResultCount math.Uint) LimitsOption {
+	return func(i *Limits) {
+		i.MaxResultCount = &maxResultCount
+	}
+}
+
+// WithMaxUserOutputSize specifies the maximum number of bytes to keep in the user output.
+func WithMaxUserOutputSize(maxUserOutputSize math.Uint) LimitsOption {
+	return func(i *Limits) {
+		i.MaxUserOutputSize = &maxUserOutputSize
+	}
+}
+
+// NewLimits creates a new Limits object.
+func NewLimits(opts ...LimitsOption) Limits {
+	l := Limits{}
+	for _, opt := range opts {
+		opt(&l)
+	}
+
+	if l.MaxGas == nil {
+		l.MaxGas = &DefaultMaxGas
+	}
+
+	if l.MaxSize == nil {
+		l.MaxSize = &DefaultMaxSize
+	}
+
+	if l.MaxResultCount == nil {
+		l.MaxResultCount = &DefaultMaxResultCount
+	}
+
+	return l
 }
 
 func validateLimits(i interface{}) error {

--- a/x/logic/types/params_test.go
+++ b/x/logic/types/params_test.go
@@ -1,15 +1,68 @@
 package types_test
 
 import (
+	"fmt"
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/okp4/okp4d/x/logic/types"
-	"github.com/stretchr/testify/require"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
-func Test_validateParams(t *testing.T) {
-	params := types.DefaultParams()
+func TestValidateParams(t *testing.T) {
+	Convey("Given a test cases", t, func() {
+		cases := []struct {
+			name      string
+			params    types.Params
+			expectErr bool
+			err       error
+		}{
+			{
+				name:      "validate default params",
+				params:    types.DefaultParams(),
+				expectErr: false,
+				err:       nil,
+			},
+			{
+				name: "validate set params",
+				params: types.NewParams(
+					types.NewInterpreter(
+						types.WithBootstrap("bootstrap"),
+						types.WithPredicatesBlacklist([]string{"halt/1"}),
+						types.WithPredicatesWhitelist([]string{"source_file/1"}),
+					),
+					types.NewLimits(
+						types.WithMaxGas(math.NewUint(1)),
+						types.WithMaxSize(math.NewUint(2)),
+						types.WithMaxResultCount(math.NewUint(3)),
+						types.WithMaxUserOutputSize(math.NewUint(4)),
+					),
+				),
+				expectErr: false,
+				err:       nil,
+			},
+		}
 
-	// default params have no error
-	require.NoError(t, params.Validate())
+		for nc, tc := range cases {
+			Convey(
+				fmt.Sprintf("Given test case #%d: %v, with params: %v", nc, tc.name, tc.params), func() {
+
+					Convey("when validate params", func() {
+						err := tc.params.Validate()
+
+						if tc.expectErr {
+							Convey("then params validation expect error", func() {
+								So(err, ShouldNotBeNil)
+								So(err, ShouldEqual, tc.err)
+							})
+						} else {
+							Convey("then error should be nil", func() {
+								So(err, ShouldBeNil)
+							})
+						}
+
+					})
+				})
+		}
+	})
 }

--- a/x/logic/types/params_test.go
+++ b/x/logic/types/params_test.go
@@ -30,6 +30,8 @@ func TestValidateParams(t *testing.T) {
 						types.WithBootstrap("bootstrap"),
 						types.WithPredicatesBlacklist([]string{"halt/1"}),
 						types.WithPredicatesWhitelist([]string{"source_file/1"}),
+						types.WithVirtualFilesBlacklist([]string{"file1"}),
+						types.WithVirtualFilesWhitelist([]string{"file2"}),
 					),
 					types.NewLimits(
 						types.WithMaxGas(math.NewUint(1)),
@@ -41,26 +43,46 @@ func TestValidateParams(t *testing.T) {
 				expectErr: false,
 				err:       nil,
 			},
+			{
+				name: "validate invalid virtual files blacklist params",
+				params: types.NewParams(
+					types.NewInterpreter(
+						types.WithVirtualFilesBlacklist([]string{"https://foo{bar/"}),
+					),
+					types.NewLimits(),
+				),
+				expectErr: true,
+				err:       fmt.Errorf("invalid virtual file in blacklist: https://foo{bar/"),
+			},
+			{
+				name: "validate invalid virtual files whitelist params",
+				params: types.NewParams(
+					types.NewInterpreter(
+						types.WithVirtualFilesWhitelist([]string{"https://foo{bar/"}),
+					),
+					types.NewLimits(),
+				),
+				expectErr: true,
+				err:       fmt.Errorf("invalid virtual file in whitelist: https://foo{bar/"),
+			},
 		}
 
 		for nc, tc := range cases {
 			Convey(
 				fmt.Sprintf("Given test case #%d: %v, with params: %v", nc, tc.name, tc.params), func() {
-
 					Convey("when validate params", func() {
 						err := tc.params.Validate()
 
 						if tc.expectErr {
 							Convey("then params validation expect error", func() {
 								So(err, ShouldNotBeNil)
-								So(err, ShouldEqual, tc.err)
+								So(err, ShouldResemble, tc.err)
 							})
 						} else {
 							Convey("then error should be nil", func() {
 								So(err, ShouldBeNil)
 							})
 						}
-
 					})
 				})
 		}


### PR DESCRIPTION
#### 🧪 Tests

Add basic tests on common module files on the `logic` module that wasn't covered by unit test. 

#### ⚙️ Params

To follow `Interpreter` params design, I've introduce [options](https://github.com/okp4/okp4d/pull/335/files#diff-760778a5bc6310e2c70e632f9a0df2e5662d35561bd28a73ed9c3e81fecff80bR120) for instantiate `Limits` params. 