### PR TITLE
ci(workflow): fix workflow naming

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,4 +1,4 @@
-name: notify-release
+name: Notify release
 
 on:
   release:

--- a/.github/workflows/update-draft-docs.yml
+++ b/.github/workflows/update-draft-docs.yml
@@ -1,4 +1,4 @@
-name: update-draft-docs
+name: Update Draft docs
 
 on:
   push:


### PR DESCRIPTION
Self explanatory. Fixes naming of `notify-release` and `update-draft-docs` names.

<img width="323" alt="image" src="https://user-images.githubusercontent.com/9574336/233852878-4f1ef586-3e8c-4b5a-8c92-c020072f6229.png">
