### PR TITLE
Refactor/sort substitutions

### DIFF
--- a/x/logic/types/logic.go
+++ b/x/logic/types/logic.go
@@ -10,6 +10,7 @@ import (
 type TermResults map[string]prolog.TermString
 
 // ToSubstitutions converts a TermResults value to a slice of Substitution values.
+// The slice is sorted in ascending order of variable names.
 func (t TermResults) ToSubstitutions() []Substitution {
 	substitutions := make([]Substitution, 0, len(t))
 	for v, ts := range t {
@@ -21,6 +22,10 @@ func (t TermResults) ToSubstitutions() []Substitution {
 		}
 		substitutions = append(substitutions, substitution)
 	}
+
+	sort.Slice(substitutions, func(i, j int) bool {
+		return substitutions[i].Variable < substitutions[j].Variable
+	})
 
 	return substitutions
 }

--- a/x/logic/types/logic.go
+++ b/x/logic/types/logic.go
@@ -26,6 +26,7 @@ func (t TermResults) ToSubstitutions() []Substitution {
 }
 
 // ToVariables extract from a TermResults value the variable names.
+// The variable names are sorted in ascending order.
 func (t TermResults) ToVariables() []string {
 	variables := make([]string, 0, len(t))
 	for v := range t {

--- a/x/logic/types/logic_test.go
+++ b/x/logic/types/logic_test.go
@@ -1,0 +1,87 @@
+package types
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestToSubstitutions(t *testing.T) {
+	Convey("Given test cases", t, func() {
+		cases := []struct {
+			term       TermResults
+			wantResult []Substitution
+		}{
+			{
+				term:       TermResults{},
+				wantResult: []Substitution{},
+			},
+			{
+				term: TermResults{
+					"X": "foo",
+				},
+				wantResult: []Substitution{
+					{
+						Variable: "X",
+						Term: Term{
+							Name: "foo",
+						},
+					},
+				},
+			},
+			{
+				term: TermResults{
+					"X": "foo",
+					"Y": "bar",
+				},
+				wantResult: []Substitution{
+					{
+						Variable: "X",
+						Term: Term{
+							Name: "foo",
+						},
+					},
+					{
+						Variable: "Y",
+						Term: Term{
+							Name: "bar",
+						},
+					},
+				},
+			},
+			{
+				term: TermResults{
+					"Y": "bar",
+					"X": "foo",
+				},
+				wantResult: []Substitution{
+					{
+						Variable: "X",
+						Term: Term{
+							Name: "foo",
+						},
+					},
+					{
+						Variable: "Y",
+						Term: Term{
+							Name: "bar",
+						},
+					},
+				},
+			},
+		}
+
+		for nc, tc := range cases {
+			Convey(fmt.Sprintf("Given test case #%d", nc), func() {
+				Convey("When ToSubstitutions() function is called", func() {
+					substitutions := tc.term.ToSubstitutions()
+
+					Convey("Then the result should match expectations", func() {
+						So(substitutions, ShouldResemble, tc.wantResult)
+					})
+				})
+			})
+		}
+	})
+}


### PR DESCRIPTION
Self explanatory. Sort the substitutions by variables names.

-----

Just to give a little more context, the issue arises with the following query for example, which provides the list of sorted variables but the substitutions don't follow the same order for variables `I` and `O`.

```sh
➜ okp4d query logic ask "bech32_address(-(_, I), stars1234xxxxx), bech32_address(-(okp4, I), O)." 
answer:
  has_more: false
  results:
  - substitutions:
    - term:
        arguments: []
        name: okp41234xxxxx
      variable: O
    - term:
        arguments: []
        name: '[21,1,141,....]'
      variable: I
  success: true
  variables:
  - I
  - O
gas_used: "12533"
height: "2562863"
```