### PR TITLE
fix(lint): add nolint for deprecated func in migration

### DIFF
--- a/app/upgrades/v5/upgrade.go
+++ b/app/upgrades/v5/upgrade.go
@@ -65,7 +65,7 @@ func CreateUpgradeHandler(
 		// case minttypes.ModuleName:
 		//	keyTable = minttypes.ParamKeyTable()
 		case distrtypes.ModuleName:
-			keyTable = distrtypes.ParamKeyTable()
+			keyTable = distrtypes.ParamKeyTable() //nolint:staticcheck
 		case slashingtypes.ModuleName:
 			keyTable = slashingtypes.ParamKeyTable() //nolint:staticcheck
 		case govtypes.ModuleName:


### PR DESCRIPTION
#368 [fail with this `//nolint staticcheck`](https://github.com/okp4/okp4d/actions/runs/5159578056/jobs/9323426905) and when merging it, this is fail without, I didn't understand why but this PR re-introduce it and linter is now happy. 