### PR TITLE
🧠 Logic: return RPC error on interpreter error

### DIFF
--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -46,6 +46,23 @@ func TestGRPCAsk(t *testing.T) {
 				expectedError: false,
 			},
 			{
+				program: "father(bob, alice). father(bob, john).",
+				query:   "father(bob, X).",
+				expectedAsnwer: &types.Answer{
+					Success:   true,
+					HasMore:   true,
+					Variables: []string{"X"},
+					Results: []types.Result{{Substitutions: []types.Substitution{{
+						Variable: "X",
+						Term: types.Term{
+							Name:      "alice",
+							Arguments: nil,
+						},
+					}}}},
+				},
+				expectedError: false,
+			},
+			{
 				program: "father(bob, alice).",
 				query:   "father(bob, john).",
 				expectedAsnwer: &types.Answer{

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -46,6 +46,17 @@ func TestGRPCAsk(t *testing.T) {
 				expectedError: false,
 			},
 			{
+				program: "father(bob, alice).",
+				query:   "father(bob, john).",
+				expectedAsnwer: &types.Answer{
+					Success:   false,
+					HasMore:   false,
+					Variables: nil,
+					Results:   nil,
+				},
+				expectedError: false,
+			},
+			{
 				program:        "father(bob, alice).",
 				query:          "father(bob, X, O).",
 				expectedAsnwer: nil,

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -105,7 +105,6 @@ func TestGRPCAsk(t *testing.T) {
 									So(result, ShouldNotBeNil)
 									So(result.Answer, ShouldResemble, tc.expectedAsnwer)
 								}
-
 							})
 						})
 					})

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -25,12 +25,13 @@ func TestGRPCAsk(t *testing.T) {
 		cases := []struct {
 			program        string
 			query          string
-			expectedAsnwer types.Answer
+			expectedAsnwer *types.Answer
+			expectedError  bool
 		}{
 			{
 				program: "father(bob, alice).",
 				query:   "father(bob, X).",
-				expectedAsnwer: types.Answer{
+				expectedAsnwer: &types.Answer{
 					Success:   true,
 					HasMore:   false,
 					Variables: []string{"X"},
@@ -42,6 +43,13 @@ func TestGRPCAsk(t *testing.T) {
 						},
 					}}}},
 				},
+				expectedError: false,
+			},
+			{
+				program:        "father(bob, alice).",
+				query:          "father(bob, X, O).",
+				expectedAsnwer: nil,
+				expectedError:  true,
 			},
 		}
 
@@ -89,9 +97,15 @@ func TestGRPCAsk(t *testing.T) {
 							result, err := queryClient.Ask(gocontext.Background(), &query)
 
 							Convey("Then it should return the expected answer", func() {
-								So(err, ShouldBeNil)
-								So(result, ShouldNotBeNil)
-								So(*result.Answer, ShouldResemble, tc.expectedAsnwer)
+								if tc.expectedError {
+									So(err, ShouldNotBeNil)
+									So(result, ShouldBeNil)
+								} else {
+									So(err, ShouldBeNil)
+									So(result, ShouldNotBeNil)
+									So(result.Answer, ShouldResemble, tc.expectedAsnwer)
+								}
+
 							})
 						})
 					})

--- a/x/logic/keeper/interpreter.go
+++ b/x/logic/keeper/interpreter.go
@@ -42,7 +42,6 @@ func (k Keeper) execute(ctx goctx.Context, program, query string) (*types.QueryS
 	if err != nil {
 		return nil, sdkerrors.Wrapf(types.Internal, "error creating interpreter: %v", err.Error())
 	}
-
 	if err := i.ExecContext(ctx, program); err != nil {
 		return nil, sdkerrors.Wrapf(types.InvalidArgument, "error compiling query: %v", err.Error())
 	}
@@ -66,7 +65,6 @@ func (k Keeper) execute(ctx goctx.Context, program, query string) (*types.QueryS
 		if err := sols.Scan(m); err != nil {
 			return nil, sdkerrors.Wrapf(types.Internal, "error scanning solution: %v", err.Error())
 		}
-
 		if nb.IsZero() {
 			variables = m.ToVariables()
 		}
@@ -78,7 +76,7 @@ func (k Keeper) execute(ctx goctx.Context, program, query string) (*types.QueryS
 		if sdkCtx.GasMeter().IsOutOfGas() {
 			panic(sdk.ErrorOutOfGas{Descriptor: "Prolog interpreter execution"})
 		}
-		return nil, err
+		return nil, sdkerrors.Wrapf(types.InvalidArgument, "error interpreting solutions: %v", err.Error())
 	}
 
 	var userOutput string

--- a/x/logic/keeper/interpreter.go
+++ b/x/logic/keeper/interpreter.go
@@ -74,8 +74,11 @@ func (k Keeper) execute(ctx goctx.Context, program, query string) (*types.QueryS
 		results = append(results, types.Result{Substitutions: m.ToSubstitutions()})
 	}
 
-	if sols.Err() != nil && sdkCtx.GasMeter().IsOutOfGas() {
-		panic(sdk.ErrorOutOfGas{Descriptor: "Prolog interpreter execution"})
+	if err := sols.Err(); err != nil {
+		if sdkCtx.GasMeter().IsOutOfGas() {
+			panic(sdk.ErrorOutOfGas{Descriptor: "Prolog interpreter execution"})
+		}
+		return nil, err
 	}
 
 	var userOutput string


### PR DESCRIPTION
#### 📝 Issue

When there is an error when asking logic module, module return a valid answer but with the `success` boolean set to `false`. This answer attribute (`success`) is only intended to say that the question your asking is not successful (there is no answer possible) but it doesn't mean that the interpreter fails. 

#### 🐛 Solution 

Now, when a error occurs in the prolog program, the error is now returned as an RPC error and command fails.

#### 👁️ Exemple

##### Before

```bash
❯ okp4d query logic ask "json_prolog(Json, Term)."
answer 
  has_more: false
  results: []
  success: false
  variables: []
gas_used: "2216"
height: "136124"
user_output: ""
```


##### After 

```bash
❯ okp4d query logic ask "json_prolog(Json, Term)."
Error: rpc error: code = InvalidArgument desc = error interpreting solutions: json_prolog/2: could not unify two variable: invalid argument: invalid request

Usage:
  okp4d query logic ask [query] [flags]

Examples:
$ okp4d query logic ask "chain_id(X)." # returns the chain-id

Flags:
      --grpc-addr string      the gRPC endpoint to use for this chain
      --grpc-insecure         allow gRPC over insecure channels, if not TLS the server must use TLS
      --height int            Use a specific height to query state at (this can error if the node is pruning state)
  -h, --help                  help for ask
      --node string           <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
  -o, --output string         Output format (text|json) (default "text")
      --program string        reads the program from the given string.
      --program-file string   reads the program from the given filename or from stdin if "-" is passed as the filename.

Global Flags:
      --chain-id string     The network chain ID (default "okp4d")
      --home string         directory for config and data (default "/Users/benjamin/.okp4d")
      --log_format string   The logging format (json|plain) (default "plain")
      --log_level string    The logging level (trace|debug|info|warn|error|fatal|panic) (default "info")
      --trace               print out full stack trace on errors


```
