### PR TITLE
🧠 Logic: fix empty string conversion to Atom

### DIFF
--- a/x/logic/predicate/did_test.go
+++ b/x/logic/predicate/did_test.go
@@ -29,16 +29,20 @@ func TestDID(t *testing.T) {
 				wantResult: []types.TermResults{{"X": "example", "Y": "'123456'"}},
 			},
 			{
+				query:      `did_components('did:example:123456',did(X,Y,Z,_,_)).`,
+				wantResult: []types.TermResults{{"X": "example", "Y": "'123456'", "Z": "''"}},
+			},
+			{
 				query:      `did_components('did:example:123456/path', X).`,
-				wantResult: []types.TermResults{{"X": "did(example,'123456',path,_1,_2)"}},
+				wantResult: []types.TermResults{{"X": "did(example,'123456',path,'','')"}},
 			},
 			{
 				query:      `did_components('did:example:123456?versionId=1', X).`,
-				wantResult: []types.TermResults{{"X": "did(example,'123456',_1,'versionId=1',_2)"}},
+				wantResult: []types.TermResults{{"X": "did(example,'123456','','versionId=1','')"}},
 			},
 			{
 				query:      `did_components('did:example:123456/path%20with/space', X).`,
-				wantResult: []types.TermResults{{"X": "did(example,'123456','path with/space',_1,_2)"}},
+				wantResult: []types.TermResults{{"X": "did(example,'123456','path with/space','','')"}},
 			},
 			{
 				query:      `did_components(X,did(example,'123456',_,'versionId=1',_)).`,

--- a/x/logic/util/prolog.go
+++ b/x/logic/util/prolog.go
@@ -7,7 +7,6 @@ import (
 )
 
 // StringToTerm converts a string to a term.
-// If the string is empty, it returns a variable.
 func StringToTerm(s string) engine.Term {
 	return engine.NewAtom(s)
 }

--- a/x/logic/util/prolog.go
+++ b/x/logic/util/prolog.go
@@ -9,10 +9,6 @@ import (
 // StringToTerm converts a string to a term.
 // If the string is empty, it returns a variable.
 func StringToTerm(s string) engine.Term {
-	if s == "" {
-		return engine.NewVariable()
-	}
-
 	return engine.NewAtom(s)
 }
 


### PR DESCRIPTION
#### 📝 Issue

A potential issue was found (thanks @antho31) when asking the prolog interpreter to unify a string representing a did uri to DID component atom. When trying to unify `did_components('did:example:123456?versionId=1', did(Method, ID, Path, Query, Fragment)).` Where `did:example:123456/test?versionId=1'` doesn't contains either a `Path` or a `Fragment`, those two atom are unified to a new variable because it's represented as an empty string. The result substitution will give something like this : 

```json
{
  "variable": "Fragment",
  "term": {
    "name": "_210",
    "arguments": []
  }
},
{
  "variable": "Path",
  "term": {
    "name": "_282",
    "arguments": []
  }
},
```
In the ichiban core interpreter, NewVariable is represented with an int64 and incremented each time its call but incremental value is kept in the local node environment. Each time we call this unifying, result will be different.

#### 🐛 Solution 

Do no convert empty string into NewVariable. As suggest by @ccamel, we could later add an implementation on the NewVariable engine to initialize the NewVariable engine with the block height as initial value each time interpreter is instantiated to be sure that each node has the same initial value.

Now, if empty string should be unified to an Atom, it's return empty string. 

```json
{
  "variable": "Fragment",
  "term": {
    "name": "''",
    "arguments": []
  }
},
{
  "variable": "Path",
  "term": {
    "name": "''",
    "arguments": []
  }
},
```