### PR TITLE
🐛 Fix gci import typo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,7 +65,7 @@ linters-settings:
       - prefix(github.com/cosmos/cosmos-sdk) # cosmos-sdk & cosmos org libs
       - prefix(github.com/cosmos/interchain-security) # interchain-security
       - prefix(github.com/cosmos/ibc-go) # ibc
-      - prefix( github.com/okp4/okp4d) # okp4
+      - prefix(github.com/okp4/okp4d) # okp4
     custom-order: true
 
   cyclop:

--- a/app/app.go
+++ b/app/app.go
@@ -15,18 +15,6 @@ import (
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/ignite/cli/ignite/pkg/openapiconsole"
-	appparams "github.com/okp4/okp4d/app/params"
-	okp4wasm "github.com/okp4/okp4d/app/wasm"
-	"github.com/okp4/okp4d/docs"
-	logicmodule "github.com/okp4/okp4d/x/logic"
-	logicfs "github.com/okp4/okp4d/x/logic/fs"
-	logicmodulekeeper "github.com/okp4/okp4d/x/logic/keeper"
-	logicmoduletypes "github.com/okp4/okp4d/x/logic/types"
-	"github.com/okp4/okp4d/x/mint"
-	mintkeeper "github.com/okp4/okp4d/x/mint/keeper"
-	minttypes "github.com/okp4/okp4d/x/mint/types"
-	"github.com/okp4/okp4d/x/vesting"
-	vestingtypes "github.com/okp4/okp4d/x/vesting/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cast"
 
@@ -133,6 +121,19 @@ import (
 	ibckeeper "github.com/cosmos/ibc-go/v7/modules/core/keeper"
 	solomachine "github.com/cosmos/ibc-go/v7/modules/light-clients/06-solomachine"
 	ibctm "github.com/cosmos/ibc-go/v7/modules/light-clients/07-tendermint"
+
+	appparams "github.com/okp4/okp4d/app/params"
+	okp4wasm "github.com/okp4/okp4d/app/wasm"
+	"github.com/okp4/okp4d/docs"
+	logicmodule "github.com/okp4/okp4d/x/logic"
+	logicfs "github.com/okp4/okp4d/x/logic/fs"
+	logicmodulekeeper "github.com/okp4/okp4d/x/logic/keeper"
+	logicmoduletypes "github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/x/mint"
+	mintkeeper "github.com/okp4/okp4d/x/mint/keeper"
+	minttypes "github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/x/vesting"
+	vestingtypes "github.com/okp4/okp4d/x/vesting/types"
 )
 
 const (

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -1,12 +1,12 @@
 package app
 
 import (
-	"github.com/okp4/okp4d/app/params"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/std"
 	"github.com/cosmos/cosmos-sdk/x/auth/tx"
+
+	"github.com/okp4/okp4d/app/params"
 )
 
 // makeEncodingConfig creates an EncodingConfig for an amino based test configuration.

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -3,12 +3,12 @@ package app
 import (
 	"fmt"
 
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
 	v4 "github.com/okp4/okp4d/app/upgrades/v4"
 	v41 "github.com/okp4/okp4d/app/upgrades/v41"
 	v5 "github.com/okp4/okp4d/app/upgrades/v5"
-
-	storetypes "github.com/cosmos/cosmos-sdk/store/types"
-	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
 func (app *App) setupUpgradeHandlers() {

--- a/app/wasm/query.go
+++ b/app/wasm/query.go
@@ -5,13 +5,14 @@ import (
 
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	logickeeper "github.com/okp4/okp4d/x/logic/keeper"
-	logicwasm "github.com/okp4/okp4d/x/logic/wasm"
 
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	logickeeper "github.com/okp4/okp4d/x/logic/keeper"
+	logicwasm "github.com/okp4/okp4d/x/logic/wasm"
 )
 
 // customQuery represents the wasm custom query structure, it is intended to allow wasm contracts to execute queries

--- a/cmd/okp4d/cmd/config.go
+++ b/cmd/okp4d/cmd/config.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"github.com/okp4/okp4d/app"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/app"
 )
 
 func initSDKConfig() {

--- a/cmd/okp4d/cmd/genaccounts.go
+++ b/cmd/okp4d/cmd/genaccounts.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	authvesting "github.com/okp4/okp4d/x/vesting/types"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -18,6 +17,8 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+
+	authvesting "github.com/okp4/okp4d/x/vesting/types"
 )
 
 const (

--- a/cmd/okp4d/cmd/root.go
+++ b/cmd/okp4d/cmd/root.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/okp4/okp4d/app"
-	appparams "github.com/okp4/okp4d/app/params"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -40,6 +38,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+
+	"github.com/okp4/okp4d/app"
+	appparams "github.com/okp4/okp4d/app/params"
 )
 
 // NewRootCmd creates a new root command for a Cosmos SDK application.

--- a/cmd/okp4d/main.go
+++ b/cmd/okp4d/main.go
@@ -4,11 +4,11 @@ import (
 	"errors"
 	"os"
 
-	"github.com/okp4/okp4d/app"
-	"github.com/okp4/okp4d/cmd/okp4d/cmd"
-
 	"github.com/cosmos/cosmos-sdk/server"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
+
+	"github.com/okp4/okp4d/app"
+	"github.com/okp4/okp4d/cmd/okp4d/cmd"
 )
 
 func main() {

--- a/scripts/generate_command_doc.go
+++ b/scripts/generate_command_doc.go
@@ -5,10 +5,11 @@ import (
 	"log"
 	"os"
 
-	"github.com/okp4/okp4d/cmd/okp4d/cmd"
 	"github.com/spf13/cobra/doc"
 
 	"github.com/cosmos/cosmos-sdk/server"
+
+	"github.com/okp4/okp4d/cmd/okp4d/cmd"
 )
 
 func main() {

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/okp4/okp4d/app"
 	"github.com/stretchr/testify/require"
 
 	tmdb "github.com/cometbft/cometbft-db"
@@ -20,6 +19,8 @@ import (
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/okp4/okp4d/app"
 )
 
 type (

--- a/x/logic/client/cli/query.go
+++ b/x/logic/client/cli/query.go
@@ -3,10 +3,11 @@ package cli
 import (
 	"fmt"
 
-	"github.com/okp4/okp4d/x/logic/types"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
+
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 // GetQueryCmd returns the cli query commands for this module.

--- a/x/logic/client/cli/query_ask.go
+++ b/x/logic/client/cli/query_ask.go
@@ -6,12 +6,13 @@ import (
 	"io"
 	"os"
 
-	"github.com/okp4/okp4d/x/logic/types"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/version"
+
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 var (

--- a/x/logic/client/cli/query_params.go
+++ b/x/logic/client/cli/query_params.go
@@ -3,11 +3,12 @@ package cli
 import (
 	"context"
 
-	"github.com/okp4/okp4d/x/logic/types"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func CmdQueryParams() *cobra.Command {

--- a/x/logic/client/cli/tx.go
+++ b/x/logic/client/cli/tx.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/okp4/okp4d/x/logic/types"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
+
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 var DefaultRelativePacketTimeoutTimestamp = uint64((time.Duration(10) * time.Minute).Nanoseconds())

--- a/x/logic/fs/filtered_fs_test.go
+++ b/x/logic/fs/filtered_fs_test.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/util"
 	"github.com/samber/lo"
 
 	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/util"
 )
 
 func TestSourceFile(t *testing.T) {

--- a/x/logic/fs/wasm.go
+++ b/x/logic/fs/wasm.go
@@ -9,9 +9,9 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/okp4/okp4d/x/logic/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 const (

--- a/x/logic/fs/wasm_test.go
+++ b/x/logic/fs/wasm_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/okp4/okp4d/x/logic/testutil"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -19,6 +18,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/testutil"
 )
 
 func TestWasmHandler(t *testing.T) {

--- a/x/logic/genesis.go
+++ b/x/logic/genesis.go
@@ -1,12 +1,12 @@
 package logic
 
 import (
-	"github.com/okp4/okp4d/x/logic/keeper"
-	"github.com/okp4/okp4d/x/logic/types"
-
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/keeper"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 // InitGenesis initializes the module's state from a provided genesis state.

--- a/x/logic/interpreter/registry.go
+++ b/x/logic/interpreter/registry.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/ichiban/prolog"
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/predicate"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/predicate"
 )
 
 // registry is a map from predicate names (in the form of "atom/arity") to predicates functions.

--- a/x/logic/keeper/grpc_query_ask.go
+++ b/x/logic/keeper/grpc_query_ask.go
@@ -3,12 +3,12 @@ package keeper
 import (
 	goctx "context"
 
-	"github.com/okp4/okp4d/x/logic/meter"
-	"github.com/okp4/okp4d/x/logic/types"
-
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/meter"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func (k Keeper) Ask(ctx goctx.Context, req *types.QueryServiceAskRequest) (response *types.QueryServiceAskResponse, err error) {

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -7,10 +7,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/okp4/okp4d/x/logic"
-	"github.com/okp4/okp4d/x/logic/keeper"
-	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -20,6 +16,11 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/okp4/okp4d/x/logic"
+	"github.com/okp4/okp4d/x/logic/keeper"
+	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func TestGRPCAsk(t *testing.T) {

--- a/x/logic/keeper/grpc_query_params.go
+++ b/x/logic/keeper/grpc_query_params.go
@@ -3,11 +3,12 @@ package keeper
 import (
 	"context"
 
-	"github.com/okp4/okp4d/x/logic/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func (k Keeper) Params(c context.Context, req *types.QueryServiceParamsRequest) (*types.QueryServiceParamsResponse, error) {

--- a/x/logic/keeper/grpc_query_params_test.go
+++ b/x/logic/keeper/grpc_query_params_test.go
@@ -7,10 +7,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/okp4/okp4d/x/logic"
-	"github.com/okp4/okp4d/x/logic/keeper"
-	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -22,6 +18,11 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/okp4/okp4d/x/logic"
+	"github.com/okp4/okp4d/x/logic/keeper"
+	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func TestGRPCParams(t *testing.T) {

--- a/x/logic/keeper/interpreter.go
+++ b/x/logic/keeper/interpreter.go
@@ -5,18 +5,19 @@ import (
 	"math"
 
 	"github.com/ichiban/prolog"
-	"github.com/okp4/okp4d/x/logic/fs"
-	"github.com/okp4/okp4d/x/logic/interpreter"
-	"github.com/okp4/okp4d/x/logic/interpreter/bootstrap"
-	"github.com/okp4/okp4d/x/logic/meter"
-	"github.com/okp4/okp4d/x/logic/types"
-	"github.com/okp4/okp4d/x/logic/util"
 	"github.com/samber/lo"
 
 	errorsmod "cosmossdk.io/errors"
 	sdkmath "cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/fs"
+	"github.com/okp4/okp4d/x/logic/interpreter"
+	"github.com/okp4/okp4d/x/logic/interpreter/bootstrap"
+	"github.com/okp4/okp4d/x/logic/meter"
+	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/x/logic/util"
 )
 
 const (

--- a/x/logic/keeper/keeper.go
+++ b/x/logic/keeper/keeper.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"io/fs"
 
-	"github.com/okp4/okp4d/x/logic/types"
-
 	"github.com/cometbft/cometbft/libs/log"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 type FSProvider = func(ctx goctx.Context) fs.FS

--- a/x/logic/keeper/migrations.go
+++ b/x/logic/keeper/migrations.go
@@ -1,11 +1,11 @@
 package keeper
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/okp4/okp4d/x/logic/exported"
 	v2 "github.com/okp4/okp4d/x/logic/migrations/v2"
 	v3 "github.com/okp4/okp4d/x/logic/migrations/v3"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type Migrator struct {

--- a/x/logic/keeper/msg_server.go
+++ b/x/logic/keeper/msg_server.go
@@ -3,12 +3,12 @@ package keeper
 import (
 	"context"
 
-	"github.com/okp4/okp4d/x/logic/types"
-
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 type msgServer struct {

--- a/x/logic/keeper/msg_server_test.go
+++ b/x/logic/keeper/msg_server_test.go
@@ -7,10 +7,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/okp4/okp4d/x/logic"
-	"github.com/okp4/okp4d/x/logic/keeper"
-	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -19,6 +15,11 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/okp4/okp4d/x/logic"
+	"github.com/okp4/okp4d/x/logic/keeper"
+	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func TestUpdateParams(t *testing.T) {

--- a/x/logic/keeper/params.go
+++ b/x/logic/keeper/params.go
@@ -1,9 +1,9 @@
 package keeper
 
 import (
-	"github.com/okp4/okp4d/x/logic/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 // GetParams get all parameters as types.Params.

--- a/x/logic/meter/weighted_test.go
+++ b/x/logic/meter/weighted_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/okp4/okp4d/x/logic/testutil"
 
 	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/okp4/okp4d/x/logic/testutil"
 )
 
 func TestMultiplyUint64Overflow(t *testing.T) {

--- a/x/logic/migrations/v2/migrations.go
+++ b/x/logic/migrations/v2/migrations.go
@@ -1,11 +1,11 @@
 package v2
 
 import (
-	"github.com/okp4/okp4d/x/logic/exported"
-	"github.com/okp4/okp4d/x/logic/types"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/exported"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func MigrateStore(ctx sdk.Context, legacySubspace exported.Subspace, cdc codec.BinaryCodec) error {

--- a/x/logic/migrations/v3/migrations.go
+++ b/x/logic/migrations/v3/migrations.go
@@ -1,14 +1,14 @@
 package v2
 
 import (
-	"github.com/okp4/okp4d/x/logic/exported"
-	v2types "github.com/okp4/okp4d/x/logic/migrations/v2/types"
-	"github.com/okp4/okp4d/x/logic/types"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+
+	"github.com/okp4/okp4d/x/logic/exported"
+	v2types "github.com/okp4/okp4d/x/logic/migrations/v2/types"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func v2ParamKeyTable() paramtypes.KeyTable {

--- a/x/logic/module.go
+++ b/x/logic/module.go
@@ -6,10 +6,6 @@ import (
 	"fmt"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/okp4/okp4d/x/logic/client/cli"
-	"github.com/okp4/okp4d/x/logic/exported"
-	"github.com/okp4/okp4d/x/logic/keeper"
-	"github.com/okp4/okp4d/x/logic/types"
 	"github.com/spf13/cobra"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -19,6 +15,11 @@ import (
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/okp4/okp4d/x/logic/client/cli"
+	"github.com/okp4/okp4d/x/logic/exported"
+	"github.com/okp4/okp4d/x/logic/keeper"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 var (

--- a/x/logic/predicate/address.go
+++ b/x/logic/predicate/address.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/util"
 
 	bech322 "github.com/cosmos/cosmos-sdk/types/bech32"
+
+	"github.com/okp4/okp4d/x/logic/util"
 )
 
 // Bech32Address is a predicate that convert a bech32 encoded string into base64 bytes and give the address prefix, or

--- a/x/logic/predicate/address_test.go
+++ b/x/logic/predicate/address_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -17,6 +15,9 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func TestBech32(t *testing.T) {

--- a/x/logic/predicate/bank.go
+++ b/x/logic/predicate/bank.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/types"
-	"github.com/okp4/okp4d/x/logic/util"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/x/logic/util"
 )
 
 // BankBalances is a predicate which unifies the given terms with the list of balances (coins) of the given account.

--- a/x/logic/predicate/bank_test.go
+++ b/x/logic/predicate/bank_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -19,6 +17,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func TestBank(t *testing.T) {

--- a/x/logic/predicate/block.go
+++ b/x/logic/predicate/block.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ichiban/prolog/engine"
+
 	"github.com/okp4/okp4d/x/logic/util"
 )
 

--- a/x/logic/predicate/block_test.go
+++ b/x/logic/predicate/block_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/testutil"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -16,6 +15,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/testutil"
 )
 
 func TestBlock(t *testing.T) {

--- a/x/logic/predicate/builtin_test.go
+++ b/x/logic/predicate/builtin_test.go
@@ -6,9 +6,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
-	"github.com/okp4/okp4d/x/logic/util"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -18,6 +15,10 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/x/logic/util"
 )
 
 func TestWrite(t *testing.T) {

--- a/x/logic/predicate/chain.go
+++ b/x/logic/predicate/chain.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ichiban/prolog/engine"
+
 	"github.com/okp4/okp4d/x/logic/util"
 )
 

--- a/x/logic/predicate/chain_test.go
+++ b/x/logic/predicate/chain_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/testutil"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -15,6 +14,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/testutil"
 )
 
 func TestChainID(t *testing.T) {

--- a/x/logic/predicate/crypto.go
+++ b/x/logic/predicate/crypto.go
@@ -6,9 +6,10 @@ import (
 	"fmt"
 
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/util"
 
 	"github.com/cometbft/cometbft/crypto"
+
+	"github.com/okp4/okp4d/x/logic/util"
 )
 
 // SHAHash is a predicate that computes the Hash of the given Data. The signature is as follow:

--- a/x/logic/predicate/crypto_test.go
+++ b/x/logic/predicate/crypto_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -17,6 +15,9 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func TestCryptoHash(t *testing.T) {

--- a/x/logic/predicate/did.go
+++ b/x/logic/predicate/did.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ichiban/prolog/engine"
 	godid "github.com/nuts-foundation/go-did/did"
+
 	"github.com/okp4/okp4d/x/logic/util"
 )
 

--- a/x/logic/predicate/did_test.go
+++ b/x/logic/predicate/did_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -17,6 +15,9 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func TestDID(t *testing.T) {

--- a/x/logic/predicate/file_test.go
+++ b/x/logic/predicate/file_test.go
@@ -11,9 +11,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/ichiban/prolog"
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/fs"
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -23,6 +20,10 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/fs"
+	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func TestSourceFile(t *testing.T) {

--- a/x/logic/predicate/json.go
+++ b/x/logic/predicate/json.go
@@ -8,12 +8,13 @@ import (
 	"strings"
 
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/util"
 	"github.com/samber/lo"
 
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/util"
 )
 
 // AtomJSON is a term which represents a json as a compound term `json([Pair])`.

--- a/x/logic/predicate/json_test.go
+++ b/x/logic/predicate/json_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -17,6 +15,9 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func TestJsonProlog(t *testing.T) {

--- a/x/logic/predicate/uri.go
+++ b/x/logic/predicate/uri.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/ichiban/prolog/engine"
+
 	"github.com/okp4/okp4d/x/logic/util"
 )
 

--- a/x/logic/predicate/uri_test.go
+++ b/x/logic/predicate/uri_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -17,6 +15,9 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func TestURIEncoded(t *testing.T) {

--- a/x/logic/predicate/util.go
+++ b/x/logic/predicate/util.go
@@ -5,9 +5,10 @@ import (
 	"sort"
 
 	"github.com/ichiban/prolog/engine"
-	"github.com/okp4/okp4d/x/logic/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 // SortBalances by coin denomination.

--- a/x/logic/testutil/logic.go
+++ b/x/logic/testutil/logic.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ichiban/prolog"
 	"github.com/ichiban/prolog/engine"
+
 	"github.com/okp4/okp4d/x/logic/interpreter/bootstrap"
 )
 

--- a/x/logic/types/genesis_test.go
+++ b/x/logic/types/genesis_test.go
@@ -3,8 +3,9 @@ package types_test
 import (
 	"testing"
 
-	"github.com/okp4/okp4d/x/logic/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func TestGenesisState_Validate(t *testing.T) {

--- a/x/logic/types/params_test.go
+++ b/x/logic/types/params_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/okp4/okp4d/x/logic/types"
-
 	. "github.com/smartystreets/goconvey/convey"
 
 	"cosmossdk.io/math"
+
+	"github.com/okp4/okp4d/x/logic/types"
 )
 
 func TestValidateParams(t *testing.T) {

--- a/x/logic/wasm/query.go
+++ b/x/logic/wasm/query.go
@@ -3,10 +3,10 @@ package wasm
 import (
 	"encoding/json"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/okp4/okp4d/x/logic/keeper"
 	"github.com/okp4/okp4d/x/logic/types"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // LogicQuerier ease the bridge between the logic module with the wasm CustomQuerier to allow wasm contracts to query

--- a/x/mint/abci.go
+++ b/x/mint/abci.go
@@ -3,11 +3,11 @@ package mint
 import (
 	"time"
 
-	"github.com/okp4/okp4d/x/mint/keeper"
-	"github.com/okp4/okp4d/x/mint/types"
-
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/mint/keeper"
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 // BeginBlocker mints new tokens for the previous block.

--- a/x/mint/client/cli/query.go
+++ b/x/mint/client/cli/query.go
@@ -3,11 +3,12 @@ package cli
 import (
 	"fmt"
 
-	"github.com/okp4/okp4d/x/mint/types"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 // GetQueryCmd returns the cli query commands for the minting module.

--- a/x/mint/client/cli/query_test.go
+++ b/x/mint/client/cli/query_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/okp4/okp4d/x/mint"
-	mintcli "github.com/okp4/okp4d/x/mint/client/cli"
 	"github.com/stretchr/testify/require"
 
 	rpcclientmock "github.com/cometbft/cometbft/rpc/client/mock"
@@ -19,6 +17,9 @@ import (
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	testutilmod "github.com/cosmos/cosmos-sdk/types/module/testutil"
+
+	"github.com/okp4/okp4d/x/mint"
+	mintcli "github.com/okp4/okp4d/x/mint/client/cli"
 )
 
 func TestGetCmdQueryParams(t *testing.T) {

--- a/x/mint/keeper/genesis.go
+++ b/x/mint/keeper/genesis.go
@@ -1,11 +1,11 @@
 package keeper
 
 import (
-	"github.com/okp4/okp4d/x/mint/types"
-
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 // InitGenesis new mint genesis.

--- a/x/mint/keeper/genesis_test.go
+++ b/x/mint/keeper/genesis_test.go
@@ -4,10 +4,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/okp4/okp4d/x/mint"
-	"github.com/okp4/okp4d/x/mint/keeper"
-	minttestutil "github.com/okp4/okp4d/x/mint/testutil"
-	"github.com/okp4/okp4d/x/mint/types"
 	"github.com/stretchr/testify/suite"
 
 	"cosmossdk.io/math"
@@ -18,6 +14,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/okp4/okp4d/x/mint"
+	"github.com/okp4/okp4d/x/mint/keeper"
+	minttestutil "github.com/okp4/okp4d/x/mint/testutil"
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 var minterAcc = authtypes.NewEmptyModuleAccount(types.ModuleName, authtypes.Minter)

--- a/x/mint/keeper/grpc_query.go
+++ b/x/mint/keeper/grpc_query.go
@@ -3,9 +3,9 @@ package keeper
 import (
 	"context"
 
-	"github.com/okp4/okp4d/x/mint/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/x/mint/keeper/grpc_query_test.go
+++ b/x/mint/keeper/grpc_query_test.go
@@ -5,10 +5,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/okp4/okp4d/x/mint"
-	"github.com/okp4/okp4d/x/mint/keeper"
-	minttestutil "github.com/okp4/okp4d/x/mint/testutil"
-	"github.com/okp4/okp4d/x/mint/types"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -17,6 +13,11 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/okp4/okp4d/x/mint"
+	"github.com/okp4/okp4d/x/mint/keeper"
+	minttestutil "github.com/okp4/okp4d/x/mint/testutil"
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 type MintTestSuite struct {

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -1,8 +1,6 @@
 package keeper
 
 import (
-	"github.com/okp4/okp4d/x/mint/types"
-
 	"github.com/cometbft/cometbft/libs/log"
 
 	"cosmossdk.io/math"
@@ -10,6 +8,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 // Keeper of the mint store.

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -4,10 +4,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/okp4/okp4d/x/mint"
-	"github.com/okp4/okp4d/x/mint/keeper"
-	minttestutil "github.com/okp4/okp4d/x/mint/testutil"
-	"github.com/okp4/okp4d/x/mint/types"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/cosmos-sdk/testutil"
@@ -15,6 +11,11 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/okp4/okp4d/x/mint"
+	"github.com/okp4/okp4d/x/mint/keeper"
+	minttestutil "github.com/okp4/okp4d/x/mint/testutil"
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 type IntegrationTestSuite struct {

--- a/x/mint/keeper/migrations.go
+++ b/x/mint/keeper/migrations.go
@@ -1,10 +1,10 @@
 package keeper
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/okp4/okp4d/x/mint/exported"
 	v2 "github.com/okp4/okp4d/x/mint/migrations/v2"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type Migrator struct {

--- a/x/mint/keeper/msg_server.go
+++ b/x/mint/keeper/msg_server.go
@@ -3,12 +3,12 @@ package keeper
 import (
 	"context"
 
-	"github.com/okp4/okp4d/x/mint/types"
-
 	errorsmod "cosmossdk.io/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 var _ types.MsgServer = msgServer{}

--- a/x/mint/keeper/msg_server_test.go
+++ b/x/mint/keeper/msg_server_test.go
@@ -1,9 +1,9 @@
 package keeper_test
 
 import (
-	"github.com/okp4/okp4d/x/mint/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 func (s *IntegrationTestSuite) TestUpdateParams() {

--- a/x/mint/migrations/v2/migrations.go
+++ b/x/mint/migrations/v2/migrations.go
@@ -1,12 +1,12 @@
 package v2
 
 import (
-	"github.com/okp4/okp4d/x/mint/exported"
-	"github.com/okp4/okp4d/x/mint/types"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/mint/exported"
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 // MigrateStore migrates the x/mint module state from the consensus version 1 to

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -6,11 +6,6 @@ import (
 	"fmt"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/okp4/okp4d/x/mint/client/cli"
-	"github.com/okp4/okp4d/x/mint/exported"
-	"github.com/okp4/okp4d/x/mint/keeper"
-	"github.com/okp4/okp4d/x/mint/simulation"
-	"github.com/okp4/okp4d/x/mint/types"
 	"github.com/spf13/cobra"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -21,6 +16,12 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+
+	"github.com/okp4/okp4d/x/mint/client/cli"
+	"github.com/okp4/okp4d/x/mint/exported"
+	"github.com/okp4/okp4d/x/mint/keeper"
+	"github.com/okp4/okp4d/x/mint/simulation"
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 var (

--- a/x/mint/simulation/decoder.go
+++ b/x/mint/simulation/decoder.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/okp4/okp4d/x/mint/types"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/kv"
+
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 // NewDecodeStore returns a decoder function closure that unmarshals the KVPair's

--- a/x/mint/simulation/decoder_test.go
+++ b/x/mint/simulation/decoder_test.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/okp4/okp4d/x/mint"
-	"github.com/okp4/okp4d/x/mint/simulation"
-	"github.com/okp4/okp4d/x/mint/types"
 	"github.com/stretchr/testify/require"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+
+	"github.com/okp4/okp4d/x/mint"
+	"github.com/okp4/okp4d/x/mint/simulation"
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 func TestDecodeStore(t *testing.T) {

--- a/x/mint/simulation/genesis.go
+++ b/x/mint/simulation/genesis.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/okp4/okp4d/x/mint/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
+
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 // Simulation parameter constants.

--- a/x/mint/simulation/genesis_test.go
+++ b/x/mint/simulation/genesis_test.go
@@ -6,8 +6,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/okp4/okp4d/x/mint/simulation"
-	"github.com/okp4/okp4d/x/mint/types"
 	"github.com/stretchr/testify/require"
 
 	sdkmath "cosmossdk.io/math"
@@ -17,6 +15,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+
+	"github.com/okp4/okp4d/x/mint/simulation"
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 // TestRandomizedGenState tests the normal scenario of applying RandomizedGenState.

--- a/x/mint/simulation/proposals.go
+++ b/x/mint/simulation/proposals.go
@@ -3,12 +3,12 @@ package simulation
 import (
 	"math/rand"
 
-	"github.com/okp4/okp4d/x/mint/types"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/address"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
+
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 // Simulation operation weights constants.

--- a/x/mint/simulation/proposals_test.go
+++ b/x/mint/simulation/proposals_test.go
@@ -4,8 +4,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/okp4/okp4d/x/mint/simulation"
-	"github.com/okp4/okp4d/x/mint/types"
 	"gotest.tools/v3/assert"
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -13,6 +11,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/address"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
+
+	"github.com/okp4/okp4d/x/mint/simulation"
+	"github.com/okp4/okp4d/x/mint/types"
 )
 
 func TestProposalMsgs(t *testing.T) {

--- a/x/vesting/client/cli/tx.go
+++ b/x/vesting/client/cli/tx.go
@@ -6,13 +6,14 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/okp4/okp4d/x/vesting/types"
 	"github.com/spf13/cobra"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/okp4/okp4d/x/vesting/types"
 )
 
 // FlagDelayed Transaction command flags.

--- a/x/vesting/module.go
+++ b/x/vesting/module.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/okp4/okp4d/x/vesting/client/cli"
-	"github.com/okp4/okp4d/x/vesting/types"
 	"github.com/spf13/cobra"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -16,6 +14,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
+
+	"github.com/okp4/okp4d/x/vesting/client/cli"
+	"github.com/okp4/okp4d/x/vesting/types"
 )
 
 var (

--- a/x/vesting/msg_server.go
+++ b/x/vesting/msg_server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/armon/go-metrics"
-	"github.com/okp4/okp4d/x/vesting/types"
 
 	errorsmod "cosmossdk.io/errors"
 
@@ -13,6 +12,8 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/okp4/okp4d/x/vesting/types"
 )
 
 type msgServer struct {

--- a/x/vesting/msg_server_test.go
+++ b/x/vesting/msg_server_test.go
@@ -5,9 +5,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/okp4/okp4d/x/vesting"
-	vestingtestutil "github.com/okp4/okp4d/x/vesting/testutil"
-	vestingtypes "github.com/okp4/okp4d/x/vesting/types"
 	"github.com/stretchr/testify/suite"
 
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -18,6 +15,10 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/okp4/okp4d/x/vesting"
+	vestingtestutil "github.com/okp4/okp4d/x/vesting/testutil"
+	vestingtypes "github.com/okp4/okp4d/x/vesting/types"
 )
 
 var (

--- a/x/vesting/types/codec.go
+++ b/x/vesting/types/codec.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"github.com/okp4/okp4d/x/vesting/exported"
-
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/cosmos/cosmos-sdk/codec/types"
@@ -10,6 +8,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/okp4/okp4d/x/vesting/exported"
 )
 
 // RegisterLegacyAminoCodec registers the vesting interfaces and concrete types on the

--- a/x/vesting/types/vesting_account.go
+++ b/x/vesting/types/vesting_account.go
@@ -4,12 +4,13 @@ import (
 	"errors"
 	"time"
 
-	vestexported "github.com/okp4/okp4d/x/vesting/exported"
 	"sigs.k8s.io/yaml"
 
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	vestexported "github.com/okp4/okp4d/x/vesting/exported"
 )
 
 // Compile-time type assertions.

--- a/x/vesting/types/vesting_account_test.go
+++ b/x/vesting/types/vesting_account_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/okp4/okp4d/x/vesting"
-	"github.com/okp4/okp4d/x/vesting/types"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -20,6 +18,9 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+
+	"github.com/okp4/okp4d/x/vesting"
+	"github.com/okp4/okp4d/x/vesting/types"
 )
 
 var (


### PR DESCRIPTION
Linter configuration contains [typo](https://github.com/okp4/okp4d/pull/392/files#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R68) for okp4d import prefix. Fix-it and reapply imports.