### PR TITLE
🧠 Logic: `open/4` predicate

### DIFF
--- a/x/logic/interpreter/registry.go
+++ b/x/logic/interpreter/registry.go
@@ -55,7 +55,7 @@ var registry = map[string]any{
 	"current_output/1":          engine.CurrentOutput,
 	"set_input/1":               engine.SetInput,
 	"set_output/1":              engine.SetOutput,
-	"open/4":                    engine.Open,
+	"open/4":                    predicate.Open,
 	"close/2":                   engine.Close,
 	"flush_output/1":            engine.FlushOutput,
 	"stream_property/2":         engine.StreamProperty,

--- a/x/logic/predicate/file.go
+++ b/x/logic/predicate/file.go
@@ -93,7 +93,7 @@ func Open(vm *engine.VM, sourceSink, mode, stream, options engine.Term, k engine
 	case engine.Atom:
 		name = s.String()
 	default:
-		return engine.Error(fmt.Errorf("open/4: invalid domain for source, should be an atom, give %T", s))
+		return engine.Error(fmt.Errorf("open/4: invalid domain for source, should be an atom, got %T", s))
 	}
 
 	var streamMode ioMode
@@ -111,11 +111,11 @@ func Open(vm *engine.VM, sourceSink, mode, stream, options engine.Term, k engine
 			return engine.Error(fmt.Errorf("open/4: invalid open mode (read | write | append)"))
 		}
 	default:
-		return engine.Error(fmt.Errorf("open/4: invalid domain for open mode, should be an atom, give %T", m))
+		return engine.Error(fmt.Errorf("open/4: invalid domain for open mode, should be an atom, got %T", m))
 	}
 
 	if _, ok := env.Resolve(stream).(engine.Variable); !ok {
-		return engine.Error(fmt.Errorf("open/4: stream can only be a variable, give %T", env.Resolve(stream)))
+		return engine.Error(fmt.Errorf("open/4: stream can only be a variable, got %T", env.Resolve(stream)))
 	}
 
 	if streamMode != ioModeRead {
@@ -124,7 +124,7 @@ func Open(vm *engine.VM, sourceSink, mode, stream, options engine.Term, k engine
 
 	f, err := vm.FS.Open(name)
 	if err != nil {
-		return engine.Error(fmt.Errorf("open/4: failed open stream: %w", err))
+		return engine.Error(fmt.Errorf("open/4: couldn't open stream: %w", err))
 	}
 	s := engine.NewInputTextStream(f)
 

--- a/x/logic/predicate/file.go
+++ b/x/logic/predicate/file.go
@@ -3,6 +3,7 @@ package predicate
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 
@@ -55,6 +56,84 @@ func SourceFile(vm *engine.VM, file engine.Term, cont engine.Cont, env *engine.E
 	}
 
 	return engine.Delay(promises...)
+}
+
+// ioMode describes what operations you can perform on the stream.
+type ioMode int
+
+const (
+	// ioModeRead means you can read from the stream.
+	ioModeRead = ioMode(os.O_RDONLY)
+	// ioModeWrite means you can write to the stream.
+	ioModeWrite = ioMode(os.O_CREATE | os.O_WRONLY)
+	// ioModeAppend means you can append to the stream.
+	ioModeAppend = ioMode(os.O_APPEND) | ioModeWrite
+)
+
+var (
+	atomRead   = engine.NewAtom("read")
+	atomWrite  = engine.NewAtom("write")
+	atomAppend = engine.NewAtom("append")
+)
+
+func (m ioMode) Term() engine.Term {
+	return [...]engine.Term{
+		ioModeRead:   atomRead,
+		ioModeWrite:  atomWrite,
+		ioModeAppend: atomAppend,
+	}[m]
+}
+
+// Open opens SourceSink in mode and unifies with stream.
+func Open(vm *engine.VM, sourceSink, mode, stream, options engine.Term, k engine.Cont, env *engine.Env) *engine.Promise {
+	var name string
+	switch s := env.Resolve(sourceSink).(type) {
+	case engine.Variable:
+		return engine.Error(fmt.Errorf("open/4: source cannot be a variable"))
+	case engine.Atom:
+		name = s.String()
+	default:
+		return engine.Error(fmt.Errorf("open/4: invalid domain for source, should be an atom, give %T", s))
+	}
+
+	var streamMode ioMode
+	switch m := env.Resolve(mode).(type) {
+	case engine.Variable:
+		return engine.Error(fmt.Errorf("open/4: streamMode cannot be a variable"))
+	case engine.Atom:
+		var ok bool
+		streamMode, ok = map[engine.Atom]ioMode{
+			atomRead:   ioModeRead,
+			atomWrite:  ioModeWrite,
+			atomAppend: ioModeAppend,
+		}[m]
+		if !ok {
+			return engine.Error(fmt.Errorf("open/4: invalid open mode (read | write | append)"))
+		}
+	default:
+		return engine.Error(fmt.Errorf("open/4: invalid domain for open mode, should be an atom, give %T", m))
+	}
+
+	if _, ok := env.Resolve(stream).(engine.Variable); !ok {
+		return engine.Error(fmt.Errorf("open/4: stream can only be a variable, give %T", env.Resolve(stream)))
+	}
+
+	if streamMode != ioModeRead {
+		return engine.Error(fmt.Errorf("open/4: only read mode is allowed here"))
+	}
+
+	f, err := vm.FS.Open(name)
+	if err != nil {
+		return engine.Error(fmt.Errorf("open/4: failed open stream: %w", err))
+	}
+	s := engine.NewInputTextStream(f)
+
+	iter := engine.ListIterator{List: options, Env: env}
+	for iter.Next() {
+		return engine.Error(fmt.Errorf("open/4: options is not allowed here"))
+	}
+
+	return engine.Unify(vm, stream, s, k, env)
 }
 
 func getLoadedSources(vm *engine.VM) map[string]struct{} {

--- a/x/logic/predicate/file_test.go
+++ b/x/logic/predicate/file_test.go
@@ -237,7 +237,7 @@ func TestOpen(t *testing.T) {
 				},
 				program:     "get_first_char(C) :- open(34, write, Stream, _), get_char(Stream, C).",
 				query:       `get_first_char(C).`,
-				wantError:   fmt.Errorf("open/4: invalid domain for source, should be an atom, give engine.Integer"),
+				wantError:   fmt.Errorf("open/4: invalid domain for source, should be an atom, got engine.Integer"),
 				wantSuccess: false,
 			},
 			{
@@ -246,7 +246,7 @@ func TestOpen(t *testing.T) {
 				},
 				program:     "get_first_char(C) :- open(file, write, stream, _), get_char(Stream, C).",
 				query:       `get_first_char(C).`,
-				wantError:   fmt.Errorf("open/4: stream can only be a variable, give engine.Atom"),
+				wantError:   fmt.Errorf("open/4: stream can only be a variable, got engine.Atom"),
 				wantSuccess: false,
 			},
 			{
@@ -255,7 +255,7 @@ func TestOpen(t *testing.T) {
 				},
 				program:     "get_first_char(C) :- open(file, 45, Stream, _), get_char(Stream, C).",
 				query:       `get_first_char(C).`,
-				wantError:   fmt.Errorf("open/4: invalid domain for open mode, should be an atom, give engine.Integer"),
+				wantError:   fmt.Errorf("open/4: invalid domain for open mode, should be an atom, got engine.Integer"),
 				wantSuccess: false,
 			},
 			{
@@ -291,7 +291,7 @@ func TestOpen(t *testing.T) {
 				},
 				program:     "get_first_char(C) :- open(file2, read, Stream, _), get_char(Stream, C).",
 				query:       `get_first_char(C).`,
-				wantError:   fmt.Errorf("open/4: failed open stream: read file2: path not found"),
+				wantError:   fmt.Errorf("open/4: couldn't open stream: read file2: path not found"),
 				wantSuccess: false,
 			},
 			{

--- a/x/logic/testutil/logic.go
+++ b/x/logic/testutil/logic.go
@@ -49,6 +49,7 @@ func NewComprehensiveInterpreterMust(ctx context.Context) (i *prolog.Interpreter
 	i.Register1(engine.NewAtom("current_output"), engine.CurrentOutput)
 	i.Register1(engine.NewAtom("current_input"), engine.CurrentInput)
 	i.Register2(engine.NewAtom("put_char"), engine.PutChar)
+	i.Register2(engine.NewAtom("get_char"), engine.GetChar)
 	i.Register3(engine.NewAtom("write_term"), engine.WriteTerm)
 
 	err := i.Compile(ctx, bootstrap.Bootstrap())


### PR DESCRIPTION
Implement our own `open/4` predicate, allowing usage of the virtual file system to open wasm uri which was not used in the ichiban implementation. 
See #379 for more details.
