### PR TITLE
ci(lint): prevent golangci cache issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -100,6 +100,7 @@ jobs:
         if: steps.changed-go-files.outputs.any_changed == 'true'
         with:
           go-version: '1.20'
+          cache: false
 
       - name: Lint go code (golangci-lint)
         uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
The [golangci-lint-action](https://github.com/golangci/golangci-lint-action) seems to encounter cache issues sometimes, see: https://github.com/okp4/okp4d/actions/runs/5320225585/jobs/9636440668

This is related to this issue: https://github.com/golangci/golangci-lint-action/issues/135

It seems that disabling the `setup-go` action cache solves that, it shouldn't be problematic as the golangci action has its own cache.