### PR TITLE
🧬 Publish draft and tagged Buf proto on registry

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,7 +89,8 @@ jobs:
         uses: bufbuild/buf-setup-action@v1.14.0
 
       - name: Push okp4 proto on buf registry
-        uses: bufbuild/buf-push-action@v1
-        with:
-          input: 'proto'
-          buf_token: ${{ secrets.BUF_TOKEN }}
+        run:
+          buf push proto ${{ github.ref_type == 'tag' && '--tag' || '--draft' }} ${{ github.ref_name }}
+
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
Since tag option is [not handled](https://github.com/bufbuild/buf-push-action/issues/20) by the GitHub Buf action, I replace the action by the classic cli command. It will push the released proto when tags is pushed, otherwise it will push as draft on Buf registry.