### PR TITLE
🧬 Buf: don't draft on main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Push okp4 proto on buf registry
         run:
-          buf push proto ${{ github.ref_type == 'tag' && '--tag' || '--draft' }} ${{ github.ref_name }}
+          buf push proto --tag ${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
 
         env:
           BUF_TOKEN: ${{ secrets.BUF_TOKEN }}


### PR DESCRIPTION
Sorry for the second PR following #408, [draft is not allowed on main branch](https://github.com/okp4/okp4d/actions/runs/5423718329/jobs/9862063062#step:4:7) (since `main` name isn't allowed by buf registry). Put back like is [done on the buf-push-action](https://github.com/bufbuild/buf-push-action/blob/main/push.bash#L40) except that in case of a tag, we put the tag name instead of the commit SHA.