### PR TITLE
Build/command docs mdx3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -390,8 +390,9 @@ doc-command: ## Generate markdown documentation for the command
 	sed -i $(SED_FLAG) 's/(default \"\/.*\/\.okp4d\")/(default \"\/home\/john\/\.okp4d\")/g' $$OUT_FOLDER/*.md; \
 	sed -i $(SED_FLAG) 's/node\ name\ (default\ \".*\")/node\ name\ (default\ \"my-machine\")/g' $$OUT_FOLDER/*.md; \
 	sed -i $(SED_FLAG) 's/IP\ (default\ \".*\")/IP\ (default\ \"127.0.0.1\")/g' $$OUT_FOLDER/*.md; \
+	sed -i $(SED_FLAG) 's/&lt;appd&gt;/okp4d/g' $$OUT_FOLDER/*.md; \
 	sed -i $(SED_FLAG) 's/<appd>/okp4d/g' $$OUT_FOLDER/*.md; \
-    sed -i $(SED_FLAG) 's/<\([a-zA-Z-]*\)>/\&lt;\1\&gt;/g' $$OUT_FOLDER/*.md; \
+	sed -i $(SED_FLAG) -E 's| (https?://[a-zA-Z0-9\.\/_=%-]+)| [\1](\1) |g' $$OUT_FOLDER/*.md; \
 	docker run --rm \
 	  -v `pwd`:/usr/src/docs \
 	  -w /usr/src/docs \

--- a/docs/.markdownlint.yaml
+++ b/docs/.markdownlint.yaml
@@ -5,3 +5,4 @@ no-inline-html: false
 fenced-code-language: false
 code-block-style: false
 link-fragments: false
+commands-show-output: false

--- a/docs/command/okp4d.md
+++ b/docs/command/okp4d.md
@@ -7,7 +7,7 @@ OKP4 Daemon 👹
 OKP4 Daemon 👹 - a revolutionary public PoS layer 1 specifically designed to enable communities to trustlessly share data,
 algorithms and resources to build the Dataverse!
 
-Want to lean more about OKP4 network? Complete documentation is available at <https://docs.okp4.network> 👀
+Want to lean more about OKP4 network? Complete documentation is available at [https://docs.okp4.network](https://docs.okp4.network)  👀
 
 ### Options
 

--- a/docs/command/okp4d_add-genesis-account.md
+++ b/docs/command/okp4d_add-genesis-account.md
@@ -22,7 +22,7 @@ okp4d add-genesis-account [address_or_key_name] [coin][,[coin]] [flags]
   -h, --help                     help for add-genesis-account
       --home string              The application home directory (default "/home/john/.okp4d")
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test) (default "test")
-      --node string              &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string            Output format (text|json) (default "text")
       --vesting-amount string    amount of coins for vesting accounts
       --vesting-cliff-time int   schedule cliff time (unix epoch) for vesting accounts

--- a/docs/command/okp4d_config.md
+++ b/docs/command/okp4d_config.md
@@ -3,7 +3,7 @@
 Create or query an application CLI configuration file
 
 ```
-okp4d config &lt;key&gt; [value] [flags]
+okp4d config <key> [value] [flags]
 ```
 
 ### Options

--- a/docs/command/okp4d_debug_prefixes.md
+++ b/docs/command/okp4d_debug_prefixes.md
@@ -13,7 +13,7 @@ okp4d debug prefixes [flags]
 ### Examples
 
 ```
-okp4d debug prefixes
+$ okp4d debug prefixes
 ```
 
 ### Options

--- a/docs/command/okp4d_debug_pubkey.md
+++ b/docs/command/okp4d_debug_pubkey.md
@@ -7,7 +7,7 @@ Decode a pubkey from proto JSON
 Decode a pubkey from proto JSON and display it's address.
 
 Example:
-$ okp4d debug pubkey '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ"}'
+$ okp4d debug pubkey '\{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AurroA7jvfPd1AadmmOvWM2rJSwipXfRf8yD6pLbA2DJ"\}'
 
 ```
 okp4d debug pubkey [pubkey] [flags]

--- a/docs/command/okp4d_gentx.md
+++ b/docs/command/okp4d_gentx.md
@@ -59,7 +59,7 @@ okp4d gentx [key_name] [amount] [flags]
       --ledger                              Use a connected Ledger device
       --min-self-delegation string          The minimum self delegation required on the validator
       --moniker string                      The validator's (optional) moniker
-      --node string                         &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                         <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --node-id string                      The node's NodeID
       --note string                         Note to add a description to the transaction (previously --memo)
       --offline                             Offline mode (does not allow any online functionality)

--- a/docs/command/okp4d_keys.md
+++ b/docs/command/okp4d_keys.md
@@ -21,10 +21,10 @@ The keyring supports the following backends:
 
 kwallet and pass backends depend on external tools. Refer to their respective documentation for more
 information:
-    KWallet     <https://github.com/KDE/kwallet>
-    pass        <https://www.passwordstore.org/>
+    KWallet     [https://github.com/KDE/kwallet](https://github.com/KDE/kwallet)
+    pass        [https://www.passwordstore.org/](https://www.passwordstore.org/)
 
-The pass backend requires GnuPG: <https://gnupg.org/>
+The pass backend requires GnuPG: [https://gnupg.org/](https://gnupg.org/)
 
 ### Options
 

--- a/docs/command/okp4d_keys_add.md
+++ b/docs/command/okp4d_keys_add.md
@@ -24,7 +24,7 @@ Example:
     keys add mymultisig --multisig "keyname1,keyname2,keyname3" --multisig-threshold 2
 
 ```
-okp4d keys add &lt;name&gt; [flags]
+okp4d keys add <name> [flags]
 ```
 
 ### Options
@@ -43,7 +43,7 @@ okp4d keys add &lt;name&gt; [flags]
       --multisig-threshold int   K out of N required signatures. For use in conjunction with --multisig (default 1)
       --no-backup                Don't print out seed phrase (if others are watching the terminal)
       --nosort                   Keys passed to --multisig are taken in the order they're supplied
-      --pubkey string            Parse a public key in JSON format and saves key info to &lt;name&gt; file.
+      --pubkey string            Parse a public key in JSON format and saves key info to <name> file.
       --recover                  Provide seed phrase to recover existing key instead of creating
 ```
 

--- a/docs/command/okp4d_keys_delete.md
+++ b/docs/command/okp4d_keys_delete.md
@@ -11,7 +11,7 @@ only the public key references stored locally, i.e.
 private keys stored in a ledger device cannot be deleted with the CLI.
 
 ```
-okp4d keys delete &lt;name&gt;... [flags]
+okp4d keys delete <name>... [flags]
 ```
 
 ### Options

--- a/docs/command/okp4d_keys_export.md
+++ b/docs/command/okp4d_keys_export.md
@@ -14,7 +14,7 @@ FULLY AWARE OF THE RISKS. If you are unsure, you may want to do some research
 and export your keys in ASCII-armored encrypted format.
 
 ```
-okp4d keys export &lt;name&gt; [flags]
+okp4d keys export <name> [flags]
 ```
 
 ### Options

--- a/docs/command/okp4d_keys_import.md
+++ b/docs/command/okp4d_keys_import.md
@@ -7,7 +7,7 @@ Import private keys into the local keybase
 Import a ASCII armored private key into the local keybase.
 
 ```
-okp4d keys import &lt;name&gt; &lt;keyfile&gt; [flags]
+okp4d keys import <name> <keyfile> [flags]
 ```
 
 ### Options

--- a/docs/command/okp4d_keys_migrate.md
+++ b/docs/command/okp4d_keys_migrate.md
@@ -10,7 +10,7 @@ If this is the case, the key is already migrated. Therefore, we skip it and cont
 Otherwise, we try to deserialize it using Amino into LegacyInfo. If this attempt is successful, we serialize
 LegacyInfo to Protobuf serialization format and overwrite the keyring entry. If any error occurred, it will be
 outputted in CLI and migration will be continued until all keys in the keyring DB are exhausted.
-See <https://github.com/cosmos/cosmos-sdk/pull/9695> for more details.
+See [https://github.com/cosmos/cosmos-sdk/pull/9695](https://github.com/cosmos/cosmos-sdk/pull/9695)  for more details.
 
 It is recommended to run in 'dry-run' mode first to verify all key migration material.
 

--- a/docs/command/okp4d_query_account.md
+++ b/docs/command/okp4d_query_account.md
@@ -13,7 +13,7 @@ okp4d query account [address] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for account
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_auth_account.md
+++ b/docs/command/okp4d_query_auth_account.md
@@ -13,7 +13,7 @@ okp4d query auth account [address] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for account
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_auth_accounts.md
+++ b/docs/command/okp4d_query_auth_accounts.md
@@ -15,7 +15,7 @@ okp4d query auth accounts [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for accounts
       --limit uint         pagination limit of all-accounts to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of all-accounts to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of all-accounts to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_auth_address-by-acc-num.md
+++ b/docs/command/okp4d_query_auth_address-by-acc-num.md
@@ -19,7 +19,7 @@ okp4d q auth address-by-acc-num 1
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for address-by-acc-num
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_auth_module-account.md
+++ b/docs/command/okp4d_query_auth_module-account.md
@@ -19,7 +19,7 @@ okp4d q auth module-account auth
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for module-account
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_auth_module-accounts.md
+++ b/docs/command/okp4d_query_auth_module-accounts.md
@@ -13,7 +13,7 @@ okp4d query auth module-accounts [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for module-accounts
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_auth_params.md
+++ b/docs/command/okp4d_query_auth_params.md
@@ -19,7 +19,7 @@ okp4d query auth params [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_authz_grants-by-grantee.md
+++ b/docs/command/okp4d_query_authz_grants-by-grantee.md
@@ -21,7 +21,7 @@ okp4d query authz grants-by-grantee [grantee-addr] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for grants-by-grantee
       --limit uint         pagination limit of grantee-grants to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of grantee-grants to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of grantee-grants to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_authz_grants-by-granter.md
+++ b/docs/command/okp4d_query_authz_grants-by-granter.md
@@ -21,7 +21,7 @@ okp4d query authz grants-by-granter [granter-addr] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for grants-by-granter
       --limit uint         pagination limit of granter-grants to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of granter-grants to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of granter-grants to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_authz_grants.md
+++ b/docs/command/okp4d_query_authz_grants.md
@@ -23,7 +23,7 @@ okp4d query authz grants [granter-addr] [grantee-addr] [msg-type-url]? [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for grants
       --limit uint         pagination limit of grants to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of grants to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of grants to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_bank_balances.md
+++ b/docs/command/okp4d_query_bank_balances.md
@@ -24,7 +24,7 @@ okp4d query bank balances [address] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for balances
       --limit uint         pagination limit of all balances to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of all balances to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of all balances to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_bank_denom-metadata.md
+++ b/docs/command/okp4d_query_bank_denom-metadata.md
@@ -25,7 +25,7 @@ okp4d query bank denom-metadata [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for denom-metadata
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_bank_send-enabled.md
+++ b/docs/command/okp4d_query_bank_send-enabled.md
@@ -35,7 +35,7 @@ Getting all entries:
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for send-enabled
       --limit uint         pagination limit of send enabled entries to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of send enabled entries to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of send enabled entries to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_bank_spendable-balances.md
+++ b/docs/command/okp4d_query_bank_spendable-balances.md
@@ -9,7 +9,7 @@ okp4d query bank spendable-balances [address] [flags]
 ### Examples
 
 ```
-okp4d query bank spendable-balances [address]
+$ okp4d query bank spendable-balances [address]
 ```
 
 ### Options
@@ -22,7 +22,7 @@ okp4d query bank spendable-balances [address]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for spendable-balances
       --limit uint         pagination limit of spendable balances to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of spendable balances to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of spendable balances to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_bank_total.md
+++ b/docs/command/okp4d_query_bank_total.md
@@ -26,7 +26,7 @@ okp4d query bank total [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for total
       --limit uint         pagination limit of all supply totals to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of all supply totals to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of all supply totals to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_distribution_commission.md
+++ b/docs/command/okp4d_query_distribution_commission.md
@@ -20,7 +20,7 @@ okp4d query distribution commission [validator] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for commission
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_distribution_community-pool.md
+++ b/docs/command/okp4d_query_distribution_community-pool.md
@@ -20,7 +20,7 @@ okp4d query distribution community-pool [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for community-pool
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_distribution_params.md
+++ b/docs/command/okp4d_query_distribution_params.md
@@ -13,7 +13,7 @@ okp4d query distribution params [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_distribution_rewards.md
+++ b/docs/command/okp4d_query_distribution_rewards.md
@@ -21,7 +21,7 @@ okp4d query distribution rewards [delegator-addr] [validator-addr] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for rewards
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_distribution_slashes.md
+++ b/docs/command/okp4d_query_distribution_slashes.md
@@ -22,7 +22,7 @@ okp4d query distribution slashes [validator] [start-height] [end-height] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for slashes
       --limit uint         pagination limit of validator slashes to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of validator slashes to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of validator slashes to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_distribution_validator-distribution-info.md
+++ b/docs/command/okp4d_query_distribution_validator-distribution-info.md
@@ -19,7 +19,7 @@ okp4d query distribution validator-distribution-info [validator] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for validator-distribution-info
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_distribution_validator-outstanding-rewards.md
+++ b/docs/command/okp4d_query_distribution_validator-outstanding-rewards.md
@@ -20,7 +20,7 @@ okp4d query distribution validator-outstanding-rewards [validator] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for validator-outstanding-rewards
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_evidence.md
+++ b/docs/command/okp4d_query_evidence.md
@@ -23,7 +23,7 @@ okp4d query evidence [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for evidence
       --limit uint         pagination limit of evidence to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of evidence to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of evidence to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_feegrant_grant.md
+++ b/docs/command/okp4d_query_feegrant_grant.md
@@ -21,7 +21,7 @@ okp4d query feegrant grant [granter] [grantee] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for grant
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_feegrant_grants-by-grantee.md
+++ b/docs/command/okp4d_query_feegrant_grants-by-grantee.md
@@ -22,7 +22,7 @@ okp4d query feegrant grants-by-grantee [grantee] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for grants-by-grantee
       --limit uint         pagination limit of grants to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of grants to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of grants to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_feegrant_grants-by-granter.md
+++ b/docs/command/okp4d_query_feegrant_grants-by-granter.md
@@ -22,7 +22,7 @@ okp4d query feegrant grants-by-granter [granter] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for grants-by-granter
       --limit uint         pagination limit of grants to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of grants to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of grants to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_gov_deposit.md
+++ b/docs/command/okp4d_query_gov_deposit.md
@@ -20,7 +20,7 @@ okp4d query gov deposit [proposal-id] [depositer-addr] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for deposit
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_deposits.md
+++ b/docs/command/okp4d_query_gov_deposits.md
@@ -23,7 +23,7 @@ okp4d query gov deposits [proposal-id] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for deposits
       --limit uint         pagination limit of deposits to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of deposits to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of deposits to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_gov_param.md
+++ b/docs/command/okp4d_query_gov_param.md
@@ -21,7 +21,7 @@ okp4d query gov param [param-type] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for param
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_params.md
+++ b/docs/command/okp4d_query_gov_params.md
@@ -20,7 +20,7 @@ okp4d query gov params [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_proposal.md
+++ b/docs/command/okp4d_query_gov_proposal.md
@@ -21,7 +21,7 @@ okp4d query gov proposal [proposal-id] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for proposal
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_proposals.md
+++ b/docs/command/okp4d_query_gov_proposals.md
@@ -26,7 +26,7 @@ okp4d query gov proposals [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for proposals
       --limit uint         pagination limit of proposals to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of proposals to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of proposals to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_gov_proposer.md
+++ b/docs/command/okp4d_query_gov_proposer.md
@@ -20,7 +20,7 @@ okp4d query gov proposer [proposal-id] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for proposer
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_tally.md
+++ b/docs/command/okp4d_query_gov_tally.md
@@ -21,7 +21,7 @@ okp4d query gov tally [proposal-id] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for tally
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_vote.md
+++ b/docs/command/okp4d_query_gov_vote.md
@@ -20,7 +20,7 @@ okp4d query gov vote [proposal-id] [voter-addr] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for vote
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_gov_votes.md
+++ b/docs/command/okp4d_query_gov_votes.md
@@ -23,7 +23,7 @@ okp4d query gov votes [proposal-id] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for votes
       --limit uint         pagination limit of votes to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of votes to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of votes to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_group_group-info.md
+++ b/docs/command/okp4d_query_group_group-info.md
@@ -13,7 +13,7 @@ okp4d query group group-info [id] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for group-info
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_group-members.md
+++ b/docs/command/okp4d_query_group_group-members.md
@@ -15,7 +15,7 @@ okp4d query group group-members [id] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for group-members
       --limit uint         pagination limit of group-members to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of group-members to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of group-members to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_group_group-policies-by-admin.md
+++ b/docs/command/okp4d_query_group_group-policies-by-admin.md
@@ -15,7 +15,7 @@ okp4d query group group-policies-by-admin [admin] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for group-policies-by-admin
       --limit uint         pagination limit of group-policies-by-admin to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of group-policies-by-admin to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of group-policies-by-admin to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_group_group-policies-by-group.md
+++ b/docs/command/okp4d_query_group_group-policies-by-group.md
@@ -15,7 +15,7 @@ okp4d query group group-policies-by-group [group-id] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for group-policies-by-group
       --limit uint         pagination limit of groups-policies-by-group to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of groups-policies-by-group to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of groups-policies-by-group to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_group_group-policy-info.md
+++ b/docs/command/okp4d_query_group_group-policy-info.md
@@ -13,7 +13,7 @@ okp4d query group group-policy-info [group-policy-account] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for group-policy-info
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_groups-by-admin.md
+++ b/docs/command/okp4d_query_group_groups-by-admin.md
@@ -15,7 +15,7 @@ okp4d query group groups-by-admin [admin] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for groups-by-admin
       --limit uint         pagination limit of groups-by-admin to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of groups-by-admin to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of groups-by-admin to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_group_groups-by-member.md
+++ b/docs/command/okp4d_query_group_groups-by-member.md
@@ -15,7 +15,7 @@ okp4d query group groups-by-member [address] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for groups-by-member
       --limit uint         pagination limit of groups-by-members to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of groups-by-members to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of groups-by-members to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_group_groups.md
+++ b/docs/command/okp4d_query_group_groups.md
@@ -15,7 +15,7 @@ okp4d query group groups [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for groups
       --limit uint         pagination limit of groups to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of groups to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of groups to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_group_proposal.md
+++ b/docs/command/okp4d_query_group_proposal.md
@@ -13,7 +13,7 @@ okp4d query group proposal [id] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for proposal
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_proposals-by-group-policy.md
+++ b/docs/command/okp4d_query_group_proposals-by-group-policy.md
@@ -15,7 +15,7 @@ okp4d query group proposals-by-group-policy [group-policy-account] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for proposals-by-group-policy
       --limit uint         pagination limit of proposals-by-group-policy to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of proposals-by-group-policy to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of proposals-by-group-policy to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_group_tally-result.md
+++ b/docs/command/okp4d_query_group_tally-result.md
@@ -13,7 +13,7 @@ okp4d query group tally-result [proposal-id] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for tally-result
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_vote.md
+++ b/docs/command/okp4d_query_group_vote.md
@@ -13,7 +13,7 @@ okp4d query group vote [proposal-id] [voter] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for vote
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_group_votes-by-proposal.md
+++ b/docs/command/okp4d_query_group_votes-by-proposal.md
@@ -15,7 +15,7 @@ okp4d query group votes-by-proposal [proposal-id] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for votes-by-proposal
       --limit uint         pagination limit of votes-by-proposal to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of votes-by-proposal to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of votes-by-proposal to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_group_votes-by-voter.md
+++ b/docs/command/okp4d_query_group_votes-by-voter.md
@@ -15,7 +15,7 @@ okp4d query group votes-by-voter [voter] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for votes-by-voter
       --limit uint         pagination limit of votes-by-voter to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of votes-by-voter to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of votes-by-voter to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc-fee_channel.md
+++ b/docs/command/okp4d_query_ibc-fee_channel.md
@@ -23,7 +23,7 @@ okp4d query ibc-fee channel transfer channel-6
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for channel
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_channels.md
+++ b/docs/command/okp4d_query_ibc-fee_channels.md
@@ -25,7 +25,7 @@ okp4d query ibc-fee channels
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for channels
       --limit uint         pagination limit of channels to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of channels to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of channels to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc-fee_counterparty-payee.md
+++ b/docs/command/okp4d_query_ibc-fee_counterparty-payee.md
@@ -23,7 +23,7 @@ okp4d query ibc-fee counterparty-payee channel-5 cosmos1layxcsmyye0dc0har9sdfzwc
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for counterparty-payee
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_packet.md
+++ b/docs/command/okp4d_query_ibc-fee_packet.md
@@ -23,7 +23,7 @@ okp4d query ibc-fee packet
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for packet
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_packets-for-channel.md
+++ b/docs/command/okp4d_query_ibc-fee_packets-for-channel.md
@@ -25,7 +25,7 @@ okp4d query ibc-fee packets-for-channel
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for packets-for-channel
       --limit uint         pagination limit of packets-for-channel to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of packets-for-channel to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of packets-for-channel to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc-fee_packets.md
+++ b/docs/command/okp4d_query_ibc-fee_packets.md
@@ -25,7 +25,7 @@ okp4d query ibc-fee packets
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for packets
       --limit uint         pagination limit of packets to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of packets to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of packets to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc-fee_payee.md
+++ b/docs/command/okp4d_query_ibc-fee_payee.md
@@ -23,7 +23,7 @@ okp4d query ibc-fee payee channel-5 cosmos1layxcsmyye0dc0har9sdfzwckaz8sjwlfsj8z
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for payee
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_total-ack-fees.md
+++ b/docs/command/okp4d_query_ibc-fee_total-ack-fees.md
@@ -23,7 +23,7 @@ okp4d query ibc-fee total-ack-fees transfer channel-5 100
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for total-ack-fees
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_total-recv-fees.md
+++ b/docs/command/okp4d_query_ibc-fee_total-recv-fees.md
@@ -23,7 +23,7 @@ okp4d query ibc-fee total-recv-fees transfer channel-5 100
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for total-recv-fees
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-fee_total-timeout-fees.md
+++ b/docs/command/okp4d_query_ibc-fee_total-timeout-fees.md
@@ -23,7 +23,7 @@ okp4d query ibc-fee total-timeout-fees transfer channel-5 100
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for total-timeout-fees
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-transfer_denom-hash.md
+++ b/docs/command/okp4d_query_ibc-transfer_denom-hash.md
@@ -23,7 +23,7 @@ okp4d query ibc-transfer denom-hash transfer/channel-0/uatom
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for denom-hash
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-transfer_denom-trace.md
+++ b/docs/command/okp4d_query_ibc-transfer_denom-trace.md
@@ -23,7 +23,7 @@ okp4d query ibc-transfer denom-trace 27A6394C3F9FF9C9DCF5DFFADF9BB5FE9A37C7E92B0
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for denom-trace
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-transfer_denom-traces.md
+++ b/docs/command/okp4d_query_ibc-transfer_denom-traces.md
@@ -25,7 +25,7 @@ okp4d query ibc-transfer denom-traces
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for denom-traces
       --limit uint         pagination limit of denominations trace to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of denominations trace to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of denominations trace to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc-transfer_escrow-address.md
+++ b/docs/command/okp4d_query_ibc-transfer_escrow-address.md
@@ -23,7 +23,7 @@ okp4d query ibc-transfer escrow-address [port] [channel-id]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for escrow-address
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-transfer_params.md
+++ b/docs/command/okp4d_query_ibc-transfer_params.md
@@ -23,7 +23,7 @@ okp4d query ibc-transfer params
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc-transfer_total-escrow.md
+++ b/docs/command/okp4d_query_ibc-transfer_total-escrow.md
@@ -23,7 +23,7 @@ okp4d query ibc-transfer total-escrow uosmo
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for total-escrow
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_channel_channels.md
+++ b/docs/command/okp4d_query_ibc_channel_channels.md
@@ -25,7 +25,7 @@ okp4d query ibc channel channels
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for channels
       --limit uint         pagination limit of channels to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of channels to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of channels to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_channel_client-state.md
+++ b/docs/command/okp4d_query_ibc_channel_client-state.md
@@ -23,7 +23,7 @@ okp4d query ibc channel client-state [port-id] [channel-id]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for client-state
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_channel_connections.md
+++ b/docs/command/okp4d_query_ibc_channel_connections.md
@@ -25,7 +25,7 @@ okp4d query ibc channel connections [connection-id]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for connections
       --limit uint         pagination limit of channels associated with a connection to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of channels associated with a connection to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of channels associated with a connection to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_channel_end.md
+++ b/docs/command/okp4d_query_ibc_channel_end.md
@@ -23,7 +23,7 @@ okp4d query ibc channel end [port-id] [channel-id]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for end
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
       --prove              show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_channel_next-sequence-receive.md
+++ b/docs/command/okp4d_query_ibc_channel_next-sequence-receive.md
@@ -23,7 +23,7 @@ okp4d query ibc channel next-sequence-receive [port-id] [channel-id]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for next-sequence-receive
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
       --prove              show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_channel_packet-ack.md
+++ b/docs/command/okp4d_query_ibc_channel_packet-ack.md
@@ -23,7 +23,7 @@ okp4d query ibc channel packet-ack [port-id] [channel-id] [sequence]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for packet-ack
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
       --prove              show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_channel_packet-commitment.md
+++ b/docs/command/okp4d_query_ibc_channel_packet-commitment.md
@@ -23,7 +23,7 @@ okp4d query ibc channel packet-commitment [port-id] [channel-id] [sequence]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for packet-commitment
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
       --prove              show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_channel_packet-commitments.md
+++ b/docs/command/okp4d_query_ibc_channel_packet-commitments.md
@@ -25,7 +25,7 @@ okp4d query ibc channel packet-commitments [port-id] [channel-id]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for packet-commitments
       --limit uint         pagination limit of packet commitments associated with a channel to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of packet commitments associated with a channel to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of packet commitments associated with a channel to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_channel_packet-receipt.md
+++ b/docs/command/okp4d_query_ibc_channel_packet-receipt.md
@@ -23,7 +23,7 @@ okp4d query ibc channel packet-receipt [port-id] [channel-id] [sequence]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for packet-receipt
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
       --prove              show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_channel_unreceived-acks.md
+++ b/docs/command/okp4d_query_ibc_channel_unreceived-acks.md
@@ -27,7 +27,7 @@ okp4d query ibc channel unreceived-acks [port-id] [channel-id] --sequences=1,2,3
       --grpc-insecure          allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int             Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help                   help for unreceived-acks
-      --node string            &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string            <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string          Output format (text|json) (default "text")
       --sequences int64Slice   comma separated list of packet sequence numbers (default [])
 ```

--- a/docs/command/okp4d_query_ibc_channel_unreceived-packets.md
+++ b/docs/command/okp4d_query_ibc_channel_unreceived-packets.md
@@ -27,7 +27,7 @@ okp4d query ibc channel unreceived-packets [port-id] [channel-id] --sequences=1,
       --grpc-insecure          allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int             Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help                   help for unreceived-packets
-      --node string            &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string            <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string          Output format (text|json) (default "text")
       --sequences int64Slice   comma separated list of packet sequence numbers (default [])
 ```

--- a/docs/command/okp4d_query_ibc_client_consensus-state-heights.md
+++ b/docs/command/okp4d_query_ibc_client_consensus-state-heights.md
@@ -25,7 +25,7 @@ okp4d query ibc client consensus-state-heights [client-id]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for consensus-state-heights
       --limit uint         pagination limit of consensus state heights to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of consensus state heights to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of consensus state heights to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_client_consensus-state.md
+++ b/docs/command/okp4d_query_ibc_client_consensus-state.md
@@ -25,7 +25,7 @@ okp4d query ibc client  consensus-state [client-id] [height]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for consensus-state
       --latest-height      return latest stored consensus state
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
       --prove              show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_client_consensus-states.md
+++ b/docs/command/okp4d_query_ibc_client_consensus-states.md
@@ -25,7 +25,7 @@ okp4d query ibc client consensus-states [client-id]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for consensus-states
       --limit uint         pagination limit of consensus states to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of consensus states to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of consensus states to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_client_header.md
+++ b/docs/command/okp4d_query_ibc_client_header.md
@@ -23,7 +23,7 @@ okp4d query ibc client  header
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for header
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_client_params.md
+++ b/docs/command/okp4d_query_ibc_client_params.md
@@ -23,7 +23,7 @@ okp4d query ibc client params
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_client_self-consensus-state.md
+++ b/docs/command/okp4d_query_ibc_client_self-consensus-state.md
@@ -23,7 +23,7 @@ okp4d query ibc client self-consensus-state
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for self-consensus-state
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_client_state.md
+++ b/docs/command/okp4d_query_ibc_client_state.md
@@ -23,7 +23,7 @@ okp4d query ibc client state [client-id]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for state
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
       --prove              show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_client_states.md
+++ b/docs/command/okp4d_query_ibc_client_states.md
@@ -25,7 +25,7 @@ okp4d query ibc client states
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for states
       --limit uint         pagination limit of client states to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of client states to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of client states to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_client_status.md
+++ b/docs/command/okp4d_query_ibc_client_status.md
@@ -23,7 +23,7 @@ okp4d query ibc client status [client-id]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for status
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_connection_connections.md
+++ b/docs/command/okp4d_query_ibc_connection_connections.md
@@ -25,7 +25,7 @@ okp4d query ibc connection connections
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for connections
       --limit uint         pagination limit of connection ends to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of connection ends to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of connection ends to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_ibc_connection_end.md
+++ b/docs/command/okp4d_query_ibc_connection_end.md
@@ -23,7 +23,7 @@ okp4d query ibc connection end [connection-id]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for end
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
       --prove              show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_ibc_connection_params.md
+++ b/docs/command/okp4d_query_ibc_connection_params.md
@@ -23,7 +23,7 @@ okp4d query ibc connection params
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_ibc_connection_path.md
+++ b/docs/command/okp4d_query_ibc_connection_path.md
@@ -23,7 +23,7 @@ okp4d query  ibc connection path [client-id]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for path
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
       --prove              show proofs for the query results (default true)
 ```

--- a/docs/command/okp4d_query_interchain-accounts_controller_interchain-account.md
+++ b/docs/command/okp4d_query_interchain-accounts_controller_interchain-account.md
@@ -23,7 +23,7 @@ okp4d query interchain-accounts controller interchain-account cosmos1layxcsmyye0
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for interchain-account
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_interchain-accounts_controller_params.md
+++ b/docs/command/okp4d_query_interchain-accounts_controller_params.md
@@ -23,7 +23,7 @@ okp4d query interchain-accounts controller params
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_interchain-accounts_host_packet-events.md
+++ b/docs/command/okp4d_query_interchain-accounts_host_packet-events.md
@@ -23,7 +23,7 @@ okp4d query interchain-accounts host packet-events channel-0 100
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for packet-events
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_interchain-accounts_host_params.md
+++ b/docs/command/okp4d_query_interchain-accounts_host_params.md
@@ -23,7 +23,7 @@ okp4d query interchain-accounts host params
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_logic_ask.md
+++ b/docs/command/okp4d_query_logic_ask.md
@@ -19,7 +19,7 @@ okp4d query logic ask [query] [flags]
 ### Examples
 
 ```
-okp4d query logic ask "chain_id(X)." # returns the chain-id
+$ okp4d query logic ask "chain_id(X)." # returns the chain-id
 ```
 
 ### Options
@@ -29,7 +29,7 @@ okp4d query logic ask "chain_id(X)." # returns the chain-id
       --grpc-insecure         allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int            Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help                  help for ask
-      --node string           &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string           <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string         Output format (text|json) (default "text")
       --program string        reads the program from the given string.
       --program-file string   reads the program from the given filename or from stdin if "-" is passed as the filename.

--- a/docs/command/okp4d_query_logic_params.md
+++ b/docs/command/okp4d_query_logic_params.md
@@ -13,7 +13,7 @@ okp4d query logic params [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_mint_annual-provisions.md
+++ b/docs/command/okp4d_query_mint_annual-provisions.md
@@ -13,7 +13,7 @@ okp4d query mint annual-provisions [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for annual-provisions
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_mint_inflation.md
+++ b/docs/command/okp4d_query_mint_inflation.md
@@ -13,7 +13,7 @@ okp4d query mint inflation [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for inflation
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_mint_params.md
+++ b/docs/command/okp4d_query_mint_params.md
@@ -13,7 +13,7 @@ okp4d query mint params [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_params_subspace.md
+++ b/docs/command/okp4d_query_params_subspace.md
@@ -13,7 +13,7 @@ okp4d query params subspace [subspace] [key] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for subspace
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_slashing_params.md
+++ b/docs/command/okp4d_query_slashing_params.md
@@ -19,7 +19,7 @@ okp4d query slashing params [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_slashing_signing-info.md
+++ b/docs/command/okp4d_query_slashing_signing-info.md
@@ -6,7 +6,7 @@ Query a validator's signing information
 
 Use a validators' consensus public key to find the signing-info for that validator:
 
-$ okp4d query slashing signing-info '{"@type":"/cosmos.crypto.ed25519.PubKey","key":"OauFcTKbN5Lx3fJL689cikXBqe+hcp6Y+x0rYUdR9Jk="}'
+$ okp4d query slashing signing-info '\{"@type":"/cosmos.crypto.ed25519.PubKey","key":"OauFcTKbN5Lx3fJL689cikXBqe+hcp6Y+x0rYUdR9Jk="\}'
 
 ```
 okp4d query slashing signing-info [validator-conspub] [flags]
@@ -19,7 +19,7 @@ okp4d query slashing signing-info [validator-conspub] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for signing-info
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_slashing_signing-infos.md
+++ b/docs/command/okp4d_query_slashing_signing-infos.md
@@ -21,7 +21,7 @@ okp4d query slashing signing-infos [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for signing-infos
       --limit uint         pagination limit of signing infos to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of signing infos to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of signing infos to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_delegation.md
+++ b/docs/command/okp4d_query_staking_delegation.md
@@ -20,7 +20,7 @@ okp4d query staking delegation [delegator-addr] [validator-addr] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for delegation
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_delegations-to.md
+++ b/docs/command/okp4d_query_staking_delegations-to.md
@@ -22,7 +22,7 @@ okp4d query staking delegations-to [validator-addr] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for delegations-to
       --limit uint         pagination limit of validator delegations to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of validator delegations to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of validator delegations to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_delegations.md
+++ b/docs/command/okp4d_query_staking_delegations.md
@@ -22,7 +22,7 @@ okp4d query staking delegations [delegator-addr] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for delegations
       --limit uint         pagination limit of delegations to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of delegations to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of delegations to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_historical-info.md
+++ b/docs/command/okp4d_query_staking_historical-info.md
@@ -20,7 +20,7 @@ okp4d query staking historical-info [height] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for historical-info
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_params.md
+++ b/docs/command/okp4d_query_staking_params.md
@@ -20,7 +20,7 @@ okp4d query staking params [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_pool.md
+++ b/docs/command/okp4d_query_staking_pool.md
@@ -20,7 +20,7 @@ okp4d query staking pool [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for pool
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_redelegation.md
+++ b/docs/command/okp4d_query_staking_redelegation.md
@@ -20,7 +20,7 @@ okp4d query staking redelegation [delegator-addr] [src-validator-addr] [dst-vali
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for redelegation
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_redelegations-from.md
+++ b/docs/command/okp4d_query_staking_redelegations-from.md
@@ -22,7 +22,7 @@ okp4d query staking redelegations-from [validator-addr] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for redelegations-from
       --limit uint         pagination limit of validator redelegations to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of validator redelegations to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of validator redelegations to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_redelegations.md
+++ b/docs/command/okp4d_query_staking_redelegations.md
@@ -22,7 +22,7 @@ okp4d query staking redelegations [delegator-addr] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for redelegations
       --limit uint         pagination limit of delegator redelegations to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of delegator redelegations to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of delegator redelegations to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_unbonding-delegation.md
+++ b/docs/command/okp4d_query_staking_unbonding-delegation.md
@@ -20,7 +20,7 @@ okp4d query staking unbonding-delegation [delegator-addr] [validator-addr] [flag
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for unbonding-delegation
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_unbonding-delegations-from.md
+++ b/docs/command/okp4d_query_staking_unbonding-delegations-from.md
@@ -22,7 +22,7 @@ okp4d query staking unbonding-delegations-from [validator-addr] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for unbonding-delegations-from
       --limit uint         pagination limit of unbonding delegations to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of unbonding delegations to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of unbonding delegations to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_unbonding-delegations.md
+++ b/docs/command/okp4d_query_staking_unbonding-delegations.md
@@ -22,7 +22,7 @@ okp4d query staking unbonding-delegations [delegator-addr] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for unbonding-delegations
       --limit uint         pagination limit of unbonding delegations to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of unbonding delegations to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of unbonding delegations to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_staking_validator.md
+++ b/docs/command/okp4d_query_staking_validator.md
@@ -20,7 +20,7 @@ okp4d query staking validator [validator-addr] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for validator
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_staking_validators.md
+++ b/docs/command/okp4d_query_staking_validators.md
@@ -22,7 +22,7 @@ okp4d query staking validators [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for validators
       --limit uint         pagination limit of validators to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of validators to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of validators to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_tendermint-validator-set.md
+++ b/docs/command/okp4d_query_tendermint-validator-set.md
@@ -11,7 +11,7 @@ okp4d query tendermint-validator-set [height] [flags]
 ```
   -h, --help            help for tendermint-validator-set
       --limit int       Query number of results returned per page (default 100)
-      --node string     &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string     <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string   Output format (text|json) (default "text")
       --page int        Query a specific page of paginated results (default 1)
 ```

--- a/docs/command/okp4d_query_tx.md
+++ b/docs/command/okp4d_query_tx.md
@@ -7,7 +7,7 @@ Query for a transaction by hash, "&lt;addr&gt;/&lt;seq&gt;" combination or comma
 Example:
 $ okp4d query tx &lt;hash&gt;
 $ okp4d query tx --type=acc_seq &lt;addr&gt;/&lt;sequence&gt;
-$ okp4d query tx --type=signature <sig1_base64>,<sig2_base64...>
+$ okp4d query tx --type=signature &lt;sig1_base64&gt;,&lt;sig2_base64...&gt;
 
 ```
 okp4d query tx --type=[hash|acc_seq|signature] [hash|acc_seq|signature] [flags]
@@ -20,7 +20,7 @@ okp4d query tx --type=[hash|acc_seq|signature] [hash|acc_seq|signature] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for tx
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
       --type string        The type to be used when querying tx, can be one of "hash", "acc_seq", "signature" (default "hash")
 ```

--- a/docs/command/okp4d_query_txs.md
+++ b/docs/command/okp4d_query_txs.md
@@ -5,7 +5,7 @@ Query for paginated transactions that match a set of events
 ### Synopsis
 
 Search for transactions that match the exact given events where results are paginated.
-Each event takes the form of '{eventType}.{eventAttribute}={value}'. Please refer
+Each event takes the form of '\{eventType\}.\{eventAttribute\}=\{value\}'. Please refer
 to each module's documentation for the full set of events to query for. Each module
 documents its respective events under 'xx_events.md'.
 
@@ -25,7 +25,7 @@ okp4d query txs [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for txs
       --limit int          Query number of transactions results per page returned (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
       --page int           Query a specific page of paginated results (default 1)
 ```

--- a/docs/command/okp4d_query_upgrade_applied.md
+++ b/docs/command/okp4d_query_upgrade_applied.md
@@ -18,7 +18,7 @@ okp4d query upgrade applied [upgrade-name] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for applied
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_upgrade_module_versions.md
+++ b/docs/command/okp4d_query_upgrade_module_versions.md
@@ -19,7 +19,7 @@ okp4d query upgrade module_versions [optional module_name] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for module_versions
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_upgrade_plan.md
+++ b/docs/command/okp4d_query_upgrade_plan.md
@@ -17,7 +17,7 @@ okp4d query upgrade plan [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for plan
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_code-info.md
+++ b/docs/command/okp4d_query_wasm_code-info.md
@@ -17,7 +17,7 @@ okp4d query wasm code-info [code_id] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for code-info
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_code.md
+++ b/docs/command/okp4d_query_wasm_code.md
@@ -17,7 +17,7 @@ okp4d query wasm code [code_id] [output filename] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for code
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_contract-history.md
+++ b/docs/command/okp4d_query_wasm_contract-history.md
@@ -19,7 +19,7 @@ okp4d query wasm contract-history [bech32_address] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for contract-history
       --limit uint         pagination limit of contract history to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of contract history to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of contract history to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_wasm_contract-state_all.md
+++ b/docs/command/okp4d_query_wasm_contract-state_all.md
@@ -19,7 +19,7 @@ okp4d query wasm contract-state all [bech32_address] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for all
       --limit uint         pagination limit of contract state to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of contract state to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of contract state to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_wasm_contract-state_raw.md
+++ b/docs/command/okp4d_query_wasm_contract-state_raw.md
@@ -20,7 +20,7 @@ okp4d query wasm contract-state raw [bech32_address] [key] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for raw
       --hex                hex encoded key argument
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_contract-state_smart.md
+++ b/docs/command/okp4d_query_wasm_contract-state_smart.md
@@ -20,7 +20,7 @@ okp4d query wasm contract-state smart [bech32_address] [query] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for smart
       --hex                hex encoded query argument
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_contract.md
+++ b/docs/command/okp4d_query_wasm_contract.md
@@ -17,7 +17,7 @@ okp4d query wasm contract [bech32_address] [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for contract
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_list-code.md
+++ b/docs/command/okp4d_query_wasm_list-code.md
@@ -19,7 +19,7 @@ okp4d query wasm list-code [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for list-code
       --limit uint         pagination limit of list codes to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of list codes to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of list codes to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_wasm_list-contract-by-code.md
+++ b/docs/command/okp4d_query_wasm_list-contract-by-code.md
@@ -19,7 +19,7 @@ okp4d query wasm list-contract-by-code [code_id] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for list-contract-by-code
       --limit uint         pagination limit of list contracts by code to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of list contracts by code to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of list contracts by code to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_wasm_list-contracts-by-creator.md
+++ b/docs/command/okp4d_query_wasm_list-contracts-by-creator.md
@@ -19,7 +19,7 @@ okp4d query wasm list-contracts-by-creator [creator] [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for list-contracts-by-creator
       --limit uint         pagination limit of list contracts by creator to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of list contracts by creator to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of list contracts by creator to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_query_wasm_params.md
+++ b/docs/command/okp4d_query_wasm_params.md
@@ -13,7 +13,7 @@ okp4d query wasm params [flags]
       --grpc-insecure      allow gRPC over insecure channels, if not TLS the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for params
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
 ```
 

--- a/docs/command/okp4d_query_wasm_pinned.md
+++ b/docs/command/okp4d_query_wasm_pinned.md
@@ -19,7 +19,7 @@ okp4d query wasm pinned [flags]
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for pinned
       --limit uint         pagination limit of list codes to query for (default 100)
-      --node string        &lt;host&gt;:&lt;port&gt; to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
+      --node string        <host>:<port> to Tendermint RPC interface for this chain (default "tcp://localhost:26657")
       --offset uint        pagination offset of list codes to query for
   -o, --output string      Output format (text|json) (default "text")
       --page uint          pagination page of list codes to query for. This sets offset to a multiple of limit (default 1)

--- a/docs/command/okp4d_tx_authz_exec.md
+++ b/docs/command/okp4d_tx_authz_exec.md
@@ -7,7 +7,7 @@ execute tx on behalf of granter account
 execute tx on behalf of granter account:
 Example:
  $ okp4d tx authz exec tx.json --from grantee
- $ okp4d tx bank send &lt;granter&gt; &lt;recipient&gt; --from &lt;granter&gt; --chain-id &lt;chain-id&gt; --generate-only > tx.json && okp4d tx authz exec tx.json --from grantee
+ $ okp4d tx bank send &lt;granter&gt; &lt;recipient&gt; --from &lt;granter&gt; --chain-id &lt;chain-id&gt; --generate-only &gt; tx.json && okp4d tx authz exec tx.json --from grantee
 
 ```
 okp4d tx authz exec [tx-json-file] --from [grantee] [flags]
@@ -33,7 +33,7 @@ okp4d tx authz exec [tx-json-file] --from [grantee] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_authz_grant.md
+++ b/docs/command/okp4d_tx_authz_grant.md
@@ -11,7 +11,7 @@ Examples:
  $ okp4d tx authz grant cosmos1skjw.. generic --msg-type=/cosmos.gov.v1.MsgVote --from=cosmos1sk..
 
 ```
-okp4d tx authz grant &lt;grantee&gt; <authorization_type="send"|"generic"|"delegate"|"unbond"|"redelegate"> --from &lt;granter&gt; [flags]
+okp4d tx authz grant <grantee> <authorization_type="send"|"generic"|"delegate"|"unbond"|"redelegate"> --from <granter> [flags]
 ```
 
 ### Options
@@ -39,7 +39,7 @@ okp4d tx authz grant &lt;grantee&gt; <authorization_type="send"|"generic"|"deleg
       --keyring-dir string           The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                       Use a connected Ledger device
       --msg-type string              The Msg method name for which we are creating a GenericAuthorization
-      --node string                  &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                  <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                  Note to add a description to the transaction (previously --memo)
       --offline                      Offline mode (does not allow any online functionality)
   -o, --output string                Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_authz_revoke.md
+++ b/docs/command/okp4d_tx_authz_revoke.md
@@ -32,7 +32,7 @@ okp4d tx authz revoke [grantee] [msg-type-url] --from=[granter] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_bank_multi-send.md
+++ b/docs/command/okp4d_tx_bank_multi-send.md
@@ -34,7 +34,7 @@ okp4d tx bank multi-send [from_key_or_address] [to_address_1, to_address_2, ...]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_bank_send.md
+++ b/docs/command/okp4d_tx_bank_send.md
@@ -32,7 +32,7 @@ okp4d tx bank send [from_key_or_address] [to_address] [amount] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_broadcast.md
+++ b/docs/command/okp4d_tx_broadcast.md
@@ -35,7 +35,7 @@ okp4d tx broadcast [file_path] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_crisis_invariant-broken.md
+++ b/docs/command/okp4d_tx_crisis_invariant-broken.md
@@ -26,7 +26,7 @@ okp4d tx crisis invariant-broken [module-name] [invariant-route] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_decode.md
+++ b/docs/command/okp4d_tx_decode.md
@@ -27,7 +27,7 @@ okp4d tx decode [protobuf-byte-string] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_distribution_fund-community-pool.md
+++ b/docs/command/okp4d_tx_distribution_fund-community-pool.md
@@ -33,7 +33,7 @@ okp4d tx distribution fund-community-pool [amount] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_distribution_set-withdraw-addr.md
+++ b/docs/command/okp4d_tx_distribution_set-withdraw-addr.md
@@ -33,7 +33,7 @@ okp4d tx distribution set-withdraw-addr [withdraw-addr] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_distribution_withdraw-all-rewards.md
+++ b/docs/command/okp4d_tx_distribution_withdraw-all-rewards.md
@@ -35,7 +35,7 @@ okp4d tx distribution withdraw-all-rewards [flags]
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --max-msgs int             Limit the number of messages per tx (0 for unlimited)
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_distribution_withdraw-rewards.md
+++ b/docs/command/okp4d_tx_distribution_withdraw-rewards.md
@@ -36,7 +36,7 @@ okp4d tx distribution withdraw-rewards [validator-addr] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_encode.md
+++ b/docs/command/okp4d_tx_encode.md
@@ -32,7 +32,7 @@ okp4d tx encode [file] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_feegrant_grant.md
+++ b/docs/command/okp4d_tx_feegrant_grant.md
@@ -39,7 +39,7 @@ okp4d tx feegrant grant [granter_key_or_address] [grantee] [flags]
       --keyring-backend string     Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string         The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                     Use a connected Ledger device
-      --node string                &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                Note to add a description to the transaction (previously --memo)
       --offline                    Offline mode (does not allow any online functionality)
   -o, --output string              Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_feegrant_revoke.md
+++ b/docs/command/okp4d_tx_feegrant_revoke.md
@@ -34,7 +34,7 @@ okp4d tx feegrant revoke [granter] [grantee] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_deposit.md
+++ b/docs/command/okp4d_tx_gov_deposit.md
@@ -34,7 +34,7 @@ okp4d tx gov deposit [proposal-id] [deposit] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_draft-proposal.md
+++ b/docs/command/okp4d_tx_gov_draft-proposal.md
@@ -26,7 +26,7 @@ okp4d tx gov draft-proposal [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal.md
@@ -12,12 +12,12 @@ $ okp4d tx gov submit-legacy-proposal --proposal="path/to/proposal.json" --from 
 
 Where proposal.json contains:
 
-{
+\{
   "title": "Test Proposal",
   "description": "My awesome proposal",
   "type": "Text",
   "deposit": "10test"
-}
+\}
 
 Which is equivalent to:
 
@@ -49,7 +49,7 @@ okp4d tx gov submit-legacy-proposal [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_cancel-software-upgrade.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_cancel-software-upgrade.md
@@ -32,7 +32,7 @@ okp4d tx gov submit-legacy-proposal cancel-software-upgrade [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_ibc-upgrade.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_ibc-upgrade.md
@@ -7,14 +7,14 @@ Submit an IBC upgrade proposal
 Submit an IBC client breaking upgrade proposal along with an initial deposit.
 The client state specified is the upgraded client state representing the upgraded chain
 Example Upgraded Client State JSON:
-{
+\{
 	"@type":"/ibc.lightclients.tendermint.v1.ClientState",
  	"chain_id":"testchain1",
 	"unbonding_period":"1814400s",
-	"latest_height":{"revision_number":"0","revision_height":"2"},
-	"proof_specs":[{"leaf_spec":{"hash":"SHA256","prehash_key":"NO_HASH","prehash_value":"SHA256","length":"VAR_PROTO","prefix":"AA=="},"inner_spec":{"child_order":[0,1],"child_size":33,"min_prefix_length":4,"max_prefix_length":12,"empty_child":null,"hash":"SHA256"},"max_depth":0,"min_depth":0},{"leaf_spec":{"hash":"SHA256","prehash_key":"NO_HASH","prehash_value":"SHA256","length":"VAR_PROTO","prefix":"AA=="},"inner_spec":{"child_order":[0,1],"child_size":32,"min_prefix_length":1,"max_prefix_length":1,"empty_child":null,"hash":"SHA256"},"max_depth":0,"min_depth":0}],
+	"latest_height":\{"revision_number":"0","revision_height":"2"\},
+	"proof_specs":[\{"leaf_spec":\{"hash":"SHA256","prehash_key":"NO_HASH","prehash_value":"SHA256","length":"VAR_PROTO","prefix":"AA=="\},"inner_spec":\{"child_order":[0,1],"child_size":33,"min_prefix_length":4,"max_prefix_length":12,"empty_child":null,"hash":"SHA256"\},"max_depth":0,"min_depth":0\},\{"leaf_spec":\{"hash":"SHA256","prehash_key":"NO_HASH","prehash_value":"SHA256","length":"VAR_PROTO","prefix":"AA=="\},"inner_spec":\{"child_order":[0,1],"child_size":32,"min_prefix_length":1,"max_prefix_length":1,"empty_child":null,"hash":"SHA256"\},"max_depth":0,"min_depth":0\}],
 	"upgrade_path":["upgrade","upgradedIBCState"],
-}
+\}
 
 ```
 okp4d tx gov submit-legacy-proposal ibc-upgrade [name] [height] [path/to/upgraded_client_state.json] [flags]
@@ -42,7 +42,7 @@ okp4d tx gov submit-legacy-proposal ibc-upgrade [name] [height] [path/to/upgrade
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_param-change.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_param-change.md
@@ -17,22 +17,22 @@ Proper vetting of a parameter change proposal should prevent this from happening
 regardless.
 
 Example:
-$ okp4d tx gov submit-proposal param-change <path/to/proposal.json> --from=<key_or_address>
+$ okp4d tx gov submit-proposal param-change &lt;path/to/proposal.json&gt; --from=&lt;key_or_address&gt;
 
 Where proposal.json contains:
 
-{
+\{
   "title": "Staking Param Change",
   "description": "Update max validators",
   "changes": [
-    {
+    \{
       "subspace": "staking",
       "key": "MaxValidators",
       "value": 105
-    }
+    \}
   ],
   "deposit": "1000stake"
-}
+\}
 
 ```
 okp4d tx gov submit-legacy-proposal param-change [proposal-file] [flags]
@@ -58,7 +58,7 @@ okp4d tx gov submit-legacy-proposal param-change [proposal-file] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_software-upgrade.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_software-upgrade.md
@@ -6,7 +6,7 @@ Submit a software upgrade proposal
 
 Submit a software upgrade along with an initial deposit.
 Please specify a unique name and height for the upgrade to take effect.
-You may include info to reference a binary download link, in a format compatible with: <https://github.com/cosmos/cosmos-sdk/tree/main/cosmovisor>
+You may include info to reference a binary download link, in a format compatible with: [https://github.com/cosmos/cosmos-sdk/tree/main/cosmovisor](https://github.com/cosmos/cosmos-sdk/tree/main/cosmovisor)
 
 ```
 okp4d tx gov submit-legacy-proposal software-upgrade [name] (--upgrade-height [height]) (--upgrade-info [info]) [flags]
@@ -36,7 +36,7 @@ okp4d tx gov submit-legacy-proposal software-upgrade [name] (--upgrade-height [h
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --no-validate              Skip validation of the upgrade info
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-legacy-proposal_update-client.md
+++ b/docs/command/okp4d_tx_gov_submit-legacy-proposal_update-client.md
@@ -34,7 +34,7 @@ okp4d tx gov submit-legacy-proposal update-client [subject-client-id] [substitut
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_submit-proposal.md
+++ b/docs/command/okp4d_tx_gov_submit-proposal.md
@@ -12,15 +12,15 @@ $ okp4d tx gov submit-proposal path/to/proposal.json
 
 Where proposal.json contains:
 
-{
+\{
   // array of proto-JSON-encoded sdk.Msgs
   "messages": [
-    {
+    \{
       "@type": "/cosmos.bank.v1beta1.MsgSend",
       "from_address": "cosmos1...",
       "to_address": "cosmos1...",
-      "amount":[{"denom": "stake","amount": "10"}]
-    }
+      "amount":[\{"denom": "stake","amount": "10"\}]
+    \}
   ],
   // metadata can be any of base64 encoded, raw text, stringified json, IPFS link to json
   // see below for example metadata
@@ -28,17 +28,17 @@ Where proposal.json contains:
   "deposit": "10stake"
   "title: "My proposal"
   "summary": "A short summary of my proposal"
-}
+\}
 
 metadata example:
-{
+\{
 	"title": "",
 	"authors": [""],
 	"summary": "",
 	"details": "",
 	"proposal_forum_url": "",
 	"vote_option_context": "",
-}
+\}
 
 ```
 okp4d tx gov submit-proposal [path/to/proposal.json] [flags]
@@ -64,7 +64,7 @@ okp4d tx gov submit-proposal [path/to/proposal.json] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_vote.md
+++ b/docs/command/okp4d_tx_gov_vote.md
@@ -35,7 +35,7 @@ okp4d tx gov vote [proposal-id] [option] [flags]
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --metadata string          Specify metadata of the vote
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_gov_weighted-vote.md
+++ b/docs/command/okp4d_tx_gov_weighted-vote.md
@@ -35,7 +35,7 @@ okp4d tx gov weighted-vote [proposal-id] [weighted-options] [flags]
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --metadata string          Specify metadata of the weighted vote
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_create-group-policy.md
+++ b/docs/command/okp4d_tx_group_create-group-policy.md
@@ -55,7 +55,7 @@ Here, we can use percentage decision policy when needed, where 0 < percentage <=
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_create-group-with-policy.md
+++ b/docs/command/okp4d_tx_group_create-group-with-policy.md
@@ -70,7 +70,7 @@ and policy.json contains:
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_create-group.md
+++ b/docs/command/okp4d_tx_group_create-group.md
@@ -55,7 +55,7 @@ Where members.json contains:
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_draft-proposal.md
+++ b/docs/command/okp4d_tx_group_draft-proposal.md
@@ -26,7 +26,7 @@ okp4d tx group draft-proposal [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_exec.md
+++ b/docs/command/okp4d_tx_group_exec.md
@@ -26,7 +26,7 @@ okp4d tx group exec [proposal-id] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_leave-group.md
+++ b/docs/command/okp4d_tx_group_leave-group.md
@@ -35,7 +35,7 @@ okp4d tx group leave-group [member-address] [group-id] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_submit-proposal.md
+++ b/docs/command/okp4d_tx_group_submit-proposal.md
@@ -72,7 +72,7 @@ metadata example:
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_update-group-admin.md
+++ b/docs/command/okp4d_tx_group_update-group-admin.md
@@ -26,7 +26,7 @@ okp4d tx group update-group-admin [admin] [group-id] [new-admin] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_update-group-members.md
+++ b/docs/command/okp4d_tx_group_update-group-members.md
@@ -53,7 +53,7 @@ Set a member's weight to "0" to delete it.
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_update-group-metadata.md
+++ b/docs/command/okp4d_tx_group_update-group-metadata.md
@@ -26,7 +26,7 @@ okp4d tx group update-group-metadata [admin] [group-id] [metadata] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_update-group-policy-admin.md
+++ b/docs/command/okp4d_tx_group_update-group-policy-admin.md
@@ -26,7 +26,7 @@ okp4d tx group update-group-policy-admin [admin] [group-policy-account] [new-adm
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_update-group-policy-decision-policy.md
+++ b/docs/command/okp4d_tx_group_update-group-policy-decision-policy.md
@@ -26,7 +26,7 @@ okp4d tx group update-group-policy-decision-policy [admin] [group-policy-account
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_update-group-policy-metadata.md
+++ b/docs/command/okp4d_tx_group_update-group-policy-metadata.md
@@ -26,7 +26,7 @@ okp4d tx group update-group-policy-metadata [admin] [group-policy-account] [new-
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_vote.md
+++ b/docs/command/okp4d_tx_group_vote.md
@@ -42,7 +42,7 @@ okp4d tx group vote [proposal-id] [voter] [vote-option] [metadata] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_group_withdraw-proposal.md
+++ b/docs/command/okp4d_tx_group_withdraw-proposal.md
@@ -35,7 +35,7 @@ okp4d tx group withdraw-proposal [proposal-id] [group-policy-admin-or-proposer] 
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc-fee_pay-packet-fee.md
+++ b/docs/command/okp4d_tx_ibc-fee_pay-packet-fee.md
@@ -37,7 +37,7 @@ okp4d tx ibc-fee pay-packet-fee transfer channel-0 1 --recv-fee 10stake --ack-fe
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc-fee_register-counterparty-payee.md
+++ b/docs/command/okp4d_tx_ibc-fee_register-counterparty-payee.md
@@ -36,7 +36,7 @@ okp4d tx ibc-fee register-counterparty-payee transfer channel-0 cosmos1rsp837a4k
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc-fee_register-payee.md
+++ b/docs/command/okp4d_tx_ibc-fee_register-payee.md
@@ -36,7 +36,7 @@ okp4d tx ibc-fee register-payee transfer channel-0 cosmos1rsp837a4kvtgp2m4uqzdge
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc-transfer_transfer.md
+++ b/docs/command/okp4d_tx_ibc-transfer_transfer.md
@@ -6,7 +6,7 @@ Transfer a fungible token through IBC
 
 Transfer a fungible token through IBC. Timeouts can be specified
 as absolute or relative using the "absolute-timeouts" flag. Timeout height can be set by passing in the height string
-in the form {revision}-{height} using the "packet-timeout-height" flag. Relative timeout height is added to the block
+in the form \{revision\}-\{height\} using the "packet-timeout-height" flag. Relative timeout height is added to the block
 height queried from the latest consensus state corresponding to the counterparty channel. Relative timeout timestamp
 is added to the greater value of the local clock time and the block timestamp queried from the latest consensus state
 corresponding to the counterparty channel. Any timeout set to 0 is disabled.
@@ -43,7 +43,7 @@ okp4d tx ibc-transfer transfer [src-port] [src-channel] [receiver] [amount]
       --keyring-dir string              The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                          Use a connected Ledger device
       --memo string                     Memo to be sent along with the packet.
-      --node string                     &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                     <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                     Note to add a description to the transaction (previously --memo)
       --offline                         Offline mode (does not allow any online functionality)
   -o, --output string                   Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc_client_create.md
+++ b/docs/command/okp4d_tx_ibc_client_create.md
@@ -5,8 +5,8 @@ create new IBC client
 ### Synopsis
 
 create a new IBC client with the specified client state and consensus state
-	- ClientState JSON example: {"@type":"/ibc.lightclients.solomachine.v1.ClientState","sequence":"1","frozen_sequence":"0","consensus_state":{"public_key":{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AtK50+5pJOoaa04qqAqrnyAqsYrwrR/INnA6UPIaYZlp"},"diversifier":"testing","timestamp":"10"},"allow_update_after_proposal":false}
-	- ConsensusState JSON example: {"@type":"/ibc.lightclients.solomachine.v1.ConsensusState","public_key":{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AtK50+5pJOoaa04qqAqrnyAqsYrwrR/INnA6UPIaYZlp"},"diversifier":"testing","timestamp":"10"}
+	- ClientState JSON example: \{"@type":"/ibc.lightclients.solomachine.v1.ClientState","sequence":"1","frozen_sequence":"0","consensus_state":\{"public_key":\{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AtK50+5pJOoaa04qqAqrnyAqsYrwrR/INnA6UPIaYZlp"\},"diversifier":"testing","timestamp":"10"\},"allow_update_after_proposal":false\}
+	- ConsensusState JSON example: \{"@type":"/ibc.lightclients.solomachine.v1.ConsensusState","public_key":\{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AtK50+5pJOoaa04qqAqrnyAqsYrwrR/INnA6UPIaYZlp"\},"diversifier":"testing","timestamp":"10"\}
 
 ```
 okp4d tx ibc client create [path/to/client_state.json] [path/to/consensus_state.json] [flags]
@@ -15,7 +15,7 @@ okp4d tx ibc client create [path/to/client_state.json] [path/to/consensus_state.
 ### Examples
 
 ```
-okp4d tx ibc client create [path/to/client_state.json] [path/to/consensus_state.json] --from node0 --home ../node0/&lt;app&gt;cli --chain-id $CID
+okp4d tx ibc client create [path/to/client_state.json] [path/to/consensus_state.json] --from node0 --home ../node0/<app>cli --chain-id $CID
 ```
 
 ### Options
@@ -38,7 +38,7 @@ okp4d tx ibc client create [path/to/client_state.json] [path/to/consensus_state.
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc_client_misbehaviour.md
+++ b/docs/command/okp4d_tx_ibc_client_misbehaviour.md
@@ -13,7 +13,7 @@ okp4d tx ibc client misbehaviour [clientID] [path/to/misbehaviour.json] [flags]
 ### Examples
 
 ```
-okp4d tx ibc client misbehaviour [clientID] [path/to/misbehaviour.json] --from node0 --home ../node0/&lt;app&gt;cli --chain-id $CID
+okp4d tx ibc client misbehaviour [clientID] [path/to/misbehaviour.json] --from node0 --home ../node0/<app>cli --chain-id $CID
 ```
 
 ### Options
@@ -36,7 +36,7 @@ okp4d tx ibc client misbehaviour [clientID] [path/to/misbehaviour.json] --from n
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc_client_update.md
+++ b/docs/command/okp4d_tx_ibc_client_update.md
@@ -13,7 +13,7 @@ okp4d tx ibc client update [client-id] [path/to/client_msg.json] [flags]
 ### Examples
 
 ```
-okp4d tx ibc client update [client-id] [path/to/client_msg.json] --from node0 --home ../node0/&lt;app&gt;cli --chain-id $CID
+okp4d tx ibc client update [client-id] [path/to/client_msg.json] --from node0 --home ../node0/<app>cli --chain-id $CID
 ```
 
 ### Options
@@ -36,7 +36,7 @@ okp4d tx ibc client update [client-id] [path/to/client_msg.json] --from node0 --
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_ibc_client_upgrade.md
+++ b/docs/command/okp4d_tx_ibc_client_upgrade.md
@@ -5,8 +5,8 @@ upgrade an IBC client
 ### Synopsis
 
 upgrade the IBC client associated with the provided client identifier while providing proof committed by the counterparty chain to the new client and consensus states
-	- ClientState JSON example: {"@type":"/ibc.lightclients.solomachine.v1.ClientState","sequence":"1","frozen_sequence":"0","consensus_state":{"public_key":{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AtK50+5pJOoaa04qqAqrnyAqsYrwrR/INnA6UPIaYZlp"},"diversifier":"testing","timestamp":"10"},"allow_update_after_proposal":false}
-	- ConsensusState JSON example: {"@type":"/ibc.lightclients.solomachine.v1.ConsensusState","public_key":{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AtK50+5pJOoaa04qqAqrnyAqsYrwrR/INnA6UPIaYZlp"},"diversifier":"testing","timestamp":"10"}
+	- ClientState JSON example: \{"@type":"/ibc.lightclients.solomachine.v1.ClientState","sequence":"1","frozen_sequence":"0","consensus_state":\{"public_key":\{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AtK50+5pJOoaa04qqAqrnyAqsYrwrR/INnA6UPIaYZlp"\},"diversifier":"testing","timestamp":"10"\},"allow_update_after_proposal":false\}
+	- ConsensusState JSON example: \{"@type":"/ibc.lightclients.solomachine.v1.ConsensusState","public_key":\{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"AtK50+5pJOoaa04qqAqrnyAqsYrwrR/INnA6UPIaYZlp"\},"diversifier":"testing","timestamp":"10"\}
 
 ```
 okp4d tx ibc client upgrade [client-identifier] [path/to/client_state.json] [path/to/consensus_state.json] [upgrade-client-proof] [upgrade-consensus-state-proof] [flags]
@@ -15,7 +15,7 @@ okp4d tx ibc client upgrade [client-identifier] [path/to/client_state.json] [pat
 ### Examples
 
 ```
-okp4d tx ibc client upgrade [client-identifier] [path/to/client_state.json] [path/to/consensus_state.json] [client-state-proof] [consensus-state-proof] --from node0 --home ../node0/&lt;app&gt;cli --chain-id $CID
+okp4d tx ibc client upgrade [client-identifier] [path/to/client_state.json] [path/to/consensus_state.json] [client-state-proof] [consensus-state-proof] --from node0 --home ../node0/<app>cli --chain-id $CID
 ```
 
 ### Options
@@ -38,7 +38,7 @@ okp4d tx ibc client upgrade [client-identifier] [path/to/client_state.json] [pat
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_interchain-accounts_controller_register.md
+++ b/docs/command/okp4d_tx_interchain-accounts_controller_register.md
@@ -7,7 +7,7 @@ Register an interchain account on the provided connection.
 Register an account on the counterparty chain via the
 connection id from the source chain. Connection identifier should be for the source chain
 and the interchain account will be created on the counterparty chain. Callers are expected to
-provide the appropriate application version string via {version} flag. Generates a new
+provide the appropriate application version string via \{version\} flag. Generates a new
 port identifier using the provided owner string, binds to the port identifier and claims
 the associated capability.
 
@@ -35,7 +35,7 @@ okp4d tx interchain-accounts controller register [connection-id] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_interchain-accounts_controller_send-tx.md
+++ b/docs/command/okp4d_tx_interchain-accounts_controller_send-tx.md
@@ -6,7 +6,7 @@ Send an interchain account tx on the provided connection.
 
 Submits pre-built packet data containing messages to be executed on the host chain
 and attempts to send the packet. Packet data is provided as json, file or string. An
-appropriate relative timeoutTimestamp must be provided with flag {relative-packet-timeout}
+appropriate relative timeoutTimestamp must be provided with flag \{relative-packet-timeout\}
 
 ```
 okp4d tx interchain-accounts controller send-tx [connection-id] [path/to/packet_msg.json] [flags]
@@ -32,7 +32,7 @@ okp4d tx interchain-accounts controller send-tx [connection-id] [path/to/packet_
       --keyring-backend string         Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string             The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                         Use a connected Ledger device
-      --node string                    &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                    <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                    Note to add a description to the transaction (previously --memo)
       --offline                        Offline mode (does not allow any online functionality)
   -o, --output string                  Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_multi-sign.md
+++ b/docs/command/okp4d_tx_multi-sign.md
@@ -47,7 +47,7 @@ okp4d tx multi-sign [file] [name] [[signature]...] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_sign-batch.md
+++ b/docs/command/okp4d_tx_sign-batch.md
@@ -20,7 +20,7 @@ transaction that is signed.
 If --account-number or --sequence flag is used when offline=false, they are ignored and
 overwritten by the default flag values.
 
-The --multisig=<multisig_key> flag generates a signature on behalf of a multisig
+The --multisig=&lt;multisig_key&gt; flag generates a signature on behalf of a multisig
 account key. It implies --signature-only.
 
 ```
@@ -49,7 +49,7 @@ okp4d tx sign-batch [file] ([file2]...) [flags]
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --multisig string          Address or key name of the multisig account on behalf of which the transaction shall be signed
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_sign.md
+++ b/docs/command/okp4d_tx_sign.md
@@ -14,7 +14,7 @@ As a result, the account and sequence number queries will not be performed and
 it is required to set such parameters manually. Note, invalid values will cause
 the transaction to fail.
 
-The --multisig=<multisig_key> flag generates a signature on behalf of a multisig account
+The --multisig=&lt;multisig_key&gt; flag generates a signature on behalf of a multisig account
 key. It implies --signature-only. Full multisig signed transactions may eventually
 be generated via the 'multisign' command.
 
@@ -44,7 +44,7 @@ okp4d tx sign [file] [flags]
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
       --multisig string          Address or key name of the multisig account on behalf of which the transaction shall be signed
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_slashing_unjail.md
+++ b/docs/command/okp4d_tx_slashing_unjail.md
@@ -32,7 +32,7 @@ okp4d tx slashing unjail [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_staking_cancel-unbond.md
+++ b/docs/command/okp4d_tx_staking_cancel-unbond.md
@@ -16,7 +16,7 @@ okp4d tx staking cancel-unbond [validator-addr] [amount] [creation-height] [flag
 ### Examples
 
 ```
-okp4d tx staking cancel-unbond okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 100stake 2 --from mykey
+$ okp4d tx staking cancel-unbond okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhffj 100stake 2 --from mykey
 ```
 
 ### Options
@@ -39,7 +39,7 @@ okp4d tx staking cancel-unbond okp4valoper1gghjut3ccd8ay0zduzj64hwre2fxs9ldmqhff
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_staking_create-validator.md
+++ b/docs/command/okp4d_tx_staking_create-validator.md
@@ -35,7 +35,7 @@ okp4d tx staking create-validator [flags]
       --ledger                              Use a connected Ledger device
       --min-self-delegation string          The minimum self delegation required on the validator
       --moniker string                      The validator's name
-      --node string                         &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                         <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --node-id string                      The node's ID
       --note string                         Note to add a description to the transaction (previously --memo)
       --offline                             Offline mode (does not allow any online functionality)

--- a/docs/command/okp4d_tx_staking_delegate.md
+++ b/docs/command/okp4d_tx_staking_delegate.md
@@ -33,7 +33,7 @@ okp4d tx staking delegate [validator-addr] [amount] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_staking_edit-validator.md
+++ b/docs/command/okp4d_tx_staking_edit-validator.md
@@ -31,7 +31,7 @@ okp4d tx staking edit-validator [flags]
       --ledger                       Use a connected Ledger device
       --min-self-delegation string   The minimum self delegation required on the validator
       --new-moniker string           The validator's name (default "[do-not-modify]")
-      --node string                  &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                  <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                  Note to add a description to the transaction (previously --memo)
       --offline                      Offline mode (does not allow any online functionality)
   -o, --output string                Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_staking_redelegate.md
+++ b/docs/command/okp4d_tx_staking_redelegate.md
@@ -33,7 +33,7 @@ okp4d tx staking redelegate [src-validator-addr] [dst-validator-addr] [amount] [
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_staking_unbond.md
+++ b/docs/command/okp4d_tx_staking_unbond.md
@@ -33,7 +33,7 @@ okp4d tx staking unbond [validator-addr] [amount] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_validate-signatures.md
+++ b/docs/command/okp4d_tx_validate-signatures.md
@@ -36,7 +36,7 @@ okp4d tx validate-signatures [file] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_vesting_create-cliff-vesting-account.md
+++ b/docs/command/okp4d_tx_vesting_create-cliff-vesting-account.md
@@ -34,7 +34,7 @@ okp4d tx vesting create-cliff-vesting-account [to_address] [amount] [cliff_time]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_vesting_create-periodic-vesting-account.md
+++ b/docs/command/okp4d_tx_vesting_create-periodic-vesting-account.md
@@ -8,18 +8,18 @@ A sequence of coins and period length in seconds. Periods are sequential, in tha
 		Where periods.json contains:
 
 		An array of coin strings and unix epoch times for coins to vest
-{ "start_time": 1625204910,
+\{ "start_time": 1625204910,
 "period":[
- {
+ \{
   "coins": "10test",
   "length_seconds":2592000 //30 days
- },
- {
+ \},
+ \{
 	"coins": "10test",
 	"length_seconds":2592000 //30 days
- },
+ \},
 ]
-	}
+	\}
 		
 ```
 okp4d tx vesting create-periodic-vesting-account [to_address] [periods_json_file] [flags]
@@ -45,7 +45,7 @@ okp4d tx vesting create-periodic-vesting-account [to_address] [periods_json_file
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_vesting_create-permanent-locked-account.md
+++ b/docs/command/okp4d_tx_vesting_create-permanent-locked-account.md
@@ -32,7 +32,7 @@ okp4d tx vesting create-permanent-locked-account [to_address] [amount] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_vesting_create-vesting-account.md
+++ b/docs/command/okp4d_tx_vesting_create-vesting-account.md
@@ -35,7 +35,7 @@ okp4d tx vesting create-vesting-account [to_address] [amount] [end_time] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_clear-contract-admin.md
+++ b/docs/command/okp4d_tx_wasm_clear-contract-admin.md
@@ -26,7 +26,7 @@ okp4d tx wasm clear-contract-admin [contract_addr_bech32] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_execute.md
+++ b/docs/command/okp4d_tx_wasm_execute.md
@@ -27,7 +27,7 @@ okp4d tx wasm execute [contract_addr_bech32] [json_encoded_send_args] --amount [
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_grant.md
+++ b/docs/command/okp4d_tx_wasm_grant.md
@@ -6,11 +6,11 @@ Grant authorization to an address
 
 Grant authorization to an address.
 Examples:
-$ okp4d tx grant <grantee_addr> execution <contract_addr> --allow-all-messages --max-calls 1 --no-token-transfer --expiration 1667979596
+$ okp4d tx grant &lt;grantee_addr&gt; execution &lt;contract_addr&gt; --allow-all-messages --max-calls 1 --no-token-transfer --expiration 1667979596
 
-$ okp4d tx grant <grantee_addr> execution <contract_addr> --allow-all-messages --max-funds 100000uwasm --expiration 1667979596
+$ okp4d tx grant &lt;grantee_addr&gt; execution &lt;contract_addr&gt; --allow-all-messages --max-funds 100000uwasm --expiration 1667979596
 
-$ okp4d tx grant <grantee_addr> execution <contract_addr> --allow-all-messages --max-calls 5 --max-funds 100000uwasm --expiration 1667979596
+$ okp4d tx grant &lt;grantee_addr&gt; execution &lt;contract_addr&gt; --allow-all-messages --max-calls 5 --max-funds 100000uwasm --expiration 1667979596
 
 ```
 okp4d tx wasm grant [grantee] [message_type="execution"|"migration"] [contract_addr_bech32] --allow-raw-msgs [msg1,msg2,...] --allow-msg-keys [key1,key2,...] --allow-all-messages [flags]
@@ -43,7 +43,7 @@ okp4d tx wasm grant [grantee] [message_type="execution"|"migration"] [contract_a
       --max-calls uint           Maximal number of calls to the contract
       --max-funds string         Maximal amount of tokens transferable to the contract.
       --no-token-transfer        Don't allow token transfer
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_instantiate.md
+++ b/docs/command/okp4d_tx_wasm_instantiate.md
@@ -7,7 +7,7 @@ Instantiate a wasm contract
 Creates a new instance of an uploaded wasm code with the given 'constructor' message.
 Each contract instance has a unique address assigned.
 Example:
-$ okp4d tx wasm instantiate 1 '{"foo":"bar"}' --admin="$(okp4d keys show mykey -a)" \
+$ okp4d tx wasm instantiate 1 '\{"foo":"bar"\}' --admin="$(okp4d keys show mykey -a)" \
   --from mykey --amount="100ustake" --label "local0.1.0"
 
 ```
@@ -38,7 +38,7 @@ okp4d tx wasm instantiate [code_id_int64] [json_encoded_init_args] --label [text
       --label string             A human-readable name for this contract in lists
       --ledger                   Use a connected Ledger device
       --no-admin                 You must set this explicitly if you don't want an admin
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_instantiate2.md
+++ b/docs/command/okp4d_tx_wasm_instantiate2.md
@@ -9,7 +9,7 @@ Each contract instance has a unique address assigned. They are assigned automati
 for special use cases, the given 'salt' argument and '--fix-msg' parameters can be used to generate a custom address.
 
 Predictable address example (also see 'okp4d query wasm build-address -h'):
-$ okp4d tx wasm instantiate2 1 '{"foo":"bar"}' $(echo -n "testing" | xxd -ps) --admin="$(okp4d keys show mykey -a)" \
+$ okp4d tx wasm instantiate2 1 '\{"foo":"bar"\}' $(echo -n "testing" | xxd -ps) --admin="$(okp4d keys show mykey -a)" \
   --from mykey --amount="100ustake" --label "local0.1.0" \
    --fix-msg
 
@@ -45,7 +45,7 @@ okp4d tx wasm instantiate2 [code_id_int64] [json_encoded_init_args] [salt] --lab
       --label string             A human-readable name for this contract in lists
       --ledger                   Use a connected Ledger device
       --no-admin                 You must set this explicitly if you don't want an admin
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_migrate.md
+++ b/docs/command/okp4d_tx_wasm_migrate.md
@@ -26,7 +26,7 @@ okp4d tx wasm migrate [contract_addr_bech32] [new_code_id_int64] [json_encoded_m
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_set-contract-admin.md
+++ b/docs/command/okp4d_tx_wasm_set-contract-admin.md
@@ -26,7 +26,7 @@ okp4d tx wasm set-contract-admin [contract_addr_bech32] [new_admin_addr_bech32] 
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_store.md
+++ b/docs/command/okp4d_tx_wasm_store.md
@@ -30,7 +30,7 @@ okp4d tx wasm store [wasm file] [flags]
       --keyring-backend string                Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string                    The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                                Use a connected Ledger device
-      --node string                           &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                           <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                           Note to add a description to the transaction (previously --memo)
       --offline                               Offline mode (does not allow any online functionality)
   -o, --output string                         Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_submit-proposal_clear-contract-admin.md
+++ b/docs/command/okp4d_tx_wasm_submit-proposal_clear-contract-admin.md
@@ -28,7 +28,7 @@ okp4d tx wasm submit-proposal clear-contract-admin [contract_addr_bech32] --titl
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_submit-proposal_execute-contract.md
+++ b/docs/command/okp4d_tx_wasm_submit-proposal_execute-contract.md
@@ -29,7 +29,7 @@ okp4d tx wasm submit-proposal execute-contract [contract_addr_bech32] [json_enco
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_submit-proposal_instantiate-contract-2.md
+++ b/docs/command/okp4d_tx_wasm_submit-proposal_instantiate-contract-2.md
@@ -32,7 +32,7 @@ okp4d tx wasm submit-proposal instantiate-contract-2 [code_id_int64] [json_encod
       --label string             A human-readable name for this contract in lists
       --ledger                   Use a connected Ledger device
       --no-admin                 You must set this explicitly if you don't want an admin
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_submit-proposal_instantiate-contract.md
+++ b/docs/command/okp4d_tx_wasm_submit-proposal_instantiate-contract.md
@@ -32,7 +32,7 @@ okp4d tx wasm submit-proposal instantiate-contract [code_id_int64] [json_encoded
       --label string             A human-readable name for this contract in lists
       --ledger                   Use a connected Ledger device
       --no-admin                 You must set this explicitly if you don't want an admin
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_submit-proposal_migrate-contract.md
+++ b/docs/command/okp4d_tx_wasm_submit-proposal_migrate-contract.md
@@ -28,7 +28,7 @@ okp4d tx wasm submit-proposal migrate-contract [contract_addr_bech32] [new_code_
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_submit-proposal_pin-codes.md
+++ b/docs/command/okp4d_tx_wasm_submit-proposal_pin-codes.md
@@ -28,7 +28,7 @@ okp4d tx wasm submit-proposal pin-codes [code-ids] --title [text] --summary [tex
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_submit-proposal_set-contract-admin.md
+++ b/docs/command/okp4d_tx_wasm_submit-proposal_set-contract-admin.md
@@ -28,7 +28,7 @@ okp4d tx wasm submit-proposal set-contract-admin [contract_addr_bech32] [new_adm
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_submit-proposal_store-instantiate.md
+++ b/docs/command/okp4d_tx_wasm_submit-proposal_store-instantiate.md
@@ -39,7 +39,7 @@ okp4d tx wasm submit-proposal store-instantiate [wasm file] [json_encoded_init_a
       --label string                          A human-readable name for this contract in lists
       --ledger                                Use a connected Ledger device
       --no-admin                              You must set this explicitly if you don't want an admin
-      --node string                           &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                           <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                           Note to add a description to the transaction (previously --memo)
       --offline                               Offline mode (does not allow any online functionality)
   -o, --output string                         Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_submit-proposal_sudo-contract.md
+++ b/docs/command/okp4d_tx_wasm_submit-proposal_sudo-contract.md
@@ -28,7 +28,7 @@ okp4d tx wasm submit-proposal sudo-contract [contract_addr_bech32] [json_encoded
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_submit-proposal_unpin-codes.md
+++ b/docs/command/okp4d_tx_wasm_submit-proposal_unpin-codes.md
@@ -28,7 +28,7 @@ okp4d tx wasm submit-proposal unpin-codes [code-ids] --title [text] --summary [t
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_submit-proposal_update-instantiate-config.md
+++ b/docs/command/okp4d_tx_wasm_submit-proposal_update-instantiate-config.md
@@ -35,7 +35,7 @@ okp4d tx wasm submit-proposal update-instantiate-config [code-id:permission] --t
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                   Use a connected Ledger device
-      --node string              &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string              <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string              Note to add a description to the transaction (previously --memo)
       --offline                  Offline mode (does not allow any online functionality)
   -o, --output string            Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_submit-proposal_wasm-store.md
+++ b/docs/command/okp4d_tx_wasm_submit-proposal_wasm-store.md
@@ -32,7 +32,7 @@ okp4d tx wasm submit-proposal wasm-store [wasm file] --title [text] --summary [t
       --keyring-backend string                Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string                    The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                                Use a connected Ledger device
-      --node string                           &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                           <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                           Note to add a description to the transaction (previously --memo)
       --offline                               Offline mode (does not allow any online functionality)
   -o, --output string                         Output format (text|json) (default "json")

--- a/docs/command/okp4d_tx_wasm_update-instantiate-config.md
+++ b/docs/command/okp4d_tx_wasm_update-instantiate-config.md
@@ -30,7 +30,7 @@ okp4d tx wasm update-instantiate-config [code_id_int64] [flags]
       --keyring-backend string                Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string                    The client Keyring directory; if omitted, the default 'home' directory will be used
       --ledger                                Use a connected Ledger device
-      --node string                           &lt;host&gt;:&lt;port&gt; to tendermint rpc interface for this chain (default "tcp://localhost:26657")
+      --node string                           <host>:<port> to tendermint rpc interface for this chain (default "tcp://localhost:26657")
       --note string                           Note to add a description to the transaction (previously --memo)
       --offline                               Offline mode (does not allow any online functionality)
   -o, --output string                         Output format (text|json) (default "json")

--- a/scripts/generate_command_doc.go
+++ b/scripts/generate_command_doc.go
@@ -22,5 +22,10 @@ func GenerateCommandDocumentation() error {
 		return err
 	}
 
-	return doc.GenMarkdownTree(rootCmd, targetPath)
+	err = doc.GenMarkdownTree(rootCmd, targetPath)
+	if err != nil {
+		return err
+	}
+
+	return normalizeMarkdownFiles(targetPath)
 }

--- a/scripts/generate_predicates_doc.go
+++ b/scripts/generate_predicates_doc.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"embed"
 	"fmt"
 	"go/build"
@@ -93,25 +92,4 @@ func readTemplateMust(templateName string) string {
 	}
 
 	return string(template)
-}
-
-func writeToFile(filePath string, content string) error {
-	file, err := os.Create(filePath)
-	if err != nil {
-		return fmt.Errorf("failed to create file %s: %w", filePath, err)
-	}
-	defer func(file *os.File) {
-		_ = file.Close()
-	}(file)
-
-	w := bufio.NewWriter(file)
-	if _, err = w.WriteString(content); err != nil {
-		return fmt.Errorf("failed to write to file %s: %w", filePath, err)
-	}
-
-	if err = w.Flush(); err != nil {
-		return fmt.Errorf("failed to flush writer: %w", err)
-	}
-
-	return nil
 }

--- a/scripts/util.go
+++ b/scripts/util.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func writeToFile(filePath string, content string) error {
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", filePath, err)
+	}
+	defer func(file *os.File) {
+		_ = file.Close()
+	}(file)
+
+	w := bufio.NewWriter(file)
+	if _, err = w.WriteString(content); err != nil {
+		return fmt.Errorf("failed to write to file %s: %w", filePath, err)
+	}
+
+	if err = w.Flush(); err != nil {
+		return fmt.Errorf("failed to flush writer: %w", err)
+	}
+
+	return nil
+}
+
+func normalizeMarkdownFiles(dir string) error {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		path := filepath.Join(dir, file.Name())
+		if file.IsDir() {
+			if err := normalizeMarkdownFiles(path); err != nil {
+				return err
+			}
+		} else if strings.HasSuffix(file.Name(), ".md") {
+			if err := normalizeMarkdownFile(path); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func normalizeMarkdownFile(file string) error {
+	f, err := os.Open(file)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	normalizedContent, err := normalizeMarkdownContent(f)
+	if err != nil {
+		return err
+	}
+
+	return writeToFile(file, normalizedContent)
+}
+
+func normalizeMarkdownContent(input io.Reader) (string, error) {
+	inCodeBlock := false
+	inInlineCode := false
+	var output strings.Builder
+
+	reader := bufio.NewReader(input)
+	for {
+		char, _, err := reader.ReadRune()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return "", err
+		}
+		switch char {
+		case '`':
+			output.WriteRune(char)
+
+			if !inCodeBlock {
+				inInlineCode = !inInlineCode
+			}
+		case '\n':
+			output.WriteRune(char)
+
+			peekBytes, _ := reader.Peek(3)
+			if string(peekBytes) == "```" {
+				inCodeBlock = !inCodeBlock
+
+				_, err := io.CopyN(&output, reader, 3)
+				if err != nil {
+					return "", err
+				}
+			}
+		default:
+			if !inCodeBlock && !inInlineCode {
+				switch char {
+				case '{':
+					output.WriteRune('\\')
+					output.WriteRune(char)
+				case '}':
+					output.WriteRune('\\')
+					output.WriteRune(char)
+				case '<':
+					output.WriteString("&lt;")
+				case '>':
+					output.WriteString("&gt;")
+				default:
+					output.WriteRune(char)
+				}
+				continue
+			}
+			output.WriteRune(char)
+		}
+	}
+
+	return output.String(), nil
+}


### PR DESCRIPTION
With the same aim as https://github.com/okp4/contracts/pull/441, this PR introduces the content escape during documentation generation process:

This involves escaping certain characters, such as `{` and `<`, which are incompatible with the `MDX v3` format, as outlined in the [Docusaurus blog post about preparing content for MDX v3](https://docusaurus.io/blog/preparing-your-site-for-docusaurus-v3#preparing-content-for-mdx-v3). This is particularly relevant for our documentation site, which is built using [Docusaurus](https://github.com/okp4/docs).

The regenerated documentation has been verified for compliance using [slorber/docusaurus-mdx-checker](https://github.com/slorber/docusaurus-mdx-checker):

```
➜ npx docusaurus-mdx-checker -c docs/command
[SUCCESS] All 314 MDX files compiled successfully!
```