### PR TITLE
test(logic): re-introduce convey specific nil assertions

### DIFF
--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -195,11 +195,11 @@ func TestGRPCAsk(t *testing.T) {
 
 							Convey("Then it should return the expected answer", func() {
 								if tc.expectedError != "" {
-									So(err, ShouldNotEqual, nil)
+									So(err, ShouldNotBeNil)
 									So(err.Error(), ShouldEqual, tc.expectedError)
 									So(result, ShouldBeNil)
 								} else {
-									So(err, ShouldEqual, nil)
+									So(err, ShouldBeNil)
 									So(result, ShouldNotBeNil)
 									So(result.Answer, ShouldResemble, tc.expectedAnswer)
 								}

--- a/x/logic/predicate/address_test.go
+++ b/x/logic/predicate/address_test.go
@@ -134,13 +134,13 @@ func TestBech32(t *testing.T) {
 						interpreter.Register2(engine.NewAtom("bech32_address"), Bech32Address)
 
 						err := interpreter.Compile(ctx, tc.program)
-						So(err, ShouldEqual, nil)
+						So(err, ShouldBeNil)
 
 						Convey("When the predicate is called", func() {
 							sols, err := interpreter.QueryContext(ctx, tc.query)
 
 							Convey("Then the error should be nil", func() {
-								So(err, ShouldEqual, nil)
+								So(err, ShouldBeNil)
 								So(sols, ShouldNotBeNil)
 
 								Convey("and the bindings should be as expected", func() {
@@ -148,15 +148,15 @@ func TestBech32(t *testing.T) {
 									for sols.Next() {
 										m := types.TermResults{}
 										err := sols.Scan(m)
-										So(err, ShouldEqual, nil)
+										So(err, ShouldBeNil)
 
 										got = append(got, m)
 									}
 									if tc.wantError != nil {
-										So(sols.Err(), ShouldNotEqual, nil)
+										So(sols.Err(), ShouldNotBeNil)
 										So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 									} else {
-										So(sols.Err(), ShouldEqual, nil)
+										So(sols.Err(), ShouldBeNil)
 
 										if tc.wantSuccess {
 											So(len(got), ShouldBeGreaterThan, 0)

--- a/x/logic/predicate/bank_test.go
+++ b/x/logic/predicate/bank_test.go
@@ -471,13 +471,13 @@ func TestBank(t *testing.T) {
 							interpreter.Register2(engine.NewAtom("bank_locked_balances"), BankLockedBalances)
 
 							err := interpreter.Compile(ctx, tc.program)
-							So(err, ShouldEqual, nil)
+							So(err, ShouldBeNil)
 
 							Convey("When the predicate is called", func() {
 								sols, err := interpreter.QueryContext(ctx, tc.query)
 
 								Convey("Then the error should be nil", func() {
-									So(err, ShouldEqual, nil)
+									So(err, ShouldBeNil)
 									So(sols, ShouldNotBeNil)
 
 									Convey("and the bindings should be as expected", func() {
@@ -485,15 +485,15 @@ func TestBank(t *testing.T) {
 										for sols.Next() {
 											m := types.TermResults{}
 											err := sols.Scan(m)
-											So(err, ShouldEqual, nil)
+											So(err, ShouldBeNil)
 
 											got = append(got, m)
 										}
 										if tc.wantError != nil {
-											So(sols.Err(), ShouldNotEqual, nil)
+											So(sols.Err(), ShouldNotBeNil)
 											So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 										} else {
-											So(sols.Err(), ShouldEqual, nil)
+											So(sols.Err(), ShouldBeNil)
 											So(got, ShouldResemble, tc.wantResult)
 										}
 									})

--- a/x/logic/predicate/crypto_test.go
+++ b/x/logic/predicate/crypto_test.go
@@ -113,13 +113,13 @@ func TestCryptoOperations(t *testing.T) {
 						interpreter.Register2(engine.NewAtom("hex_bytes"), HexBytes)
 
 						err := interpreter.Compile(ctx, tc.program)
-						So(err, ShouldEqual, nil)
+						So(err, ShouldBeNil)
 
 						Convey("When the predicate is called", func() {
 							sols, err := interpreter.QueryContext(ctx, tc.query)
 
 							Convey("Then the error should be nil", func() {
-								So(err, ShouldEqual, nil)
+								So(err, ShouldBeNil)
 								So(sols, ShouldNotBeNil)
 
 								Convey("and the bindings should be as expected", func() {
@@ -127,15 +127,15 @@ func TestCryptoOperations(t *testing.T) {
 									for sols.Next() {
 										m := types.TermResults{}
 										err := sols.Scan(m)
-										So(err, ShouldEqual, nil)
+										So(err, ShouldBeNil)
 
 										got = append(got, m)
 									}
 									if tc.wantError != nil {
-										So(sols.Err(), ShouldNotEqual, nil)
+										So(sols.Err(), ShouldNotBeNil)
 										So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 									} else {
-										So(sols.Err(), ShouldEqual, nil)
+										So(sols.Err(), ShouldBeNil)
 
 										if tc.wantSuccess {
 											So(len(got), ShouldBeGreaterThan, 0)
@@ -326,7 +326,7 @@ func TestXVerify(t *testing.T) {
 							sols, err := interpreter.QueryContext(ctx, tc.query)
 
 							Convey("Then the error should be nil", func() {
-								So(err, ShouldEqual, nil)
+								So(err, ShouldBeNil)
 								So(sols, ShouldNotBeNil)
 
 								Convey("and the bindings should be as expected", func() {
@@ -334,15 +334,15 @@ func TestXVerify(t *testing.T) {
 									for sols.Next() {
 										m := types.TermResults{}
 										err := sols.Scan(m)
-										So(err, ShouldEqual, nil)
+										So(err, ShouldBeNil)
 
 										got = append(got, m)
 									}
 									if tc.wantError != nil {
-										So(sols.Err(), ShouldNotEqual, nil)
+										So(sols.Err(), ShouldNotBeNil)
 										So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 									} else {
-										So(sols.Err(), ShouldEqual, nil)
+										So(sols.Err(), ShouldBeNil)
 
 										if tc.wantSuccess {
 											So(len(got), ShouldBeGreaterThan, 0)

--- a/x/logic/predicate/did_test.go
+++ b/x/logic/predicate/did_test.go
@@ -116,13 +116,13 @@ func TestDID(t *testing.T) {
 						interpreter.Register2(engine.NewAtom("did_components"), DIDComponents)
 
 						err := interpreter.Compile(ctx, tc.program)
-						So(err, ShouldEqual, nil)
+						So(err, ShouldBeNil)
 
 						Convey("When the predicate is called", func() {
 							sols, err := interpreter.QueryContext(ctx, tc.query)
 
 							Convey("Then the error should be nil", func() {
-								So(err, ShouldEqual, nil)
+								So(err, ShouldBeNil)
 								So(sols, ShouldNotBeNil)
 
 								Convey("and the bindings should be as expected", func() {
@@ -130,12 +130,12 @@ func TestDID(t *testing.T) {
 									for sols.Next() {
 										m := types.TermResults{}
 										err := sols.Scan(m)
-										So(err, ShouldEqual, nil)
+										So(err, ShouldBeNil)
 
 										got = append(got, m)
 									}
 									if tc.wantError != nil {
-										So(sols.Err(), ShouldNotEqual, nil)
+										So(sols.Err(), ShouldNotBeNil)
 										So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 									} else {
 										So(sols.Err(), ShouldBeNil)

--- a/x/logic/predicate/encoding_test.go
+++ b/x/logic/predicate/encoding_test.go
@@ -87,13 +87,13 @@ func TestHexBytesPredicate(t *testing.T) {
 						interpreter.Register2(engine.NewAtom("hex_bytes"), HexBytes)
 
 						err := interpreter.Compile(ctx, tc.program)
-						So(err, ShouldEqual, nil)
+						So(err, ShouldBeNil)
 
 						Convey("When the predicate is called", func() {
 							sols, err := interpreter.QueryContext(ctx, tc.query)
 
 							Convey("Then the error should be nil", func() {
-								So(err, ShouldEqual, nil)
+								So(err, ShouldBeNil)
 								So(sols, ShouldNotBeNil)
 
 								Convey("and the bindings should be as expected", func() {
@@ -113,15 +113,15 @@ func checkSolutions(sols *prolog.Solutions, wantResult []types.TermResults, want
 	for sols.Next() {
 		m := types.TermResults{}
 		err := sols.Scan(m)
-		So(err, ShouldEqual, nil)
+		So(err, ShouldBeNil)
 
 		got = append(got, m)
 	}
 	if wantError != nil {
-		So(sols.Err(), ShouldNotEqual, nil)
+		So(sols.Err(), ShouldNotBeNil)
 		So(sols.Err().Error(), ShouldEqual, wantError.Error())
 	} else {
-		So(sols.Err(), ShouldEqual, nil)
+		So(sols.Err(), ShouldBeNil)
 
 		if wantSuccess {
 			So(len(got), ShouldEqual, len(wantResult))

--- a/x/logic/predicate/file_test.go
+++ b/x/logic/predicate/file_test.go
@@ -147,7 +147,7 @@ func TestSourceFile(t *testing.T) {
 								sols, err := interpreter.QueryContext(ctx, tc.query)
 
 								Convey("Then the error should be nil", func() {
-									So(err, ShouldEqual, nil)
+									So(err, ShouldBeNil)
 									So(sols, ShouldNotBeNil)
 
 									Convey("and the bindings should be as expected", func() {
@@ -155,16 +155,16 @@ func TestSourceFile(t *testing.T) {
 										for sols.Next() {
 											m := types.TermResults{}
 											err := sols.Scan(m)
-											So(err, ShouldEqual, nil)
+											So(err, ShouldBeNil)
 
 											got = append(got, m)
 										}
 
 										if tc.wantError != nil {
-											So(sols.Err(), ShouldNotEqual, nil)
+											So(sols.Err(), ShouldNotBeNil)
 											So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 										} else {
-											So(sols.Err(), ShouldEqual, nil)
+											So(sols.Err(), ShouldBeNil)
 
 											if tc.wantSuccess {
 												So(len(got), ShouldBeGreaterThan, 0)
@@ -334,13 +334,13 @@ func TestOpen(t *testing.T) {
 							interpreter.Register4(engine.NewAtom("open"), Open)
 
 							err := interpreter.Compile(ctx, tc.program)
-							So(err, ShouldEqual, nil)
+							So(err, ShouldBeNil)
 
 							Convey("When the predicate is called", func() {
 								sols, err := interpreter.QueryContext(ctx, tc.query)
 
 								Convey("Then the error should be nil", func() {
-									So(err, ShouldEqual, nil)
+									So(err, ShouldBeNil)
 									So(sols, ShouldNotBeNil)
 
 									Convey("and the bindings should be as expected", func() {
@@ -348,15 +348,15 @@ func TestOpen(t *testing.T) {
 										for sols.Next() {
 											m := types.TermResults{}
 											err := sols.Scan(m)
-											So(err, ShouldEqual, nil)
+											So(err, ShouldBeNil)
 
 											got = append(got, m)
 										}
 										if tc.wantError != nil {
-											So(sols.Err(), ShouldNotEqual, nil)
+											So(sols.Err(), ShouldNotBeNil)
 											So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 										} else {
-											So(sols.Err(), ShouldEqual, nil)
+											So(sols.Err(), ShouldBeNil)
 
 											if tc.wantSuccess {
 												So(len(got), ShouldBeGreaterThan, 0)

--- a/x/logic/predicate/json_test.go
+++ b/x/logic/predicate/json_test.go
@@ -376,29 +376,29 @@ func TestJsonProlog(t *testing.T) {
 						interpreter.Register2(engine.NewAtom("json_prolog"), JSONProlog)
 
 						err := interpreter.Compile(ctx, tc.program)
-						So(err, ShouldEqual, nil)
+						So(err, ShouldBeNil)
 
 						Convey("When the predicate is called", func() {
 							sols, err := interpreter.QueryContext(ctx, tc.query)
 
 							Convey("Then the error should be nil", func() {
-								So(err, ShouldEqual, nil)
-								So(sols, ShouldNotEqual, nil)
+								So(err, ShouldBeNil)
+								So(sols, ShouldNotBeNil)
 
 								Convey("and the bindings should be as expected", func() {
 									var got []types.TermResults
 									for sols.Next() {
 										m := types.TermResults{}
 										err := sols.Scan(m)
-										So(err, ShouldEqual, nil)
+										So(err, ShouldBeNil)
 
 										got = append(got, m)
 									}
 									if tc.wantError != nil {
-										So(sols.Err(), ShouldNotEqual, nil)
+										So(sols.Err(), ShouldNotBeNil)
 										So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 									} else {
-										So(sols.Err(), ShouldEqual, nil)
+										So(sols.Err(), ShouldBeNil)
 
 										if tc.wantSuccess {
 											So(len(got), ShouldEqual, len(tc.wantResult))
@@ -486,7 +486,7 @@ func TestJsonPrologWithMoreComplexStructBidirectional(t *testing.T) {
 								sols, err := interpreter.QueryContext(ctx, fmt.Sprintf("json_prolog(%s, Term).", tc.json))
 
 								Convey("Then the error should be nil", func() {
-									So(err, ShouldEqual, nil)
+									So(err, ShouldBeNil)
 									So(sols, ShouldNotBeNil)
 
 									Convey("and the bindings should be as expected", func() {
@@ -494,15 +494,15 @@ func TestJsonPrologWithMoreComplexStructBidirectional(t *testing.T) {
 										for sols.Next() {
 											m := types.TermResults{}
 											err := sols.Scan(m)
-											So(err, ShouldEqual, nil)
+											So(err, ShouldBeNil)
 
 											got = append(got, m)
 										}
 										if tc.wantError != nil {
-											So(sols.Err(), ShouldNotEqual, nil)
+											So(sols.Err(), ShouldNotBeNil)
 											So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 										} else {
-											So(sols.Err(), ShouldEqual, nil)
+											So(sols.Err(), ShouldBeNil)
 
 											if tc.wantSuccess {
 												So(len(got), ShouldBeGreaterThan, 0)
@@ -525,7 +525,7 @@ func TestJsonPrologWithMoreComplexStructBidirectional(t *testing.T) {
 								sols, err := interpreter.QueryContext(ctx, fmt.Sprintf("json_prolog(Json, %s).", tc.term))
 
 								Convey("Then the error should be nil", func() {
-									So(err, ShouldEqual, nil)
+									So(err, ShouldBeNil)
 									So(sols, ShouldNotBeNil)
 
 									Convey("and the bindings should be as expected", func() {
@@ -533,15 +533,15 @@ func TestJsonPrologWithMoreComplexStructBidirectional(t *testing.T) {
 										for sols.Next() {
 											m := types.TermResults{}
 											err := sols.Scan(m)
-											So(err, ShouldEqual, nil)
+											So(err, ShouldBeNil)
 
 											got = append(got, m)
 										}
 										if tc.wantError != nil {
-											So(sols.Err(), ShouldNotEqual, nil)
+											So(sols.Err(), ShouldNotBeNil)
 											So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 										} else {
-											So(sols.Err(), ShouldEqual, nil)
+											So(sols.Err(), ShouldBeNil)
 
 											if tc.wantSuccess {
 												So(len(got), ShouldBeGreaterThan, 0)
@@ -565,14 +565,14 @@ func TestJsonPrologWithMoreComplexStructBidirectional(t *testing.T) {
 							sols, err := interpreter.QueryContext(ctx, fmt.Sprintf("json_prolog(%s, %s).", tc.json, tc.term))
 
 							Convey("Then the error should be nil", func() {
-								So(err, ShouldEqual, nil)
+								So(err, ShouldBeNil)
 								So(sols, ShouldNotBeNil)
 
 								Convey("and the bindings should be as expected", func() {
 									So(sols.Next(), ShouldEqual, tc.wantSuccess)
 
 									if tc.wantError != nil {
-										So(sols.Err(), ShouldNotEqual, nil)
+										So(sols.Err(), ShouldNotBeNil)
 										So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 									}
 								})

--- a/x/logic/predicate/string_test.go
+++ b/x/logic/predicate/string_test.go
@@ -154,13 +154,13 @@ func TestReadString(t *testing.T) {
 						interpreter.SetUserInput(engine.NewInputTextStream(strings.NewReader(tc.input)))
 
 						err := interpreter.Compile(ctx, tc.program)
-						So(err, ShouldEqual, nil)
+						So(err, ShouldBeNil)
 
 						Convey("When the predicate is called", func() {
 							sols, err := interpreter.QueryContext(ctx, tc.query)
 
 							Convey("Then the error should be nil", func() {
-								So(err, ShouldEqual, nil)
+								So(err, ShouldBeNil)
 								So(sols, ShouldNotBeNil)
 
 								Convey("and the bindings should be as expected", func() {
@@ -173,10 +173,10 @@ func TestReadString(t *testing.T) {
 										got = append(got, m)
 									}
 									if tc.wantError != nil {
-										So(sols.Err(), ShouldNotEqual, nil)
+										So(sols.Err(), ShouldNotBeNil)
 										So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 									} else {
-										So(sols.Err(), ShouldEqual, nil)
+										So(sols.Err(), ShouldBeNil)
 
 										if tc.wantSuccess {
 											So(len(got), ShouldBeGreaterThan, 0)
@@ -347,13 +347,13 @@ func TestStringBytes(t *testing.T) {
 								})
 
 								Convey("Then the error should be nil", func() {
-									So(err, ShouldEqual, nil)
+									So(err, ShouldBeNil)
 									So(sols, ShouldNotBeNil)
 
 									Convey("and the result should be as expected", func() {
 										if tc.wantError != nil {
 											sols.Next()
-											So(sols.Err(), ShouldNotEqual, nil)
+											So(sols.Err(), ShouldNotBeNil)
 											So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 										} else {
 											nb := 0
@@ -362,7 +362,7 @@ func TestStringBytes(t *testing.T) {
 												So(sols.Scan(m), ShouldBeNil)
 												nb++
 											}
-											So(sols.Err(), ShouldEqual, nil)
+											So(sols.Err(), ShouldBeNil)
 											if tc.wantSuccess {
 												So(nb, ShouldEqual, 1)
 											} else {

--- a/x/logic/predicate/uri_test.go
+++ b/x/logic/predicate/uri_test.go
@@ -203,7 +203,7 @@ func TestURIEncoded(t *testing.T) {
 										got = append(got, m)
 									}
 									if tc.wantError != nil {
-										So(sols.Err(), ShouldNotEqual, nil)
+										So(sols.Err(), ShouldNotBeNil)
 										So(sols.Err().Error(), ShouldEqual, tc.wantError.Error())
 									} else {
 										So(sols.Err(), ShouldBeNil)

--- a/x/logic/prolog/hex_test.go
+++ b/x/logic/prolog/hex_test.go
@@ -45,7 +45,7 @@ func TestTermHexToBytes(t *testing.T) {
 						})
 					} else {
 						Convey("then error should occurs", func() {
-							So(err, ShouldNotEqual, nil)
+							So(err, ShouldNotBeNil)
 
 							Convey("and should be as expected", func() {
 								So(err.Error(), ShouldEqual, tc.wantError.Error())

--- a/x/logic/prolog/json_test.go
+++ b/x/logic/prolog/json_test.go
@@ -67,7 +67,7 @@ func TestExtractJsonTerm(t *testing.T) {
 						})
 					} else {
 						Convey("then error should occurs", func() {
-							So(err, ShouldNotEqual, nil)
+							So(err, ShouldNotBeNil)
 							So(tc.wantError, ShouldNotBeNil)
 
 							Convey("and should be as expected", func() {

--- a/x/logic/prolog/option_test.go
+++ b/x/logic/prolog/option_test.go
@@ -150,7 +150,7 @@ func TestGetOption(t *testing.T) {
 
 					if tc.wantError == nil {
 						Convey("then no error should be thrown", func() {
-							So(err, ShouldEqual, nil)
+							So(err, ShouldBeNil)
 
 							Convey("and result should be as expected", func() {
 								So(result, ShouldEqual, tc.wantResult)
@@ -161,7 +161,7 @@ func TestGetOption(t *testing.T) {
 							So(result, ShouldEqual, tc.wantResult)
 						})
 						Convey("then error should occurs", func() {
-							So(err, ShouldNotEqual, nil)
+							So(err, ShouldNotBeNil)
 
 							Convey("and should be as expected", func() {
 								So(err.Error(), ShouldEqual, tc.wantError.Error())


### PR DESCRIPTION
The resolution of https://github.com/ichiban/prolog/issues/311 in the [v1.1.3 release](https://github.com/ichiban/prolog/releases/tag/v1.1.3) of [ichiban/prolog](https://github.com/ichiban/prolog), and the subsequent update in https://github.com/okp4/okp4d/pull/517, allows the reintegration of the `nil` assertions from [smartystreets/goconvey](https://github.com/smartystreets/goconvey) (such as `ShouldNotBeNil`) into our tests.