### PR TITLE
Feat/cli keys show

### DIFF
--- a/client/keys/did.go
+++ b/client/keys/did.go
@@ -29,37 +29,41 @@ Example:
     $ %s keys did 02d0fe99b214aaeeb5e46ae4d65a1623a95d9d0cecd57d673f7e4c9a19ac0752bc -t %s
 			`, util.KeyAlgEd25519, util.KeyAlgSecp256k1, version.AppName, util.KeyAlgSecp256k1, version.AppName, util.KeyAlgSecp256k1),
 		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			pubkeyType, err := cmd.Flags().GetString(flagPubKeyType)
-			if err != nil {
-				return err
-			}
-			pubkeyAlgo, err := util.ParseKeyAlg(pubkeyType)
-			if err != nil {
-				return errorsmod.Wrapf(errors.ErrInvalidType,
-					"invalid pubkey type; expected oneof %+q", []util.KeyAlg{util.KeyAlgSecp256k1, util.KeyAlgEd25519})
-			}
-			bs, err := getBytesFromString(args[0])
-			if err != nil {
-				return err
-			}
-			pubKey, err := util.BytesToPubKey(bs, pubkeyAlgo)
-			if err != nil {
-				return errorsmod.Wrapf(errors.ErrInvalidPubKey, "failed to make pubkey from %s; %s", args[0], err)
-			}
-			did, err := util.CreateDIDKeyByPubKey(pubKey)
-			if err != nil {
-				return errorsmod.Wrapf(errors.ErrInvalidPubKey, "failed to make did:key from %s; %s", args[0], err)
-			}
-
-			cmd.Println(did)
-
-			return nil
-		},
+		RunE: runDidCmd(),
 	}
 	cmd.Flags().StringP(flagPubKeyType, "t", util.KeyAlgSecp256k1.String(),
 		fmt.Sprintf("Pubkey type to decode (oneof %s, %s)", util.KeyAlgEd25519, util.KeyAlgSecp256k1))
 	return cmd
+}
+
+func runDidCmd() func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		pubkeyType, err := cmd.Flags().GetString(flagPubKeyType)
+		if err != nil {
+			return err
+		}
+		pubkeyAlgo, err := util.ParseKeyAlg(pubkeyType)
+		if err != nil {
+			return errorsmod.Wrapf(errors.ErrInvalidType,
+				"invalid pubkey type; expected oneof %+q", []util.KeyAlg{util.KeyAlgSecp256k1, util.KeyAlgEd25519})
+		}
+		bs, err := getBytesFromString(args[0])
+		if err != nil {
+			return err
+		}
+		pubKey, err := util.BytesToPubKey(bs, pubkeyAlgo)
+		if err != nil {
+			return errorsmod.Wrapf(errors.ErrInvalidPubKey, "failed to make pubkey from %s; %s", args[0], err)
+		}
+		did, err := util.CreateDIDKeyByPubKey(pubKey)
+		if err != nil {
+			return errorsmod.Wrapf(errors.ErrInvalidPubKey, "failed to make did:key from %s; %s", args[0], err)
+		}
+
+		cmd.Println(did)
+
+		return nil
+	}
 }
 
 func getBytesFromString(pubKey string) ([]byte, error) {

--- a/client/keys/list.go
+++ b/client/keys/list.go
@@ -5,18 +5,22 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/client/keys"
 )
 
 const (
 	flagListNames = "list-names"
+	listKeysCmd   = "list"
 )
 
-// KeyOutput is the output format for keys when listing them.
-// It is an improved copy of the KeyOutput from the keys module (github.com/cosmos/cosmos-sdk/client/keys/types.go).
-type KeyOutput struct {
-	keys.KeyOutput
-	DID string `json:"did,omitempty" yaml:"did"`
+// EnhanceListCmd replaces the original 'list' command implementation with our own 'list' command which
+// will allow us to list did:key of the keys as well as the original keys.
+func EnhanceListCmd(cmd *cobra.Command) {
+	for _, c := range cmd.Commands() {
+		if c.Name() == listKeysCmd {
+			c.RunE = runListCmd
+			break
+		}
+	}
 }
 
 // runListCmd retrieves all keys from the keyring and prints them to the console.

--- a/client/keys/list.go
+++ b/client/keys/list.go
@@ -1,24 +1,15 @@
 package keys
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/yaml"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
-	cryptokeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
-
-	"github.com/okp4/okp4d/x/logic/util"
 )
 
 const (
 	flagListNames = "list-names"
-	ListCmdName   = "list"
 )
 
 // KeyOutput is the output format for keys when listing them.
@@ -28,21 +19,8 @@ type KeyOutput struct {
 	DID string `json:"did,omitempty" yaml:"did"`
 }
 
-// ListKeysCmd lists all keys in the key store with additional info, such as the did:key equivalent of the public key.
-// This is an improved copy of the ListKeysCmd from the keys module.
-func ListKeysCmd() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:   ListCmdName,
-		Short: "List all keys",
-		Long: `Return a list of all public keys stored by this key manager
-along with their associated name, address and decentralized identifier (for supported public key algorithms)`,
-		RunE: runListCmd,
-	}
-
-	cmd.Flags().BoolP(flagListNames, "n", false, "List names only")
-	return cmd
-}
-
+// runListCmd retrieves all keys from the keyring and prints them to the console.
+// This is an improved copy of the runListCmd from the keys module of the cosmos-sdk.
 func runListCmd(cmd *cobra.Command, _ []string) error {
 	clientCtx, err := client.GetClientQueryContext(cmd)
 	if err != nil {
@@ -68,66 +46,4 @@ func runListCmd(cmd *cobra.Command, _ []string) error {
 	}
 
 	return nil
-}
-
-func printKeyringRecords(w io.Writer, records []*cryptokeyring.Record, output string) error {
-	kos, err := mkKeyOutput(records)
-	if err != nil {
-		return err
-	}
-
-	switch output {
-	case flags.OutputFormatText:
-		if err := printTextRecords(w, kos); err != nil {
-			return err
-		}
-
-	case flags.OutputFormatJSON:
-		out, err := json.Marshal(kos)
-		if err != nil {
-			return err
-		}
-
-		if _, err := fmt.Fprintf(w, "%s", out); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-func printTextRecords(w io.Writer, kos []KeyOutput) error {
-	out, err := yaml.Marshal(&kos)
-	if err != nil {
-		return err
-	}
-
-	if _, err := fmt.Fprintln(w, string(out)); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func mkKeyOutput(records []*cryptokeyring.Record) ([]KeyOutput, error) {
-	kos := make([]KeyOutput, len(records))
-
-	for i, r := range records {
-		kko, err := keys.MkAccKeyOutput(r)
-		if err != nil {
-			return nil, err
-		}
-		pk, err := r.GetPubKey()
-		if err != nil {
-			return nil, err
-		}
-		did, _ := util.CreateDIDKeyByPubKey(pk)
-
-		kos[i] = KeyOutput{
-			KeyOutput: kko,
-			DID:       did,
-		}
-	}
-
-	return kos, nil
 }

--- a/client/keys/root.go
+++ b/client/keys/root.go
@@ -4,20 +4,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	listKeysCmd = "list"
+	showKeysCmd = "show"
+)
+
 // Enhance augment the given command which is assumed to be the root command of the 'list' command.
 // It will:
 // - add the 'did' command.
-// - replace the original 'list' command with our own 'list' command which will list all did:key.
+// - replace the original 'list' command implementation with our own 'list' command which will list all did:key.
+// - replace the original 'show' command implementation with our own 'show' command which will show the did:key of the key.
 func Enhance(cmd *cobra.Command) *cobra.Command {
 	cmd.AddCommand(
 		DIDCmd(),
 	)
 
-	for i, c := range cmd.Commands() {
-		if c.Name() == ListCmdName {
-			cmd.RemoveCommand(cmd.Commands()[i])
-			cmd.AddCommand(ListKeysCmd())
-			break
+	for _, c := range cmd.Commands() {
+		switch c.Name() {
+		case listKeysCmd:
+			c.RunE = runListCmd
+		case showKeysCmd:
+			c.RunE = runShowCmd
+		default:
 		}
 	}
 

--- a/client/keys/root.go
+++ b/client/keys/root.go
@@ -4,11 +4,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	listKeysCmd = "list"
-	showKeysCmd = "show"
-)
-
 // Enhance augment the given command which is assumed to be the root command of the 'list' command.
 // It will:
 // - add the 'did' command.
@@ -19,15 +14,8 @@ func Enhance(cmd *cobra.Command) *cobra.Command {
 		DIDCmd(),
 	)
 
-	for _, c := range cmd.Commands() {
-		switch c.Name() {
-		case listKeysCmd:
-			c.RunE = runListCmd
-		case showKeysCmd:
-			c.RunE = runShowCmd
-		default:
-		}
-	}
+	EnhanceListCmd(cmd)
+	EnhanceShowCmd(cmd)
 
 	return cmd
 }

--- a/client/keys/show.go
+++ b/client/keys/show.go
@@ -1,0 +1,180 @@
+package keys
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	errorsmod "cosmossdk.io/errors"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/keys"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
+	"github.com/cosmos/cosmos-sdk/crypto/ledger"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerr "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+const (
+	flagMultiSigThreshold = "multisig-threshold"
+)
+
+func runShowCmd(cmd *cobra.Command, args []string) error {
+	clientCtx, err := client.GetClientQueryContext(cmd)
+	if err != nil {
+		return err
+	}
+
+	var keyRecord *keyring.Record
+	if len(args) == 1 {
+		keyRecord, err = fetchKey(clientCtx.Keyring, args[0])
+		if err != nil {
+			return fmt.Errorf("%s is not a valid name or address: %w", args[0], err)
+		}
+	} else {
+		keyRecord, err = fetchMultiSigKey(cmd, clientCtx, args)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := checkFlagCompatibility(cmd); err != nil {
+		return err
+	}
+
+	bechPrefix, _ := cmd.Flags().GetString(keys.FlagBechPrefix)
+	bechKeyOut, err := getBechKeyOut(bechPrefix)
+	if err != nil {
+		return err
+	}
+
+	if err := processOutput(cmd, clientCtx, keyRecord, bechKeyOut); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func fetchMultiSigKey(cmd *cobra.Command, clientCtx client.Context, args []string) (*keyring.Record, error) {
+	pks := make([]cryptotypes.PubKey, len(args))
+	for i, keyRef := range args {
+		k, err := fetchKey(clientCtx.Keyring, keyRef)
+		if err != nil {
+			return nil, fmt.Errorf("%s is not a valid name or address: %w", keyRef, err)
+		}
+		pubKey, err := k.GetPubKey()
+		if err != nil {
+			return nil, err
+		}
+		pks[i] = pubKey
+	}
+
+	multisigThreshold, _ := cmd.Flags().GetInt(flagMultiSigThreshold)
+	if err := validateMultisigThreshold(multisigThreshold, len(args)); err != nil {
+		return nil, err
+	}
+
+	multiKey := multisig.NewLegacyAminoPubKey(multisigThreshold, pks)
+	return keyring.NewMultiRecord(args[0], multiKey)
+}
+
+func checkFlagCompatibility(cmd *cobra.Command) error {
+	isShowAddr, _ := cmd.Flags().GetBool(keys.FlagAddress)
+	isShowPubKey, _ := cmd.Flags().GetBool(keys.FlagPublicKey)
+	if isShowAddr && isShowPubKey {
+		return errors.New("cannot use both --address and --pubkey at once")
+	}
+
+	isOutputSet := cmd.Flag(flags.FlagOutput) != nil && cmd.Flag(flags.FlagOutput).Changed
+	if isOutputSet && (isShowAddr || isShowPubKey) {
+		return errors.New("cannot use --output with --address or --pubkey")
+	}
+
+	return nil
+}
+
+func processOutput(cmd *cobra.Command, clientCtx client.Context, k *keyring.Record, bechKeyOut bechKeyOutFn) error {
+	isShowAddr, _ := cmd.Flags().GetBool(keys.FlagAddress)
+	isShowPubKey, _ := cmd.Flags().GetBool(keys.FlagPublicKey)
+	isShowDevice, _ := cmd.Flags().GetBool(keys.FlagDevice)
+
+	if isShowDevice {
+		return handleDeviceOutput(k)
+	}
+
+	if isShowAddr || isShowPubKey {
+		ko, err := bechKeyOut(k)
+		if err != nil {
+			return err
+		}
+		out := ko.Address
+		if isShowPubKey {
+			out = ko.PubKey
+		}
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), out)
+		return err
+	}
+
+	outputFormat := clientCtx.OutputFormat
+	return printKeyringRecord(cmd.OutOrStdout(), k, bechKeyOut, outputFormat)
+}
+
+func handleDeviceOutput(k *keyring.Record) error {
+	if k.GetType() != keyring.TypeLedger {
+		return fmt.Errorf("the device flag (-d) can only be used for ledger keys")
+	}
+	ledgerItem := k.GetLedger()
+	if ledgerItem == nil {
+		return errors.New("unable to get ledger item")
+	}
+	pk, err := k.GetPubKey()
+	if err != nil {
+		return err
+	}
+	bechPrefix := sdk.GetConfig().GetBech32AccountAddrPrefix()
+	return ledger.ShowAddress(*ledgerItem.Path, pk, bechPrefix)
+}
+
+func fetchKey(kb keyring.Keyring, keyref string) (*keyring.Record, error) {
+	k, err := kb.Key(keyref)
+
+	if err == nil || !errorsmod.IsOf(err, sdkerr.ErrIO, sdkerr.ErrKeyNotFound) {
+		return k, err
+	}
+
+	accAddr, err := sdk.AccAddressFromBech32(keyref)
+	if err != nil {
+		return k, err
+	}
+
+	k, err = kb.KeyByAddress(accAddr)
+	return k, errorsmod.Wrap(err, "Invalid key")
+}
+
+func validateMultisigThreshold(k, nKeys int) error {
+	if k <= 0 {
+		return fmt.Errorf("threshold must be a positive integer")
+	}
+	if nKeys < k {
+		return fmt.Errorf(
+			"threshold k of n multisignature: %d < %d", nKeys, k)
+	}
+	return nil
+}
+
+func getBechKeyOut(bechPrefix string) (bechKeyOutFn, error) {
+	switch bechPrefix {
+	case sdk.PrefixAccount:
+		return keys.MkAccKeyOutput, nil
+	case sdk.PrefixValidator:
+		return keys.MkValKeyOutput, nil
+	case sdk.PrefixConsensus:
+		return keys.MkConsKeyOutput, nil
+	}
+
+	return nil, fmt.Errorf("invalid Bech32 prefix encoding provided: %s", bechPrefix)
+}

--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -1,0 +1,114 @@
+package keys
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/client/keys"
+	cryptokeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+
+	"github.com/okp4/okp4d/x/logic/util"
+)
+
+type bechKeyOutFn func(k *cryptokeyring.Record) (keys.KeyOutput, error)
+
+func printKeyringRecord(w io.Writer, k *cryptokeyring.Record, bechKeyOut bechKeyOutFn, output string) error {
+	ko, err := mkKeyOutput(k, bechKeyOut)
+	if err != nil {
+		return err
+	}
+
+	switch output {
+	case flags.OutputFormatText:
+		if err := printTextRecords(w, []KeyOutput{ko}); err != nil {
+			return err
+		}
+
+	case flags.OutputFormatJSON:
+		out, err := json.Marshal(ko)
+		if err != nil {
+			return err
+		}
+
+		if _, err := fmt.Fprintln(w, string(out)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func printKeyringRecords(w io.Writer, records []*cryptokeyring.Record, output string) error {
+	kos, err := mkKeysOutput(records)
+	if err != nil {
+		return err
+	}
+
+	switch output {
+	case flags.OutputFormatText:
+		if err := printTextRecords(w, kos); err != nil {
+			return err
+		}
+
+	case flags.OutputFormatJSON:
+		out, err := json.Marshal(kos)
+		if err != nil {
+			return err
+		}
+
+		if _, err := fmt.Fprintf(w, "%s", out); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func printTextRecords(w io.Writer, kos []KeyOutput) error {
+	out, err := yaml.Marshal(&kos)
+	if err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintln(w, string(out)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func mkKeysOutput(records []*cryptokeyring.Record) ([]KeyOutput, error) {
+	kos := make([]KeyOutput, len(records))
+
+	for i, r := range records {
+		kko, err := mkKeyOutput(r, keys.MkAccKeyOutput)
+		if err != nil {
+			return nil, err
+		}
+
+		kos[i] = kko
+	}
+
+	return kos, nil
+}
+
+func mkKeyOutput(record *cryptokeyring.Record, bechKeyOut bechKeyOutFn) (KeyOutput, error) {
+	kko, err := bechKeyOut(record)
+	if err != nil {
+		return KeyOutput{}, err
+	}
+	pk, err := record.GetPubKey()
+	if err != nil {
+		return KeyOutput{}, err
+	}
+	did, _ := util.CreateDIDKeyByPubKey(pk)
+
+	return KeyOutput{
+		KeyOutput: kko,
+		DID:       did,
+	}, nil
+}

--- a/docs/command/okp4d_keys_list.md
+++ b/docs/command/okp4d_keys_list.md
@@ -5,7 +5,7 @@ List all keys
 ### Synopsis
 
 Return a list of all public keys stored by this key manager
-along with their associated name, address and decentralized identifier (for supported public key algorithms)
+along with their associated name and address.
 
 ```
 okp4d keys list [flags]

--- a/docs/command/okp4d_keys_show.md
+++ b/docs/command/okp4d_keys_show.md
@@ -18,6 +18,7 @@ okp4d keys show [name_or_address [name_or_address...]] [flags]
   -a, --address                  Output the address only (overrides --output)
       --bech string              The Bech32 prefix encoding for a key (acc|val|cons) (default "acc")
   -d, --device                   Output the address in a ledger device
+  -k, --did                      Output the did:key only (overrides --output)
   -h, --help                     help for show
       --multisig-threshold int   K out of N required signatures (default 1)
   -p, --pubkey                   Output the public key only (overrides --output)


### PR DESCRIPTION
In continuation of #536, this PR enhances the existing Cosmos SDK `keys show` command by outputing the `did:key` value for keys, specifically for `secp256k1` and `ed25519` public keys.

_Examples:_

```shell
$ okp4d keys show test1 --keyring-backend test

- address: okp415z956su069rt896dk5zrl7jmvzt9uu2gt92hku
  did: did:key:zQ3shrJ8tZURFSjbCJdmrAawZiFGibuFgBt1fVQHcZzjuWhFf
  name: test1
  pubkey: '{"@type":"/cosmos.crypto.secp256k1.PubKey","key":"A60unqk5BbIO42TRGSDYlIUIKTzwkT6wir1igQCf5Q46"}'
  type: local
```

```shell
$ okp4d keys show test1 --did --keyring-backend test
did:key:zQ3shrJ8tZURFSjbCJdmrAawZiFGibuFgBt1fVQHcZzjuWhFf
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced 'show' command to display the decentralized identifier (DID) of a key.
- **Refactor**
	- Improved key management commands, including refactoring and renaming for better clarity and functionality.
- **Documentation**
	- Updated documentation to reflect changes in key listing and showing commands, including the addition of a new option to display a key's DID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->