### PR TITLE
feat(cli): add schema-map flag to credential sign command

### DIFF
--- a/docs/command/okp4d_credential_sign.md
+++ b/docs/command/okp4d_credential_sign.md
@@ -21,6 +21,7 @@ okp4d credential sign [file] [flags]
       --keyring-backend string   Select keyring's backend (os|file|kwallet|pass|test|memory) (default "test")
       --keyring-dir string       The client Keyring directory; if omitted, the default 'home' directory will be used
       --overwrite                Overwrite existing signatures with a new one. If disabled, new signature will be appended
+      --schema-map strings       Map original URIs to alternative URIs for resolving JSON-LD schemas. Useful for redirecting network-based URIs to local filesystem paths or other URIs. Each mapping should be in the format 'originalURI=alternativeURI'. Multiple mappings can be provided by repeating the flag. Example usage: --schema-map originalURI1=alternativeURI1 --schema-map originalURI2=alternativeURI2
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
Introduce a new flag for the credential signing command to define mappings between original and alternative URIs for JSON-LD schema resolution.

This is useful in situation when a network connection is unavailable or when JSON-LD schemas cannot be resolved due to them not being deployed yet.

_Examples:_

v2 -> vnext substitution:

```shell
okp4d credential sign ipfs-description.jsonld \
  --schema-map  "https://w3id.org/okp4/ontology/v2/schema/credential/digital-service/description/=https://w3id.org/okp4/ontology/vnext/schema/credential/digital-service/description/" \
  --from my-key 
```

network -> local file substitution:

```shell
okp4d credential sign ipfs-description.jsonld \
  --schema-map "https://w3id.org/okp4/ontology/v2/schema/credential/digital-service/description/=/ontology/schema/digital-service/credential-digital-service-description.jsonld"  \
  --from my-key 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced schema mapping support for signing verifiable credentials, allowing users to map original URIs to alternative ones for JSON-LD schema resolution.
- **Documentation**
	- Updated the documentation to include the new `--schema-map` flag for the `okp4d credential sign` command, enhancing user guidance on schema mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->