### PR TITLE
docs(logic): fix missing language for fenced code

### DIFF
--- a/docs/predicate/bech32_address_2.md
+++ b/docs/predicate/bech32_address_2.md
@@ -135,7 +135,7 @@ Here's the steps of the scenario:
 
 - **Given** the program:
 
-```
+```  prolog
 okp4_addr(Addr) :- bech32_address(-('okp4', _), Addr).
 ```
 

--- a/scripts/templates/func.go.txt
+++ b/scripts/templates/func.go.txt
@@ -29,7 +29,7 @@ Here's the steps of the scenario:
 - **{{ .Keyword | trim }}** {{ .Text }}
 {{- if .DocString -}}
 {{- spacer -}}
-``` {{ .DocString.MediaType }}
+``` {{ .DocString.MediaType | default "text" }}
 {{ .DocString.Content }}
 ```
 {{- end -}}

--- a/x/logic/keeper/features/bech32_address_2.feature
+++ b/x/logic/keeper/features/bech32_address_2.feature
@@ -86,7 +86,7 @@ Feature: bech32_address/2
     This scenario shows how to check if a bech32 address is part of the okp4 protocol.
 
     Given the program:
-      """
+      """ prolog
       okp4_addr(Addr) :- bech32_address(-('okp4', _), Addr).
       """
     Given the query:
@@ -104,7 +104,7 @@ Feature: bech32_address/2
     This scenario shows how to check if a bech32 address is part of the okp4 protocol.
 
     Given the program:
-      """
+      """ prolog
       okp4_addr(Addr) :- bech32_address(-('okp4', _), Addr).
       """
     Given the query:


### PR DESCRIPTION
Fix the absence of a language spec in the fenced code block for the "program" section of the feature scenario. This adjustment is needed to satisfy the requirements of the [okp4/docs](https://github.com/okp4/docs) linter, cf error reported:

```
predicates/bech32_address_2.md:138 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "```"]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity in documentation by adding language hints to code blocks.
- **New Features**
	- Enhanced interpretation of program blocks in scenarios by adding specific language tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->