### PR TITLE
ci(workflow): fix incorrect workflow URL (Bump okp4d version)

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Update docs version
         uses: fjogeleit/http-request-action@v1
         with:
-          url: 'https://api.github.com/repos/okp4/docs/actions/workflows/bump-okp4d-version/dispatches'
+          url: 'https://api.github.com/repos/okp4/docs/actions/workflows/37674835/dispatches'
           method: 'POST'
           customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OKP4_TOKEN }}"}'
           data: |-


### PR DESCRIPTION
Self explanatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the URL for triggering workflow dispatch in the release notification process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->