### PR TITLE
Ci/manage go mod versioning

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -22,6 +22,32 @@ plugins:
               numReplacements: 1
   - - "@semantic-release/exec"
     - prepareCmd: |
+        major_version=$(cat version | cut -d. -f1)
+        if [ $major_version -gt 1 ]; then
+            module_name=$(go mod edit -json | jq -r '.Module.Path')
+            module_name_unversioned=$(echo ${module_name} | sed -E 's|/v[0-9]+$||')
+            module_name_versioned="${module_name_unversioned}/v${major_version}"
+            echo "🔬 major version detected, updating module path to ${module_name_versioned}"
+
+            go mod edit -module "${module_name_versioned}"
+            echo "✅ module name updated to ${module_name_versioned} in go.mod"
+
+            if [ "$(uname)" = "Darwin" ]; then
+              find . -type f -name "*.go" -exec \
+                sed -i '' "s|\"${module_name}|\"${module_name_versioned}|g" {} \;
+            else
+              find . -type f -name "*.go" -exec \
+                sed -i "s|\"${module_name}|\"${module_name_versioned}|g" {} \;
+            fi
+            echo "✅ packages updated to ${module_name_versioned} in source files"
+
+            echo "🧹 cleaning up go.sum"
+            go mod tidy
+        else
+            echo "🙅version is not greater than 1, no need to update module path"
+        fi
+  - - "@semantic-release/exec"
+    - prepareCmd: |
         make release-assets
   - - "@semantic-release/github"
     - assets:
@@ -34,4 +60,7 @@ plugins:
     - assets:
         - CHANGELOG.md
         - version
+        - go.mod
+        - go.sum
+        - "**/*.go"
       message: "chore(release): perform release ${nextRelease.version}"

--- a/app/app.go
+++ b/app/app.go
@@ -137,17 +137,17 @@ import (
 	ibckeeper "github.com/cosmos/ibc-go/v8/modules/core/keeper"
 	ibctm "github.com/cosmos/ibc-go/v8/modules/light-clients/07-tendermint"
 
-	okp4wasm "github.com/okp4/okp4d/app/wasm"
-	"github.com/okp4/okp4d/docs"
-	logicmodule "github.com/okp4/okp4d/x/logic"
-	logicfs "github.com/okp4/okp4d/x/logic/fs"
-	logicmodulekeeper "github.com/okp4/okp4d/x/logic/keeper"
-	logicmoduletypes "github.com/okp4/okp4d/x/logic/types"
-	"github.com/okp4/okp4d/x/mint"
-	mintkeeper "github.com/okp4/okp4d/x/mint/keeper"
-	minttypes "github.com/okp4/okp4d/x/mint/types"
-	"github.com/okp4/okp4d/x/vesting"
-	vestingtypes "github.com/okp4/okp4d/x/vesting/types"
+	okp4wasm "github.com/okp4/okp4d/v7/app/wasm"
+	"github.com/okp4/okp4d/v7/docs"
+	logicmodule "github.com/okp4/okp4d/v7/x/logic"
+	logicfs "github.com/okp4/okp4d/v7/x/logic/fs"
+	logicmodulekeeper "github.com/okp4/okp4d/v7/x/logic/keeper"
+	logicmoduletypes "github.com/okp4/okp4d/v7/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/mint"
+	mintkeeper "github.com/okp4/okp4d/v7/x/mint/keeper"
+	minttypes "github.com/okp4/okp4d/v7/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/vesting"
+	vestingtypes "github.com/okp4/okp4d/v7/x/vesting/types"
 )
 
 const (

--- a/app/encoding.go
+++ b/app/encoding.go
@@ -9,7 +9,7 @@ import (
 
 	simtestutil "github.com/cosmos/cosmos-sdk/testutil/sims"
 
-	"github.com/okp4/okp4d/app/params"
+	"github.com/okp4/okp4d/v7/app/params"
 )
 
 // makeEncodingConfig creates an EncodingConfig test configuration.

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -3,7 +3,7 @@ package app
 import (
 	"fmt"
 
-	v7 "github.com/okp4/okp4d/app/upgrades/v7"
+	v7 "github.com/okp4/okp4d/v7/app/upgrades/v7"
 )
 
 // RegisterUpgradeHandlers registers the chain upgrade handlers.

--- a/app/wasm/query.go
+++ b/app/wasm/query.go
@@ -11,8 +11,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	logickeeper "github.com/okp4/okp4d/x/logic/keeper"
-	logicwasm "github.com/okp4/okp4d/x/logic/wasm"
+	logickeeper "github.com/okp4/okp4d/v7/x/logic/keeper"
+	logicwasm "github.com/okp4/okp4d/v7/x/logic/wasm"
 )
 
 // customQuery represents the wasm custom query structure, it is intended to allow wasm contracts to execute queries

--- a/client/credential/sign.go
+++ b/client/credential/sign.go
@@ -26,7 +26,7 @@ import (
 	sdkerr "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 
-	"github.com/okp4/okp4d/x/logic/util"
+	"github.com/okp4/okp4d/v7/x/logic/util"
 )
 
 const (

--- a/client/keys/did.go
+++ b/client/keys/did.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/version"
 
-	"github.com/okp4/okp4d/x/logic/util"
+	"github.com/okp4/okp4d/v7/x/logic/util"
 )
 
 var flagPubKeyType = "type"

--- a/client/keys/utils.go
+++ b/client/keys/utils.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	cryptokeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
 
-	"github.com/okp4/okp4d/x/logic/util"
+	"github.com/okp4/okp4d/v7/x/logic/util"
 )
 
 // KeyOutput is the output format for keys when listing them.

--- a/cmd/okp4d/cmd/config.go
+++ b/cmd/okp4d/cmd/config.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/app"
+	"github.com/okp4/okp4d/v7/app"
 )
 
 func initSDKConfig() {

--- a/cmd/okp4d/cmd/root.go
+++ b/cmd/okp4d/cmd/root.go
@@ -40,10 +40,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 
-	"github.com/okp4/okp4d/app"
-	appparams "github.com/okp4/okp4d/app/params"
-	"github.com/okp4/okp4d/client/credential"
-	okp4keys "github.com/okp4/okp4d/client/keys"
+	"github.com/okp4/okp4d/v7/app"
+	appparams "github.com/okp4/okp4d/v7/app/params"
+	"github.com/okp4/okp4d/v7/client/credential"
+	okp4keys "github.com/okp4/okp4d/v7/client/keys"
 )
 
 // NewRootCmd creates a new root command for a Cosmos SDK application.

--- a/cmd/okp4d/main.go
+++ b/cmd/okp4d/main.go
@@ -7,8 +7,8 @@ import (
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 
-	"github.com/okp4/okp4d/app"
-	"github.com/okp4/okp4d/cmd/okp4d/cmd"
+	"github.com/okp4/okp4d/v7/app"
+	"github.com/okp4/okp4d/v7/cmd/okp4d/cmd"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/okp4/okp4d
+module github.com/okp4/okp4d/v7
 
 go 1.21
 
@@ -45,6 +45,7 @@ require (
 	github.com/princjef/gomarkdoc v1.1.0
 	github.com/prometheus/client_golang v1.18.0
 	github.com/samber/lo v1.39.0
+	github.com/sergi/go-diff v1.3.1
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/spf13/cast v1.6.0
 	github.com/spf13/cobra v1.8.0
@@ -249,7 +250,6 @@ require (
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
-	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/shengdoushi/base58 v1.0.0 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.2 // indirect

--- a/scripts/generate_command_doc.go
+++ b/scripts/generate_command_doc.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra/doc"
 
-	"github.com/okp4/okp4d/cmd/okp4d/cmd"
+	"github.com/okp4/okp4d/v7/cmd/okp4d/cmd"
 )
 
 func generateCommandDocumentation() error {

--- a/x/logic/client/cli/query.go
+++ b/x/logic/client/cli/query.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 // GetQueryCmd returns the cli query commands for this module.

--- a/x/logic/client/cli/query_ask.go
+++ b/x/logic/client/cli/query_ask.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/version"
 
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 var program string

--- a/x/logic/client/cli/query_params.go
+++ b/x/logic/client/cli/query_params.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 func CmdQueryParams() *cobra.Command {

--- a/x/logic/fs/filtered_fs.go
+++ b/x/logic/fs/filtered_fs.go
@@ -4,7 +4,7 @@ import (
 	"io/fs"
 	"net/url"
 
-	"github.com/okp4/okp4d/x/logic/util"
+	"github.com/okp4/okp4d/v7/x/logic/util"
 )
 
 // FilteredFS is a wrapper around a fs.FS that filters out files that are not allowed to be read.

--- a/x/logic/fs/filtered_fs_test.go
+++ b/x/logic/fs/filtered_fs_test.go
@@ -12,8 +12,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/util"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/util"
 )
 
 func TestSourceFile(t *testing.T) {

--- a/x/logic/fs/wasm.go
+++ b/x/logic/fs/wasm.go
@@ -12,7 +12,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 const (

--- a/x/logic/fs/wasm_test.go
+++ b/x/logic/fs/wasm_test.go
@@ -21,7 +21,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
 )
 
 func TestWasmHandler(t *testing.T) {

--- a/x/logic/genesis.go
+++ b/x/logic/genesis.go
@@ -5,8 +5,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/keeper"
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/keeper"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 // InitGenesis initializes the module's state from a provided genesis state.

--- a/x/logic/interpreter/registry.go
+++ b/x/logic/interpreter/registry.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ichiban/prolog"
 	"github.com/ichiban/prolog/engine"
 
-	"github.com/okp4/okp4d/x/logic/predicate"
+	"github.com/okp4/okp4d/v7/x/logic/predicate"
 )
 
 // registry is a map from predicate names (in the form of "atom/arity") to predicates functions.

--- a/x/logic/keeper/features_test.go
+++ b/x/logic/keeper/features_test.go
@@ -25,10 +25,10 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/okp4/okp4d/x/logic"
-	"github.com/okp4/okp4d/x/logic/keeper"
-	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic"
+	"github.com/okp4/okp4d/v7/x/logic/keeper"
+	logictestutil "github.com/okp4/okp4d/v7/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 func TestFeatures(t *testing.T) {

--- a/x/logic/keeper/grpc_query.go
+++ b/x/logic/keeper/grpc_query.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 var _ types.QueryServiceServer = Keeper{}

--- a/x/logic/keeper/grpc_query_ask.go
+++ b/x/logic/keeper/grpc_query_ask.go
@@ -8,8 +8,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/meter"
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/meter"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 func (k Keeper) Ask(ctx goctx.Context, req *types.QueryServiceAskRequest) (response *types.QueryServiceAskResponse, err error) {

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -20,10 +20,10 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/okp4/okp4d/x/logic"
-	"github.com/okp4/okp4d/x/logic/keeper"
-	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic"
+	"github.com/okp4/okp4d/v7/x/logic/keeper"
+	logictestutil "github.com/okp4/okp4d/v7/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 func TestGRPCAsk(t *testing.T) {

--- a/x/logic/keeper/grpc_query_params.go
+++ b/x/logic/keeper/grpc_query_params.go
@@ -8,7 +8,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 func (k Keeper) Params(c context.Context, req *types.QueryServiceParamsRequest) (*types.QueryServiceParamsResponse, error) {

--- a/x/logic/keeper/grpc_query_params_test.go
+++ b/x/logic/keeper/grpc_query_params_test.go
@@ -19,10 +19,10 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/okp4/okp4d/x/logic"
-	"github.com/okp4/okp4d/x/logic/keeper"
-	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic"
+	"github.com/okp4/okp4d/v7/x/logic/keeper"
+	logictestutil "github.com/okp4/okp4d/v7/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 func TestGRPCParams(t *testing.T) {

--- a/x/logic/keeper/interpreter.go
+++ b/x/logic/keeper/interpreter.go
@@ -14,13 +14,13 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/fs"
-	"github.com/okp4/okp4d/x/logic/interpreter"
-	"github.com/okp4/okp4d/x/logic/interpreter/bootstrap"
-	"github.com/okp4/okp4d/x/logic/meter"
-	prolog2 "github.com/okp4/okp4d/x/logic/prolog"
-	"github.com/okp4/okp4d/x/logic/types"
-	"github.com/okp4/okp4d/x/logic/util"
+	"github.com/okp4/okp4d/v7/x/logic/fs"
+	"github.com/okp4/okp4d/v7/x/logic/interpreter"
+	"github.com/okp4/okp4d/v7/x/logic/interpreter/bootstrap"
+	"github.com/okp4/okp4d/v7/x/logic/meter"
+	prolog2 "github.com/okp4/okp4d/v7/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/util"
 )
 
 const (

--- a/x/logic/keeper/keeper.go
+++ b/x/logic/keeper/keeper.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 type FSProvider = func(ctx goctx.Context) fs.FS

--- a/x/logic/keeper/msg_server.go
+++ b/x/logic/keeper/msg_server.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 type msgServer struct {

--- a/x/logic/keeper/msg_server_test.go
+++ b/x/logic/keeper/msg_server_test.go
@@ -17,10 +17,10 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/okp4/okp4d/x/logic"
-	"github.com/okp4/okp4d/x/logic/keeper"
-	logictestutil "github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic"
+	"github.com/okp4/okp4d/v7/x/logic/keeper"
+	logictestutil "github.com/okp4/okp4d/v7/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 func TestUpdateParams(t *testing.T) {

--- a/x/logic/keeper/params.go
+++ b/x/logic/keeper/params.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 // GetParams get all parameters as types.Params.

--- a/x/logic/meter/weighted_test.go
+++ b/x/logic/meter/weighted_test.go
@@ -9,7 +9,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
 )
 
 func TestMultiplyUint64Overflow(t *testing.T) {

--- a/x/logic/module.go
+++ b/x/logic/module.go
@@ -16,10 +16,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
-	"github.com/okp4/okp4d/x/logic/client/cli"
-	"github.com/okp4/okp4d/x/logic/exported"
-	"github.com/okp4/okp4d/x/logic/keeper"
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/client/cli"
+	"github.com/okp4/okp4d/v7/x/logic/exported"
+	"github.com/okp4/okp4d/v7/x/logic/keeper"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 var (

--- a/x/logic/predicate/address.go
+++ b/x/logic/predicate/address.go
@@ -5,7 +5,7 @@ import (
 
 	bech322 "github.com/cosmos/cosmos-sdk/types/bech32"
 
-	"github.com/okp4/okp4d/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/prolog"
 )
 
 // Bech32Address is a predicate that convert a [bech32] encoded string into [base64] bytes and give the address prefix,

--- a/x/logic/predicate/bank.go
+++ b/x/logic/predicate/bank.go
@@ -7,8 +7,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/prolog"
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 // BankBalances is a predicate which unifies the given terms with the list of balances (coins) of the given account.

--- a/x/logic/predicate/bank_test.go
+++ b/x/logic/predicate/bank_test.go
@@ -22,8 +22,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 func TestBank(t *testing.T) {

--- a/x/logic/predicate/block.go
+++ b/x/logic/predicate/block.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ichiban/prolog/engine"
 
-	"github.com/okp4/okp4d/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/prolog"
 )
 
 // BlockHeight is a predicate which unifies the given term with the current block height.

--- a/x/logic/predicate/block_test.go
+++ b/x/logic/predicate/block_test.go
@@ -18,7 +18,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
 )
 
 func TestBlock(t *testing.T) {

--- a/x/logic/predicate/builtin_test.go
+++ b/x/logic/predicate/builtin_test.go
@@ -18,8 +18,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/util"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/util"
 )
 
 func TestWrite(t *testing.T) {

--- a/x/logic/predicate/chain.go
+++ b/x/logic/predicate/chain.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ichiban/prolog/engine"
 
-	"github.com/okp4/okp4d/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/prolog"
 )
 
 // ChainID is a predicate which unifies the given term with the current chain ID. The signature is:

--- a/x/logic/predicate/chain_test.go
+++ b/x/logic/predicate/chain_test.go
@@ -17,7 +17,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
 )
 
 func TestChainID(t *testing.T) {

--- a/x/logic/predicate/crypto.go
+++ b/x/logic/predicate/crypto.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/ichiban/prolog/engine"
 
-	"github.com/okp4/okp4d/x/logic/prolog"
-	"github.com/okp4/okp4d/x/logic/util"
+	"github.com/okp4/okp4d/v7/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/util"
 )
 
 // CryptoDataHash is a predicate that computes the Hash of the given Data using different algorithms.

--- a/x/logic/predicate/crypto_test.go
+++ b/x/logic/predicate/crypto_test.go
@@ -19,7 +19,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
 )
 
 func TestCryptoOperations(t *testing.T) {

--- a/x/logic/predicate/did.go
+++ b/x/logic/predicate/did.go
@@ -7,7 +7,7 @@ import (
 	godid "github.com/nuts-foundation/go-did/did"
 	"github.com/samber/lo"
 
-	"github.com/okp4/okp4d/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/prolog"
 )
 
 // DIDPrefix is the prefix for a DID.

--- a/x/logic/predicate/did_test.go
+++ b/x/logic/predicate/did_test.go
@@ -19,7 +19,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
 )
 
 func TestDID(t *testing.T) {

--- a/x/logic/predicate/encoding.go
+++ b/x/logic/predicate/encoding.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ichiban/prolog/engine"
 
-	"github.com/okp4/okp4d/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/prolog"
 )
 
 // HexBytes is a predicate that unifies hexadecimal encoded bytes to a list of bytes.

--- a/x/logic/predicate/encoding_test.go
+++ b/x/logic/predicate/encoding_test.go
@@ -19,7 +19,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
 )
 
 func TestHexBytesPredicate(t *testing.T) {

--- a/x/logic/predicate/file.go
+++ b/x/logic/predicate/file.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ichiban/prolog/engine"
 
-	"github.com/okp4/okp4d/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/prolog"
 )
 
 // SourceFile is a predicate that unify the given term with the currently loaded source file.

--- a/x/logic/predicate/file_test.go
+++ b/x/logic/predicate/file_test.go
@@ -24,8 +24,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/fs"
-	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/fs"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
 )
 
 func TestSourceFile(t *testing.T) {

--- a/x/logic/predicate/json.go
+++ b/x/logic/predicate/json.go
@@ -13,7 +13,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/prolog"
 )
 
 // JSONProlog is a predicate that will unify a JSON string into prolog terms and vice versa.

--- a/x/logic/predicate/json_test.go
+++ b/x/logic/predicate/json_test.go
@@ -19,7 +19,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
 )
 
 func TestJsonProlog(t *testing.T) {

--- a/x/logic/predicate/string.go
+++ b/x/logic/predicate/string.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ichiban/prolog/engine"
 
-	"github.com/okp4/okp4d/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/prolog"
 )
 
 // ReadString is a predicate that reads characters from the provided Stream and unifies them with String.

--- a/x/logic/predicate/string_test.go
+++ b/x/logic/predicate/string_test.go
@@ -19,7 +19,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
 )
 
 func TestReadString(t *testing.T) {

--- a/x/logic/predicate/uri.go
+++ b/x/logic/predicate/uri.go
@@ -3,7 +3,7 @@ package predicate
 import (
 	"github.com/ichiban/prolog/engine"
 
-	"github.com/okp4/okp4d/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/prolog"
 )
 
 // URIEncoded is a predicate that unifies the given URI component with the given encoded or decoded string.

--- a/x/logic/predicate/uri_test.go
+++ b/x/logic/predicate/uri_test.go
@@ -19,7 +19,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
 )
 
 func TestURIEncoded(t *testing.T) {

--- a/x/logic/predicate/util.go
+++ b/x/logic/predicate/util.go
@@ -7,8 +7,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/prolog"
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/prolog"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 // SortBalances by coin denomination.

--- a/x/logic/prolog/assert.go
+++ b/x/logic/prolog/assert.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ichiban/prolog/engine"
 	"github.com/samber/lo"
 
-	"github.com/okp4/okp4d/x/logic/util"
+	"github.com/okp4/okp4d/v7/x/logic/util"
 )
 
 // PredicateMatches returns a function that matches the given predicate against the given other predicate.

--- a/x/logic/prolog/assert_test.go
+++ b/x/logic/prolog/assert_test.go
@@ -9,8 +9,8 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/okp4/okp4d/x/logic/testutil"
-	"github.com/okp4/okp4d/x/logic/util"
+	"github.com/okp4/okp4d/v7/x/logic/testutil"
+	"github.com/okp4/okp4d/v7/x/logic/util"
 )
 
 var (

--- a/x/logic/prolog/encode.go
+++ b/x/logic/prolog/encode.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ichiban/prolog/engine"
 
-	"github.com/okp4/okp4d/x/logic/util"
+	"github.com/okp4/okp4d/v7/x/logic/util"
 )
 
 // Encode encodes the given string with the given encoding.

--- a/x/logic/testutil/logic.go
+++ b/x/logic/testutil/logic.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ichiban/prolog"
 	"github.com/ichiban/prolog/engine"
 
-	"github.com/okp4/okp4d/x/logic/interpreter/bootstrap"
+	"github.com/okp4/okp4d/v7/x/logic/interpreter/bootstrap"
 )
 
 type TermResults map[string]prolog.TermString

--- a/x/logic/types/genesis_test.go
+++ b/x/logic/types/genesis_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 func TestGenesisState_Validate(t *testing.T) {

--- a/x/logic/types/params_test.go
+++ b/x/logic/types/params_test.go
@@ -8,7 +8,7 @@ import (
 
 	"cosmossdk.io/math"
 
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 func TestValidateParams(t *testing.T) {

--- a/x/logic/util/prolog.go
+++ b/x/logic/util/prolog.go
@@ -10,7 +10,7 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 const (

--- a/x/logic/wasm/query.go
+++ b/x/logic/wasm/query.go
@@ -5,8 +5,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/logic/keeper"
-	"github.com/okp4/okp4d/x/logic/types"
+	"github.com/okp4/okp4d/v7/x/logic/keeper"
+	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
 // LogicQuerier ease the bridge between the logic module with the wasm CustomQuerier to allow wasm contracts to query

--- a/x/logic/wasm/types.go
+++ b/x/logic/wasm/types.go
@@ -1,6 +1,6 @@
 package wasm
 
-import "github.com/okp4/okp4d/x/logic/types"
+import "github.com/okp4/okp4d/v7/x/logic/types"
 
 // AskQuery implements the wasm custom Ask query JSON schema, it basically redefined the Ask gRPC request parameters
 // to keep control in case of eventual breaking change in the logic module definition, and to decouple the

--- a/x/mint/abci.go
+++ b/x/mint/abci.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/mint/keeper"
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/keeper"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 // BeginBlocker mints new tokens for the previous block.

--- a/x/mint/client/cli/query.go
+++ b/x/mint/client/cli/query.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 // GetQueryCmd returns the cli query commands for the minting module.

--- a/x/mint/client/cli/query_test.go
+++ b/x/mint/client/cli/query_test.go
@@ -18,8 +18,8 @@ import (
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	testutilmod "github.com/cosmos/cosmos-sdk/types/module/testutil"
 
-	"github.com/okp4/okp4d/x/mint"
-	mintcli "github.com/okp4/okp4d/x/mint/client/cli"
+	"github.com/okp4/okp4d/v7/x/mint"
+	mintcli "github.com/okp4/okp4d/v7/x/mint/client/cli"
 )
 
 func TestGetCmdQueryParams(t *testing.T) {

--- a/x/mint/keeper/genesis.go
+++ b/x/mint/keeper/genesis.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 // InitGenesis new mint genesis.

--- a/x/mint/keeper/genesis_test.go
+++ b/x/mint/keeper/genesis_test.go
@@ -17,10 +17,10 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-	"github.com/okp4/okp4d/x/mint"
-	"github.com/okp4/okp4d/x/mint/keeper"
-	minttestutil "github.com/okp4/okp4d/x/mint/testutil"
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint"
+	"github.com/okp4/okp4d/v7/x/mint/keeper"
+	minttestutil "github.com/okp4/okp4d/v7/x/mint/testutil"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 var minterAcc = authtypes.NewEmptyModuleAccount(types.ModuleName, authtypes.Minter)

--- a/x/mint/keeper/grpc_query.go
+++ b/x/mint/keeper/grpc_query.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	"context"
 
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 var _ types.QueryServer = queryServer{}

--- a/x/mint/keeper/grpc_query_test.go
+++ b/x/mint/keeper/grpc_query_test.go
@@ -17,10 +17,10 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/okp4/okp4d/x/mint"
-	"github.com/okp4/okp4d/x/mint/keeper"
-	minttestutil "github.com/okp4/okp4d/x/mint/testutil"
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint"
+	"github.com/okp4/okp4d/v7/x/mint/keeper"
+	minttestutil "github.com/okp4/okp4d/v7/x/mint/testutil"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 type MintTestSuite struct {

--- a/x/mint/keeper/keeper.go
+++ b/x/mint/keeper/keeper.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 // Keeper of the mint store.

--- a/x/mint/keeper/keeper_test.go
+++ b/x/mint/keeper/keeper_test.go
@@ -16,10 +16,10 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/okp4/okp4d/x/mint"
-	"github.com/okp4/okp4d/x/mint/keeper"
-	minttestutil "github.com/okp4/okp4d/x/mint/testutil"
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint"
+	"github.com/okp4/okp4d/v7/x/mint/keeper"
+	minttestutil "github.com/okp4/okp4d/v7/x/mint/testutil"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 type IntegrationTestSuite struct {

--- a/x/mint/keeper/msg_server.go
+++ b/x/mint/keeper/msg_server.go
@@ -7,7 +7,7 @@ import (
 
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 var _ types.MsgServer = msgServer{}

--- a/x/mint/keeper/msg_server_test.go
+++ b/x/mint/keeper/msg_server_test.go
@@ -5,7 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 func (s *IntegrationTestSuite) TestUpdateParams() {

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -17,10 +17,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 
-	"github.com/okp4/okp4d/x/mint/client/cli"
-	"github.com/okp4/okp4d/x/mint/keeper"
-	"github.com/okp4/okp4d/x/mint/simulation"
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/client/cli"
+	"github.com/okp4/okp4d/v7/x/mint/keeper"
+	"github.com/okp4/okp4d/v7/x/mint/simulation"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 var (

--- a/x/mint/simulation/decoder.go
+++ b/x/mint/simulation/decoder.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 // NewDecodeStore returns a decoder function closure that unmarshals the KVPair's

--- a/x/mint/simulation/decoder_test.go
+++ b/x/mint/simulation/decoder_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/kv"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 
-	"github.com/okp4/okp4d/x/mint"
-	"github.com/okp4/okp4d/x/mint/simulation"
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint"
+	"github.com/okp4/okp4d/v7/x/mint/simulation"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 func TestDecodeStore(t *testing.T) {

--- a/x/mint/simulation/genesis.go
+++ b/x/mint/simulation/genesis.go
@@ -12,7 +12,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
 
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 // Simulation parameter constants.

--- a/x/mint/simulation/genesis_test.go
+++ b/x/mint/simulation/genesis_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 
-	"github.com/okp4/okp4d/x/mint/simulation"
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/simulation"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 // TestRandomizedGenState tests the normal scenario of applying RandomizedGenState.

--- a/x/mint/simulation/proposals.go
+++ b/x/mint/simulation/proposals.go
@@ -10,7 +10,7 @@ import (
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 	"github.com/cosmos/cosmos-sdk/x/simulation"
 
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 // Simulation operation weights constants.

--- a/x/mint/simulation/proposals_test.go
+++ b/x/mint/simulation/proposals_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/address"
 	simtypes "github.com/cosmos/cosmos-sdk/types/simulation"
 
-	"github.com/okp4/okp4d/x/mint/simulation"
-	"github.com/okp4/okp4d/x/mint/types"
+	"github.com/okp4/okp4d/v7/x/mint/simulation"
+	"github.com/okp4/okp4d/v7/x/mint/types"
 )
 
 func TestProposalMsgs(t *testing.T) {

--- a/x/vesting/client/cli/tx.go
+++ b/x/vesting/client/cli/tx.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/okp4/okp4d/x/vesting/types"
+	"github.com/okp4/okp4d/v7/x/vesting/types"
 )
 
 // FlagDelayed Transaction command flags.

--- a/x/vesting/module.go
+++ b/x/vesting/module.go
@@ -18,8 +18,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 
-	"github.com/okp4/okp4d/x/vesting/client/cli"
-	"github.com/okp4/okp4d/x/vesting/types"
+	"github.com/okp4/okp4d/v7/x/vesting/client/cli"
+	"github.com/okp4/okp4d/v7/x/vesting/types"
 )
 
 var (

--- a/x/vesting/msg_server.go
+++ b/x/vesting/msg_server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-	"github.com/okp4/okp4d/x/vesting/types"
+	"github.com/okp4/okp4d/v7/x/vesting/types"
 )
 
 type msgServer struct {

--- a/x/vesting/msg_server_test.go
+++ b/x/vesting/msg_server_test.go
@@ -20,9 +20,9 @@ import (
 	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-	"github.com/okp4/okp4d/x/vesting"
-	vestingtestutil "github.com/okp4/okp4d/x/vesting/testutil"
-	vestingtypes "github.com/okp4/okp4d/x/vesting/types"
+	"github.com/okp4/okp4d/v7/x/vesting"
+	vestingtestutil "github.com/okp4/okp4d/v7/x/vesting/testutil"
+	vestingtypes "github.com/okp4/okp4d/v7/x/vesting/types"
 )
 
 var (

--- a/x/vesting/types/codec.go
+++ b/x/vesting/types/codec.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-	"github.com/okp4/okp4d/x/vesting/exported"
+	"github.com/okp4/okp4d/v7/x/vesting/exported"
 )
 
 // RegisterLegacyAminoCodec registers the vesting interfaces and concrete types on the

--- a/x/vesting/types/vesting_account.go
+++ b/x/vesting/types/vesting_account.go
@@ -12,7 +12,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-	vestexported "github.com/okp4/okp4d/x/vesting/exported"
+	vestexported "github.com/okp4/okp4d/v7/x/vesting/exported"
 )
 
 // Compile-time type assertions.

--- a/x/vesting/types/vesting_account_test.go
+++ b/x/vesting/types/vesting_account_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
-	"github.com/okp4/okp4d/x/vesting"
-	"github.com/okp4/okp4d/x/vesting/types"
+	"github.com/okp4/okp4d/v7/x/vesting"
+	"github.com/okp4/okp4d/v7/x/vesting/types"
 )
 
 var (


### PR DESCRIPTION
This pull request enhances the release workflow by implementing essential steps for upgrading the repository to a major version (greater than 1), as explained in [major-versions-in-go-modules-explained](https://elliotchance.medium.com/major-versions-in-go-modules-explained-ec7c1df3888b) for instance.

The release process includes:

- Appending the major version being released to the module name to update the go module.
- Modifying import paths within .go files accordingly.
- Running `go mod tidy` (for hygiene).

Although the project is not a library and is not intended to be imported, this approach is quite canonical and necessary to allow the documentation to be generated again on <https://pkg.go.dev/github.com/okp4/okp4d>, which is currently stuck at version `v1.3.0`.

Hope everything is okay. We'll see how it goes with the next release 😅.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated import paths across various modules to align with version 7 (`v7`) of the `okp4d` repository, ensuring compatibility and reflecting changes in package structure or dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->