### PR TITLE
ci(release): specify commits that trigger a release

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,6 +4,23 @@ branches:
 plugins:
   - - "@semantic-release/commit-analyzer"
     - preset: conventionalcommits
+      releaseRules:
+        - type: build
+          scope: deps
+          release: patch
+        - type: build
+          scope: deps-dev
+          release: patch
+        - type: refactor
+          release: patch
+        - type: style
+          release: patch
+        - type: ci
+          release: patch
+        - type: chore
+          release: patch
+        - type: docs
+          release: patch
   - - "@semantic-release/release-notes-generator"
     - preset: conventionalcommits
   - - "@semantic-release/changelog"


### PR DESCRIPTION
Specify the commit types that should trigger a release (cf. [semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer/)), for instance `build(deps)` and `build(deps-dev)` categories. This is essential for the production of new released artifacts that incorporate not just fixes or features, but also security elements or performance improvements brought about by third-party dependencies, or even enhancements to the documentation.

NB: this is similar to [okp4/subql-okp4/#.releaserc.yml](https://github.com/okp4/subql-okp4/blob/v1.0.1/.releaserc.yml)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated release rules in the project configuration to improve automation of versioning and changelog generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->