### PR TITLE
ci(release): move bump-module script into a separate file

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -22,30 +22,7 @@ plugins:
               numReplacements: 1
   - - "@semantic-release/exec"
     - prepareCmd: |
-        major_version=$(cat version | cut -d. -f1)
-        if [ $major_version -gt 1 ]; then
-            module_name=$(go mod edit -json | jq -r '.Module.Path')
-            module_name_unversioned=$(echo ${module_name} | sed -E 's|/v[0-9]+$||')
-            module_name_versioned="${module_name_unversioned}/v${major_version}"
-            echo "🔬 major version detected, updating module path to ${module_name_versioned}"
-
-            go mod edit -module "${module_name_versioned}"
-            echo "✅ module name updated to ${module_name_versioned} in go.mod"
-
-            if [ "$(uname)" = "Darwin" ]; then
-              find . -type f -name "*.go" -exec \
-                sed -i '' "s|\"${module_name}|\"${module_name_versioned}|g" {} \;
-            else
-              find . -type f -name "*.go" -exec \
-                sed -i "s|\"${module_name}|\"${module_name_versioned}|g" {} \;
-            fi
-            echo "✅ packages updated to ${module_name_versioned} in source files"
-
-            echo "🧹 cleaning up go.sum"
-            go mod tidy
-        else
-            echo "🙅version is not greater than 1, no need to update module path"
-        fi
+        ./scripts/bump-module.sh
   - - "@semantic-release/exec"
     - prepareCmd: |
         make release-assets

--- a/scripts/bump-module.sh
+++ b/scripts/bump-module.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+major_version=$(cut -d. -f1 < version)
+
+if [ "${major_version}" -gt 1 ]; then
+  module_name=$(go mod edit -json | jq -r '.Module.Path')
+  module_name_unversioned=$(echo "${module_name}" | sed -E 's|/v[0-9]+$||')
+  module_name_versioned="${module_name_unversioned}/v${major_version}"
+  echo "🔬 major version detected, updating module path to ${module_name_versioned}"
+
+  go mod edit -module "${module_name_versioned}"
+  echo "✅ module name updated to ${module_name_versioned} in go.mod"
+
+  if [ "$(uname)" = "Darwin" ]; then
+    find . -type f -name "*.go" -exec \
+    sed -i '' "s|\"${module_name}|\"${module_name_versioned}|g" {} \;
+  else
+    find . -type f -name "*.go" -exec \
+    sed -i "s|\"${module_name}|\"${module_name_versioned}|g" {} \;
+  fi
+  echo "✅ packages updated to ${module_name_versioned} in source files"
+
+  echo "🧹 cleaning up go.sum"
+  go mod tidy
+else
+  echo "🙅version is not greater than 1, no need to update module path"
+fi


### PR DESCRIPTION
Resolve conflicts between shell and semantic-release variables by isolating the script in a dedicated shell script file.

```
[12:27:55 PM] [semantic-release] › ✘  An error occurred while running semantic-release: ReferenceError: module_name is not defined
    at eval (lodash.templateSources[0]:9:10)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Simplified version detection and module path updates for Go projects by replacing complex logic with a script call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->