### PR TITLE
Fix/sign cmd

### DIFF
--- a/client/credential/sign.go
+++ b/client/credential/sign.go
@@ -9,14 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
-	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
-	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2020"
-
-	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ecdsasecp256k1signature2019"
-
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/jsonld"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ecdsasecp256k1signature2019"
+	"github.com/hyperledger/aries-framework-go/pkg/doc/signature/suite/ed25519signature2020"
 	"github.com/hyperledger/aries-framework-go/pkg/doc/verifiable"
 	"github.com/piprate/json-gold/ld"
 	"github.com/spf13/cobra"
@@ -26,6 +22,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerr "github.com/cosmos/cosmos-sdk/types/errors"

--- a/client/credential/sign.go
+++ b/client/credential/sign.go
@@ -213,7 +213,7 @@ func readFromFileOrStdin(filename string) ([]byte, error) {
 
 // expandPath expands the given path, replacing the "~" symbol with the user's home directory.
 func expandPath(path string) (string, error) {
-	if len(path) == 0 || strings.HasPrefix(path, symbolHome) {
+	if len(path) == 0 || !strings.HasPrefix(path, symbolHome) {
 		return path, nil
 	}
 


### PR DESCRIPTION
This PR aims to fix some issues related to the `credential sign` command.

## Details

### VC file path

The provided credential file path to sign is now properly expanded.

### Signature

The crypto suite used to sign the credential was systematically the `Ed25519Signature2018` independently of the public key type used to sign.

We now support both `EcdsaSecp256k1Signature2019` & `Ed25519Signature2020` depending on the public key type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the signing process for verifiable credentials by dynamically selecting the appropriate signature suite (ECDSA secp256k1 or Ed25519) based on the public key type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->