### PR TITLE
Test/consult

### DIFF
--- a/docs/predicate/consult_1.md
+++ b/docs/predicate/consult_1.md
@@ -77,6 +77,10 @@ results:
 This scenario demonstrates the capability of a Prolog program to consult another Prolog program. This is useful for
 modularizing Prolog programs and reusing code.
 
+Note that the `:- multifile/1` directive is employed to enable a single predicate's definition to span several files.
+In the absence of this directive, encountering a new definition would lead the compiler to overwrite the existing
+predicate definition.
+
 Here's the steps of the scenario:
 
 - **Given** the CosmWasm smart contract "okp415ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3ts8gddht" and the behavior:
@@ -89,8 +93,10 @@ message: |
     }
   }
 response: |
+  :- multifile(program/1).
   :- consult('cosmwasm:storage:okp412ssv28mzr02jffvy4x39akrpky9ykfafzyjzmvgsqqdw78yjevpqgmqnmk?query=%7B%22object_data%22%3A%7B%22id%22%3A%20%225d3933430d0a12794fae719e0db87b6ec5f549b2%22%7D%7D&base64Decode=false').
-  a.
+
+  program(a).
 ```
 
 - **Given** the CosmWasm smart contract "okp412ssv28mzr02jffvy4x39akrpky9ykfafzyjzmvgsqqdw78yjevpqgmqnmk" and the behavior:
@@ -103,14 +109,16 @@ message: |
     }
   }
 response: |
-  b.
+  :- multifile(program/1).
+
+  program(b).
 ```
 
 - **Given** the query:
 
 ```  prolog
 consult('cosmwasm:storage:okp415ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3ts8gddht?query=%7B%22object_data%22%3A%7B%22id%22%3A%20%224cbe36399aabfcc7158ee7a66cbfffa525bb0ceab33d1ff2cff08759fe0a9b05%22%7D%7D&base64Decode=false'),
-a, b.
+program(X).
 ```
 
 - **When** the query is run (limited to 2 solutions)
@@ -118,9 +126,14 @@ a, b.
 
 ```  yaml
 has_more: false
-variables:
+variables: ["X"]
 results:
 - substitutions:
+  - variable: X
+    expression: "b"
+- substitutions:
+  - variable: X
+    expression: "a"
 ```
 
 ### Consult several Prolog programs

--- a/x/logic/keeper/features/consult_1.feature
+++ b/x/logic/keeper/features/consult_1.feature
@@ -47,6 +47,10 @@ Feature: consult/1
   This scenario demonstrates the capability of a Prolog program to consult another Prolog program. This is useful for
   modularizing Prolog programs and reusing code.
 
+  Note that the `:- multifile/1` directive is employed to enable a single predicate's definition to span several files.
+  In the absence of this directive, encountering a new definition would lead the compiler to overwrite the existing
+  predicate definition.
+
     Given the CosmWasm smart contract "okp415ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3ts8gddht" and the behavior:
       """ yaml
       message: |
@@ -56,8 +60,10 @@ Feature: consult/1
           }
         }
       response: |
+        :- multifile(program/1).
         :- consult('cosmwasm:storage:okp412ssv28mzr02jffvy4x39akrpky9ykfafzyjzmvgsqqdw78yjevpqgmqnmk?query=%7B%22object_data%22%3A%7B%22id%22%3A%20%225d3933430d0a12794fae719e0db87b6ec5f549b2%22%7D%7D&base64Decode=false').
-        a.
+
+        program(a).
       """
     Given the CosmWasm smart contract "okp412ssv28mzr02jffvy4x39akrpky9ykfafzyjzmvgsqqdw78yjevpqgmqnmk" and the behavior:
       """ yaml
@@ -68,20 +74,27 @@ Feature: consult/1
           }
         }
       response: |
-        b.
+        :- multifile(program/1).
+
+        program(b).
       """
     Given the query:
       """ prolog
       consult('cosmwasm:storage:okp415ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3ts8gddht?query=%7B%22object_data%22%3A%7B%22id%22%3A%20%224cbe36399aabfcc7158ee7a66cbfffa525bb0ceab33d1ff2cff08759fe0a9b05%22%7D%7D&base64Decode=false'),
-      a, b.
+      program(X).
       """
     When the query is run (limited to 2 solutions)
     Then the answer we get is:
       """ yaml
       has_more: false
-      variables:
+      variables: ["X"]
       results:
       - substitutions:
+        - variable: X
+          expression: "b"
+      - substitutions:
+        - variable: X
+          expression: "a"
       """
 
   @great_for_documentation


### PR DESCRIPTION
Improve the test case for the `consult/1` chaining sequence by showing the need for the `multifile/1` directive, which instructs the prolog compiler about the declaration of a predicate `P` in more than one file. This stops `consult/1` from redefining a predicate when a new definition is found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Prolog `consult/1` feature to support `:- multifile/1` directive, allowing predicates to be defined across multiple files without overwriting.
	- Introduced `program/1` declarations within `consult/1` to enable consulting multiple Prolog programs with distinct behaviors, improving modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->