### PR TITLE
Fix/non bound substitution variables

### DIFF
--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -193,6 +193,16 @@ func TestGRPCAsk(t *testing.T) {
 				},
 			},
 			{
+				program: "father(bob, X) :- true.",
+				query:   "father(B, X).",
+				expectedAnswer: &types.Answer{
+					Variables: []string{"B", "X"},
+					Results: []types.Result{{Substitutions: []types.Substitution{{
+						Variable: "B", Expression: "bob",
+					}}}},
+				},
+			},
+			{
 				program: "father(bob, alice).",
 				query:   "father(bob, X, O).",
 				expectedAnswer: &types.Answer{


### PR DESCRIPTION
Prevent non-bound substitution variables to be returned. These kind of variables are converted into string terms with a prefix of `_` followed by a number, such as `_88`. The numeric part is unpredictable and may vary across different nodes of the chain, compromising determinism — a situation that is problematic, as you know.

For instance:

```prolog
% program
father(bob, X) :- true.

% query with singleton variables: [X]
father(B, X).
```

Before:

```yaml
answer:
  has_more: false
  results:
  - error: ""
    substitutions:
    - expression: bob
      variable: B
    - expression: _42
      variable: X
  variables:
  - B
  - X
```

After:

```yaml
answer:
  has_more: false
  results:
  - error: ""
    substitutions:
    - expression: bob
      variable: B
  variables:
  - B
  - X
```

The expression value for X has been removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Enhanced the app's capability to handle complex expressions more effectively.
- **Tests**
	- Added a new test case to ensure the reliability of querying functionalities.
- **Refactor**
	- Improved the internal logic for scanning and evaluating expressions, leading to more accurate results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->