### PR TITLE
fix(logic): make the user output stream always initialized

### DIFF
--- a/x/logic/keeper/features/current_output_1.feature
+++ b/x/logic/keeper/features/current_output_1.feature
@@ -153,3 +153,38 @@ Feature: current_output/1
         - substitutions:
       user_output: "🧙!"
       """
+
+  Scenario: Write strings to the current output (no limit configured)
+  This scenario demonstrates that if no limit is configured in the logic module, the user can write as much as they want.
+  This case should not be used in production, as it can lead to performance issues.
+
+    Given the program:
+      """ prolog
+      log_message([]).
+      log_message([H|T]) :-
+          current_output(UserStream),
+          put_char(UserStream, H),
+          log_message(T).
+      """
+    Given the query:
+      """ prolog
+      log_message("Prolog's logic weaves through the fabric of the chain,\nGovernance and rules, in its domain reign."),
+      log_message("\n"),
+      log_message("Knowledge blooms in the heart of the OKP4 lore,\nUnlocking a world of possibilities to explore.").
+      """
+    When the query is run
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 2605
+      answer:
+        has_more: false
+        variables:
+        results:
+        - substitutions:
+      user_output: |
+        Prolog's logic weaves through the fabric of the chain,
+        Governance and rules, in its domain reign.
+        Knowledge blooms in the heart of the OKP4 lore,
+        Unlocking a world of possibilities to explore.
+      """


### PR DESCRIPTION
Fixes the issue where the user output stream wasn't initialized due to the absence of a specified limit in the configuration. This leads to a null pointer dereference error, triggering a panic when attempting to write to the uninitialised stream:

```
panic: runtime error: invalid memory address or nil pointer dereference: invalid argument: invalid request"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Introduced a new interface to enhance output handling.
- **Tests**
	- Added a new test case to improve query testing.
- **Refactor**
	- Modified execution logic for better output management.
- **Documentation**
	- Added a scenario demonstrating writing strings to the current output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->