### PR TITLE
Feat/cli ask limit

### DIFF
--- a/docs/command/okp4d_query_logic_ask.md
+++ b/docs/command/okp4d_query_logic_ask.md
@@ -27,6 +27,8 @@ $ okp4d query logic ask "chain_id(X)." # returns the chain-id
       --grpc-insecure      allow gRPC over insecure channels, if not the server must use TLS
       --height int         Use a specific height to query state at (this can error if the node is pruning state)
   -h, --help               help for ask
+      --limit uint         limit the maximum number of solutions to return.
+                           This parameter is constrained by the 'max_result_count' setting in the module configuration, which specifies the maximum number of results that can be requested per query. (default 1)
       --node string        <host>:<port> to CometBFT RPC interface for this chain (default "tcp://localhost:26657")
   -o, --output string      Output format (text|json) (default "text")
       --program string     reads the program from the given string.

--- a/x/logic/client/cli/query_ask.go
+++ b/x/logic/client/cli/query_ask.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	sdkmath "cosmossdk.io/math"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/version"
@@ -13,7 +15,10 @@ import (
 	"github.com/okp4/okp4d/v7/x/logic/types"
 )
 
-var program string
+var (
+	program string
+	limit   uint64
+)
 
 func CmdQueryAsk() *cobra.Command {
 	cmd := &cobra.Command{
@@ -33,9 +38,11 @@ func CmdQueryAsk() *cobra.Command {
 			query := args[0]
 			queryClient := types.NewQueryServiceClient(clientCtx)
 
+			limit := sdkmath.NewUint(limit)
 			res, err := queryClient.Ask(context.Background(), &types.QueryServiceAskRequest{
 				Program: program,
 				Query:   query,
+				Limit:   &limit,
 			})
 			if err != nil {
 				return
@@ -50,6 +57,13 @@ func CmdQueryAsk() *cobra.Command {
 		"program",
 		"",
 		`reads the program from the given string.`)
+	//nolint:lll
+	cmd.Flags().Uint64Var(
+		&limit,
+		"limit",
+		1,
+		`limit the maximum number of solutions to return.
+This parameter is constrained by the 'max_result_count' setting in the module configuration, which specifies the maximum number of results that can be requested per query.`)
 
 	flags.AddQueryFlagsToCmd(cmd)
 

--- a/x/logic/keeper/grpc_query_ask.go
+++ b/x/logic/keeper/grpc_query_ask.go
@@ -14,7 +14,7 @@ import (
 	"github.com/okp4/okp4d/v7/x/logic/util"
 )
 
-var defaultLimits = sdkmath.OneUint()
+var defaultSolutionsLimit = sdkmath.OneUint()
 
 func (k Keeper) Ask(ctx goctx.Context, req *types.QueryServiceAskRequest) (response *types.QueryServiceAskResponse, err error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
@@ -48,7 +48,7 @@ func (k Keeper) Ask(ctx goctx.Context, req *types.QueryServiceAskRequest) (respo
 		sdkCtx,
 		req.Program,
 		req.Query,
-		util.DerefOrDefault(req.Limit, defaultLimits))
+		util.DerefOrDefault(req.Limit, defaultSolutionsLimit))
 }
 
 // withGasMeter returns a new context with a gas meter that has the given limit.


### PR DESCRIPTION
Self explanatory. Expose the "limit" option to the CLI command `logic ask`.

```
Flags:
     ...
      --limit uint         limit the maximum number of solutions to return.
                           This parameter is constrained by the 'max_result_count' setting in the module configuration, which specifies the maximum number of results that can be requested per query. (default 1)
    ...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added a `limit` functionality to control the number of solutions returned in queries, enhancing user control over query results.

- **Refactor**
	- Renamed `defaultLimits` to `defaultSolutionsLimit` to better reflect its purpose.
	- Updated method parameters from `limit` to `solutionsLimit` for clarity and consistency in handling query execution limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->