### PR TITLE
build(deps): bump runner image from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,7 +80,7 @@ jobs:
           readme-filepath: README.md
 
   publish-buf-proto:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Bump runner image to [ubuntu-22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md). The [Ubuntu 20.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2004-Readme.md) runner image will be fully unsupported by April 1, 2025.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automation setup to use a newer execution environment for publishing tasks, ensuring enhanced compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->