### PR TITLE
⬆️ Ci/upgrade gofumpt

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -124,12 +124,7 @@ jobs:
       - name: Lint go code (gofumpt)
         if: steps.changed-go-files.outputs.any_changed == 'true'
         run: |
-          go install mvdan.cc/gofumpt@v0.9.2
-          if [ "$(gofumpt -l .)" != "" ]; then
-            echo "❌ Code is not gofumpt!"
-            exit 1
-          fi
-          echo "✅ Code is gofumpt!"
+          make lint-go-gofumpt
 
   lint-dockerfile:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -169,12 +169,21 @@ all: help
 lint: lint-go lint-proto ## Lint all available linters
 
 .PHONY: lint-go
-lint-go: lint-go-golangci ## Lint go source code
+lint-go: lint-go-golangci lint-go-gofumpt ## Lint go source code
 
 .PHONY: lint-go-golangci
 lint-go-golangci: $(TOOL_GOLANGCI_BIN) ## Lint go source code with golangci-lint
 	@$(call echo_msg, 🔍, Inspecting, go source code, [golangci-lint]...)
 	@$(TOOL_GOLANGCI_BIN) run -v
+
+.PHONY: lint-go-gofumpt
+lint-go-gofumpt: $(TOOL_GOFUMPT_BIN) ## Lint go source code format with gofumpt
+	@$(call echo_msg, 🔍, Inspecting, go source code, [gofumpt]...)
+	@if [ "$$($(TOOL_GOFUMPT_BIN) -l .)" != "" ]; then \
+		echo "❌ Code is not gofumpt!"; \
+		exit 1; \
+	fi
+	@echo "✅ Code is gofumpt!"
 
 .PHONY: lint-proto
 lint-proto: ## Lint proto files

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Targets:
     lint                Lint all available linters
     lint-go             Lint go source code
     lint-go-golangci    Lint go source code with golangci-lint
+    lint-go-gofumpt     Lint go source code format with gofumpt
     lint-proto          Lint proto files
   Format:
     format              Run all available formatters


### PR DESCRIPTION
Some work around [mvdan.cc/gofumpt](https://github.com/mvdan/gofumpt) tool : standardize installation in `make`, upgrade from `v0.4.0` to `v0.9.2`, add a new `lint-go-gofumpt` _target_ for format checking, and update the CI `lint` workflow to use the makefile target instead of inline installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality verification system to use a more streamlined tooling approach for consistency across development environments.

* **Documentation**
  * Documented new targets for development workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->