### PR TITLE
🏗️ refactor(logic)!: remove predicate and VFS allow/deny filters from x/logic params

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -21,6 +21,7 @@ import (
 var upgrades = []string{
 	"v11.0.0",
 	"v13.0.0",
+	"v15.0.0",
 }
 
 // registerUpgradeHandlers registers the chain upgrade handlers.

--- a/docs/predicate/asserta_1.md
+++ b/docs/predicate/asserta_1.md
@@ -47,7 +47,7 @@ assert_fact, father(X, Y).
 
 ```  yaml
 height: 42
-gas_used: 3977
+gas_used: 3779
 answer:
   has_more: false
   variables: ["X", "Y"]
@@ -83,7 +83,7 @@ asserta(parent(john, alice)).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   results:
@@ -120,7 +120,7 @@ assert_fact, parent(X, alice).
 
 ```  yaml
 height: 42
-gas_used: 3977
+gas_used: 3779
 answer:
   has_more: false
   variables: ["X"]
@@ -163,7 +163,7 @@ counter(InitialValue), increment_counter, increment_counter, counter(Incremented
 
 ```  yaml
 height: 42
-gas_used: 3989
+gas_used: 3791
 answer:
   has_more: false
   variables: ["InitialValue", "IncrementedValue", "DecrementedValue"]

--- a/docs/predicate/assertz_1.md
+++ b/docs/predicate/assertz_1.md
@@ -47,7 +47,7 @@ assert_fact, father(X, Y).
 
 ```  yaml
 height: 42
-gas_used: 3977
+gas_used: 3779
 answer:
   has_more: false
   variables: ["X", "Y"]
@@ -83,7 +83,7 @@ assertz(parent(john, alice)).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   results:
@@ -120,7 +120,7 @@ assert_fact, parent(X, alice).
 
 ```  yaml
 height: 42
-gas_used: 3977
+gas_used: 3779
 answer:
   has_more: false
   variables: ["X"]
@@ -164,7 +164,7 @@ findall(I, inventory(I), CurrentInventory).
 
 ```  yaml
 height: 42
-gas_used: 3984
+gas_used: 3786
 answer:
   has_more: false
   variables: ["I","CurrentInventory"]

--- a/docs/predicate/atomic_list_concat_2.md
+++ b/docs/predicate/atomic_list_concat_2.md
@@ -56,7 +56,7 @@ atomic_list_concat([hello, '-', 42, '-', world], Atom).
 
 ```  yaml
 height: 42
-gas_used: 4295
+gas_used: 4097
 answer:
   has_more: false
   variables: ["Atom"]

--- a/docs/predicate/atomic_list_concat_3.md
+++ b/docs/predicate/atomic_list_concat_3.md
@@ -58,7 +58,7 @@ atomic_list_concat([cosmos, hub, 4], '-', Atom).
 
 ```  yaml
 height: 42
-gas_used: 4147
+gas_used: 3949
 answer:
   has_more: false
   variables: ["Atom"]
@@ -91,7 +91,7 @@ atomic_list_concat([scheme, host, path], '://', URI).
 
 ```  yaml
 height: 42
-gas_used: 4179
+gas_used: 3981
 answer:
   has_more: false
   variables: ["URI"]

--- a/docs/predicate/bank_balances_2.md
+++ b/docs/predicate/bank_balances_2.md
@@ -82,7 +82,7 @@ bank_balances('axone1ffd5wx65l407yvm478cxzlgygw07h79sw4jwpa', Balances).
 
 ```  yaml
 height: 42
-gas_used: 4033
+gas_used: 3835
 answer:
   has_more: false
   variables: ["Balances"]
@@ -121,7 +121,7 @@ bank_balances('axone1wze8mn5nsgl9qrgazq6a92fvh7m5e6ps372aep', Balances).
 
 ```  yaml
 height: 42
-gas_used: 4017
+gas_used: 3819
 answer:
   has_more: false
   variables: ["Balances"]
@@ -166,7 +166,7 @@ first_denom('axone1ffd5wx65l407yvm478cxzlgygw07h79sw4jwpa', Denom).
 
 ```  yaml
 height: 42
-gas_used: 4035
+gas_used: 3837
 answer:
   has_more: false
   variables: ["Denom"]
@@ -211,7 +211,7 @@ has_coin('axone1ffd5wx65l407yvm478cxzlgygw07h79sw4jwpa', uaxone, Amount).
 
 ```  yaml
 height: 42
-gas_used: 4037
+gas_used: 3839
 answer:
   has_more: false
   variables: ["Amount"]
@@ -244,7 +244,7 @@ bank_balances(Address, Balances).
 
 ```  yaml
 height: 42
-gas_used: 4002
+gas_used: 3804
 answer:
   has_more: false
   variables: ["Address", "Balances"]
@@ -275,7 +275,7 @@ bank_balances('invalid_address', Balances).
 
 ```  yaml
 height: 42
-gas_used: 3999
+gas_used: 3801
 answer:
   has_more: false
   variables: ["Balances"]
@@ -306,7 +306,7 @@ bank_balances(42, _).
 
 ```  yaml
 height: 42
-gas_used: 3999
+gas_used: 3801
 answer:
   has_more: false
   results:

--- a/docs/predicate/bank_locked_balances_2.md
+++ b/docs/predicate/bank_locked_balances_2.md
@@ -81,7 +81,7 @@ bank_locked_balances('axone1ffd5wx65l407yvm478cxzlgygw07h79sw4jwpa', Balances).
 
 ```  yaml
 height: 42
-gas_used: 4033
+gas_used: 3835
 answer:
   has_more: false
   variables: ["Balances"]
@@ -120,7 +120,7 @@ bank_locked_balances('axone1wze8mn5nsgl9qrgazq6a92fvh7m5e6ps372aep', Balances).
 
 ```  yaml
 height: 42
-gas_used: 4017
+gas_used: 3819
 answer:
   has_more: false
   variables: ["Balances"]
@@ -165,7 +165,7 @@ locked_has_coin('axone1ffd5wx65l407yvm478cxzlgygw07h79sw4jwpa', uaxone, Amount).
 
 ```  yaml
 height: 42
-gas_used: 4037
+gas_used: 3839
 answer:
   has_more: false
   variables: ["Amount"]
@@ -198,7 +198,7 @@ bank_locked_balances(Address, Balances).
 
 ```  yaml
 height: 42
-gas_used: 4002
+gas_used: 3804
 answer:
   has_more: false
   variables: ["Address", "Balances"]
@@ -229,7 +229,7 @@ bank_locked_balances('invalid_address', Balances).
 
 ```  yaml
 height: 42
-gas_used: 3999
+gas_used: 3801
 answer:
   has_more: false
   variables: ["Balances"]
@@ -260,7 +260,7 @@ bank_locked_balances(42, _).
 
 ```  yaml
 height: 42
-gas_used: 3999
+gas_used: 3801
 answer:
   has_more: false
   results:

--- a/docs/predicate/bank_spendable_balances_2.md
+++ b/docs/predicate/bank_spendable_balances_2.md
@@ -81,7 +81,7 @@ bank_spendable_balances('axone1ffd5wx65l407yvm478cxzlgygw07h79sw4jwpa', Balances
 
 ```  yaml
 height: 42
-gas_used: 4033
+gas_used: 3835
 answer:
   has_more: false
   variables: ["Balances"]
@@ -120,7 +120,7 @@ bank_spendable_balances('axone1wze8mn5nsgl9qrgazq6a92fvh7m5e6ps372aep', Balances
 
 ```  yaml
 height: 42
-gas_used: 4017
+gas_used: 3819
 answer:
   has_more: false
   variables: ["Balances"]
@@ -165,7 +165,7 @@ spendable_has_coin('axone1ffd5wx65l407yvm478cxzlgygw07h79sw4jwpa', uaxone, Amoun
 
 ```  yaml
 height: 42
-gas_used: 4037
+gas_used: 3839
 answer:
   has_more: false
   variables: ["Amount"]
@@ -198,7 +198,7 @@ bank_spendable_balances(Address, Balances).
 
 ```  yaml
 height: 42
-gas_used: 4002
+gas_used: 3804
 answer:
   has_more: false
   variables: ["Address", "Balances"]
@@ -229,7 +229,7 @@ bank_spendable_balances('invalid_address', Balances).
 
 ```  yaml
 height: 42
-gas_used: 3999
+gas_used: 3801
 answer:
   has_more: false
   variables: ["Balances"]
@@ -260,7 +260,7 @@ bank_spendable_balances(42, _).
 
 ```  yaml
 height: 42
-gas_used: 3999
+gas_used: 3801
 answer:
   has_more: false
   results:

--- a/docs/predicate/base64_2.md
+++ b/docs/predicate/base64_2.md
@@ -46,7 +46,7 @@ base64(Decoded, 'SGVsbG8gd29ybGQ=').
 
 ```  yaml
 height: 42
-gas_used: 3976
+gas_used: 3778
 answer:
   has_more: false
   variables: ["Encoded", "Decoded"]

--- a/docs/predicate/base64_encoded_3.md
+++ b/docs/predicate/base64_encoded_3.md
@@ -67,7 +67,7 @@ base64_encoded('Hello World', X, []).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["X"]
@@ -96,7 +96,7 @@ base64_encoded('Hello World', X, [as(atom)]).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["X"]
@@ -128,7 +128,7 @@ base64_encoded('Hello World', X, [as(atom), padding(false)]).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["X"]
@@ -161,7 +161,7 @@ base64_encoded('<<???>>', UrlSafe, [as(atom), charset(url)]).
 
 ```  yaml
 height: 42
-gas_used: 3976
+gas_used: 3778
 answer:
   has_more: false
   variables: ["Classic", "UrlSafe"]
@@ -194,7 +194,7 @@ base64_encoded(X, 'SGVsbG8gV29ybGQ=', []).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["X"]
@@ -226,7 +226,7 @@ base64_encoded(X, 'SGVsbG8gV29ybGQ=', [as(atom)]).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["X"]
@@ -254,7 +254,7 @@ base64_encoded('Hello World', X, [charset(bad)]).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["X"]
@@ -281,7 +281,7 @@ base64_encoded('Hello World', X, [padding(bad)]).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["X"]
@@ -308,7 +308,7 @@ base64_encoded('Hello World', X, [as(bad)]).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["X"]
@@ -335,7 +335,7 @@ base64_encoded(X, 'SGVsbG8gV29ybGQ=', [as(atom), encoding(unknown)]).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["X"]
@@ -362,7 +362,7 @@ base64_encoded(X, 'SGVsbG8gV29ybGQ=', [encoding(bad, 'very bad')]).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["X"]

--- a/docs/predicate/bech32_address_2.md
+++ b/docs/predicate/bech32_address_2.md
@@ -59,7 +59,7 @@ bech32_address(Address, 'axone15wn30a9z4uc692s0kkx5fp5d4qfr3ac77gvjg4').
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["Address"]
@@ -88,7 +88,7 @@ bech32_address(-(Hrp, Address), 'axone15wn30a9z4uc692s0kkx5fp5d4qfr3ac77gvjg4').
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["Hrp", "Address"]
@@ -118,7 +118,7 @@ bech32_address(-(axone, Address), 'axone15wn30a9z4uc692s0kkx5fp5d4qfr3ac77gvjg4'
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["Address"]
@@ -145,7 +145,7 @@ bech32_address(-('axone', [163,167,23,244,162,175,49,162,170,15,181,141,68,134,1
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["Bech32"]
@@ -178,7 +178,7 @@ axone_addr('axone1p8u47en82gmzfm259y6z93r9qe63l25d858vqu').
 
 ```  yaml
 height: 42
-gas_used: 3976
+gas_used: 3778
 answer:
   has_more: false
   results:
@@ -204,7 +204,7 @@ bech32_address(Address, axoneincorrect).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["Address"]
@@ -231,7 +231,7 @@ bech32_address(-('axone', X), foo(bar)).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["X"]

--- a/docs/predicate/comet_info_1.md
+++ b/docs/predicate/comet_info_1.md
@@ -76,7 +76,7 @@ comet_info(CometInfo).
 
 ```  yaml
 height: 42
-gas_used: 3991
+gas_used: 3793
 answer:
   has_more: false
   variables: ["CometInfo"]
@@ -114,7 +114,7 @@ proposer_address(Address).
 
 ```  yaml
 height: 42
-gas_used: 3994
+gas_used: 3796
 answer:
   has_more: false
   variables: ["Address"]
@@ -151,7 +151,7 @@ last_commit_round(Round).
 
 ```  yaml
 height: 42
-gas_used: 3995
+gas_used: 3797
 answer:
   has_more: false
   variables: ["Round"]
@@ -191,7 +191,7 @@ healthy_consensus_snapshot.
 
 ```  yaml
 height: 42
-gas_used: 3991
+gas_used: 3793
 answer:
   has_more: false
   results:

--- a/docs/predicate/consult_1.md
+++ b/docs/predicate/consult_1.md
@@ -65,7 +65,7 @@ hello(Who).
 
 ```  yaml
 height: 42
-gas_used: 3978
+gas_used: 3780
 answer:
   has_more: false
   variables: ["Who"]
@@ -129,7 +129,7 @@ response: |
 
 ```  yaml
 height: 42
-gas_used: 3977
+gas_used: 3779
 answer:
   has_more: false
   variables: ["X"]
@@ -194,7 +194,7 @@ source_file(File).
 
 ```  yaml
 height: 42
-gas_used: 3976
+gas_used: 3778
 answer:
   has_more: false
   variables: ["File"]

--- a/docs/predicate/current_output_1.md
+++ b/docs/predicate/current_output_1.md
@@ -61,7 +61,7 @@ write_char_to_user_output(x).
 
 ```  yaml
 height: 42
-gas_used: 4043
+gas_used: 3845
 answer:
   has_more: false
   variables:
@@ -108,7 +108,7 @@ log_message('Hello world!').
 
 ```  yaml
 height: 42
-gas_used: 4045
+gas_used: 3847
 answer:
   has_more: false
   variables:
@@ -155,7 +155,7 @@ log_message('Hello world!').
 
 ```  yaml
 height: 42
-gas_used: 4044
+gas_used: 3846
 answer:
   has_more: false
   variables:
@@ -205,7 +205,7 @@ log_message("Hello 🧙!").
 
 ```  yaml
 height: 42
-gas_used: 4065
+gas_used: 3867
 answer:
   has_more: false
   variables:

--- a/docs/predicate/foldl_4.md
+++ b/docs/predicate/foldl_4.md
@@ -52,7 +52,7 @@ foldl(sum, [1,2,3,4], 0, Total).
 
 ```  yaml
 height: 42
-gas_used: 3992
+gas_used: 3794
 answer:
   has_more: false
   variables: ["Total"]
@@ -84,7 +84,7 @@ foldl(sum, [], 42, Total).
 
 ```  yaml
 height: 42
-gas_used: 3976
+gas_used: 3778
 answer:
   has_more: false
   variables: ["Total"]
@@ -116,7 +116,7 @@ foldl(cons, [a,b,c], [], Result).
 
 ```  yaml
 height: 42
-gas_used: 3985
+gas_used: 3787
 answer:
   has_more: false
   variables: ["Result"]

--- a/docs/predicate/foldl_5.md
+++ b/docs/predicate/foldl_5.md
@@ -52,7 +52,7 @@ foldl(add_product, [1,2,3], [4,5,6], 0, DotProduct).
 
 ```  yaml
 height: 42
-gas_used: 3988
+gas_used: 3790
 answer:
   has_more: false
   variables: ["DotProduct"]
@@ -84,7 +84,7 @@ foldl(add_product, [], [], 99, Result).
 
 ```  yaml
 height: 42
-gas_used: 3976
+gas_used: 3778
 answer:
   has_more: false
   variables: ["Result"]
@@ -116,7 +116,7 @@ foldl(make_pair, [a,b], [1,2], [], Pairs).
 
 ```  yaml
 height: 42
-gas_used: 3982
+gas_used: 3784
 answer:
   has_more: false
   variables: ["Pairs"]

--- a/docs/predicate/foldl_6.md
+++ b/docs/predicate/foldl_6.md
@@ -52,7 +52,7 @@ foldl(weighted_sum, [1,2], [3,4], [5,6], 0, Result).
 
 ```  yaml
 height: 42
-gas_used: 3984
+gas_used: 3786
 answer:
   has_more: false
   variables: ["Result"]
@@ -84,7 +84,7 @@ foldl(weighted_sum, [], [], [], 42, Result).
 
 ```  yaml
 height: 42
-gas_used: 3976
+gas_used: 3778
 answer:
   has_more: false
   variables: ["Result"]
@@ -116,7 +116,7 @@ foldl(make_triple, [a,b], [1,2], [x,y], [], Triples).
 
 ```  yaml
 height: 42
-gas_used: 3982
+gas_used: 3784
 answer:
   has_more: false
   variables: ["Triples"]

--- a/docs/predicate/foldl_7.md
+++ b/docs/predicate/foldl_7.md
@@ -52,7 +52,7 @@ foldl(quad_sum, [1,2], [3,4], [5,6], [7,8], 0, Result).
 
 ```  yaml
 height: 42
-gas_used: 3984
+gas_used: 3786
 answer:
   has_more: false
   variables: ["Result"]
@@ -84,7 +84,7 @@ foldl(quad_sum, [], [], [], [], 100, Result).
 
 ```  yaml
 height: 42
-gas_used: 3976
+gas_used: 3778
 answer:
   has_more: false
   variables: ["Result"]
@@ -116,7 +116,7 @@ foldl(make_quad, [a], [1], [x], [true], [], Quads).
 
 ```  yaml
 height: 42
-gas_used: 3979
+gas_used: 3781
 answer:
   has_more: false
   variables: ["Quads"]

--- a/docs/predicate/header_info_1.md
+++ b/docs/predicate/header_info_1.md
@@ -65,7 +65,7 @@ header_info(HeaderInfo).
 
 ```  yaml
 height: 42
-gas_used: 3991
+gas_used: 3793
 answer:
   has_more: false
   variables: ["HeaderInfo"]
@@ -109,7 +109,7 @@ height(Height).
 
 ```  yaml
 height: 100
-gas_used: 3994
+gas_used: 3796
 answer:
   has_more: false
   variables: ["Height"]
@@ -152,7 +152,7 @@ time(Time).
 
 ```  yaml
 height: 42
-gas_used: 3994
+gas_used: 3796
 answer:
   has_more: false
   variables: ["Time"]
@@ -198,7 +198,7 @@ evaluate.
 
 ```  yaml
 height: 42
-gas_used: 3991
+gas_used: 3793
 answer:
   has_more: false
   results:

--- a/docs/predicate/must_be_2.md
+++ b/docs/predicate/must_be_2.md
@@ -57,7 +57,7 @@ Result = ok.
 
 ```  yaml
 height: 42
-gas_used: 3986
+gas_used: 3788
 answer:
   has_more: false
   variables: ["Result"]
@@ -91,7 +91,7 @@ must_be(atom, X).
 
 ```  yaml
 height: 42
-gas_used: 3997
+gas_used: 3799
 answer:
   has_more: false
   variables: ["X"]

--- a/docs/predicate/open_4.md
+++ b/docs/predicate/open_4.md
@@ -100,7 +100,7 @@ open(URI, read, _, []).
 
 ```  yaml
 height: 42
-gas_used: 3988
+gas_used: 3790
 answer:
   has_more: false
   variables: ["URI"]
@@ -152,7 +152,7 @@ read_resource('cosmwasm:storage:axone15ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08x
 
 ```  yaml
 height: 42
-gas_used: 3979
+gas_used: 3781
 answer:
   has_more: false
   variables: ["Chars"]
@@ -202,7 +202,7 @@ read_resource('cosmwasm:storage:axone15ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08x
 
 ```  yaml
 height: 42
-gas_used: 3979
+gas_used: 3781
 answer:
   has_more: false
   variables: ["Chars"]
@@ -229,7 +229,7 @@ open('foo:bar', read, Stream, []).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["Stream"]
@@ -255,7 +255,7 @@ open('cosmwasm:storage:axone15ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3t
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["Stream"]
@@ -281,7 +281,7 @@ open('cosmwasm:storage:axone15ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3t
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["Stream"]
@@ -317,7 +317,7 @@ open('cosmwasm:storage:axone15ekvz3qdter33mdnk98v8whv5qdr53yusksnfgc08xd26fpdn3t
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   variables: ["Stream"]

--- a/docs/predicate/retract_1.md
+++ b/docs/predicate/retract_1.md
@@ -41,7 +41,7 @@ assertz(parent(john, alice)), retract(parent(john, alice)), parent(X, Y).
 
 ```  yaml
 height: 42
-gas_used: 3977
+gas_used: 3779
 answer:
   has_more: false
   variables: ["X","Y"]
@@ -72,7 +72,7 @@ retract(parent(jane, alice)).
 
 ```  yaml
 height: 42
-gas_used: 3975
+gas_used: 3777
 answer:
   has_more: false
   results:

--- a/docs/predicate/term_to_atom_2.md
+++ b/docs/predicate/term_to_atom_2.md
@@ -62,7 +62,7 @@ term_to_atom(greeting(hello, [world, 42]), Atom).
 
 ```  yaml
 height: 42
-gas_used: 4172
+gas_used: 3974
 answer:
   has_more: false
   variables: ["Atom"]
@@ -95,7 +95,7 @@ term_to_atom(Term, 'payload(\"hi\", [foo, 42])').
 
 ```  yaml
 height: 42
-gas_used: 5033
+gas_used: 4835
 answer:
   has_more: false
   variables: ["Term"]

--- a/docs/proto/logic.md
+++ b/docs/proto/logic.md
@@ -194,9 +194,7 @@ utilized within a query, or limiting the depth of the backtracking algorithm.
 ## Table of Contents
 
 - [logic/v1beta3/params.proto](#logic/v1beta3/params.proto)
-  - [Filter](#logic.v1beta3.Filter)
   - [GasPolicy](#logic.v1beta3.GasPolicy)
-  - [Interpreter](#logic.v1beta3.Interpreter)
   - [Limits](#logic.v1beta3.Limits)
   - [Params](#logic.v1beta3.Params)
   - [PredicateCost](#logic.v1beta3.PredicateCost)
@@ -230,18 +228,6 @@ utilized within a query, or limiting the depth of the backtracking algorithm.
 
 ## logic/v1beta3/params.proto
 
-<a name="logic.v1beta3.Filter"></a>
-
-### Filter
-
-Filter defines the parameters for filtering the set of strings which can designate anything.
-The filter is used to whitelist or blacklist strings.
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| `whitelist` | [string](#string) | repeated | whitelist specifies a list of strings that are allowed. If this field is not specified, all strings (in the context of the filter) are allowed. |
-| `blacklist` | [string](#string) | repeated | blacklist specifies a list of strings that are excluded from the set of allowed strings. If a string is included in both whitelist and blacklist, it will be excluded. This means that blacklisted strings prevails over whitelisted ones. If this field is not specified, no strings are excluded. |
-
 <a name="logic.v1beta3.GasPolicy"></a>
 
 ### GasPolicy
@@ -255,18 +241,6 @@ if not specified in the list, and a weighting factor that is applied to the unit
 | `weighting_factor` | [uint64](#uint64) |  | WeightingFactor is the factor that is applied to the unit cost of each predicate to yield the gas value. If set to 0, the value considered is 1. |
 | `default_predicate_cost` | [uint64](#uint64) |  | DefaultPredicateCost is the default unit cost of a predicate when not specified in the PredicateCosts list. If set to 0, the value considered is 1. |
 | `predicate_costs` | [PredicateCost](#logic.v1beta3.PredicateCost) | repeated | PredicateCosts is the list of predicates and their associated unit costs. |
-
-<a name="logic.v1beta3.Interpreter"></a>
-
-### Interpreter
-
-Interpreter defines the various parameters for the interpreter.
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| `predicates_filter` | [Filter](#logic.v1beta3.Filter) |  | predicates_filter specifies the filter for the predicates that are allowed to be used by the interpreter. The filter is used to whitelist or blacklist predicates represented as `<predicate_name>/[<arity>]`, for example: `findall/3`, or `call`. If a predicate name without arity is included in the filter, then all predicates with that name will be considered regardless of arity. For example, if `call` is included in the filter, then all predicates `call/1`, `call/2`, `call/3`... will be allowed. |
-| `bootstrap` | [string](#string) |  | bootstrap specifies the initial program to run when booting the logic interpreter. If not specified, the default boot sequence will be executed. |
-| `virtual_files_filter` | [Filter](#logic.v1beta3.Filter) |  | virtual_files_filter specifies the filter for the virtual files that are allowed to be used by the interpreter. The filter is used to whitelist or blacklist virtual files represented as URI, for example: `file:///path/to/file`, `cosmwasm:cw-storage:axone...?query=foo` The filter is applied to the components of the URI, for example: `file:///path/to/file` -> `file`, `/path/to/file` `cosmwasm:cw-storage:axone...?query=foo` -> `cosmwasm`, `cw-storage`, `axone...`, `query=foo` If a component is included in the filter, then all components with that name will be considered, starting from the beginning of the URI. For example, if `file` is included in the filter, then all URIs that start with `file` will be allowed, regardless of the rest of the components. But `file2` will not be allowed. If the component is not included in the filter, then the component is ignored and the next component is considered. |
 
 <a name="logic.v1beta3.Limits"></a>
 
@@ -289,7 +263,6 @@ Params defines all the configuration parameters of the "logic" module.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| `interpreter` | [Interpreter](#logic.v1beta3.Interpreter) |  | Interpreter specifies the parameter for the logic interpreter. |
 | `limits` | [Limits](#logic.v1beta3.Limits) |  | Limits defines the limits of the logic module. The limits are used to prevent the interpreter from running for too long. If the interpreter runs for too long, the execution will be aborted. |
 | `gas_policy` | [GasPolicy](#logic.v1beta3.GasPolicy) |  | GasPolicy defines the parameters for calculating predicate invocation costs. |
 

--- a/proto/logic/v1beta3/params.proto
+++ b/proto/logic/v1beta3/params.proto
@@ -10,11 +10,7 @@ option go_package = "github.com/axone-protocol/axoned/x/logic/types";
 message Params {
   option (gogoproto.goproto_stringer) = false;
 
-  // Interpreter specifies the parameter for the logic interpreter.
-  Interpreter interpreter = 1 [
-    (gogoproto.nullable) = false,
-    (gogoproto.moretags) = "yaml:\"interpreter\""
-  ];
+  reserved 1;
 
   // Limits defines the limits of the logic module.
   // The limits are used to prevent the interpreter from running for too long.
@@ -51,63 +47,6 @@ message Limits {
   // max_variables specifies the maximum number of variables that can be create by the interpreter.
   // A value of 0 means that there is no limit on the number of variables.
   uint64 max_variables = 5 [(gogoproto.moretags) = "yaml:\"max_variables\""];
-}
-
-// Filter defines the parameters for filtering the set of strings which can designate anything.
-// The filter is used to whitelist or blacklist strings.
-message Filter {
-  // whitelist specifies a list of strings that are allowed.
-  // If this field is not specified, all strings (in the context of the filter) are allowed.
-  repeated string whitelist = 1 [
-    (gogoproto.nullable) = true,
-    (gogoproto.moretags) = "yaml:\"whitelist\""
-  ];
-
-  // blacklist specifies a list of strings that are excluded from the set of allowed strings.
-  // If a string is included in both whitelist and blacklist, it will be excluded. This means that
-  // blacklisted strings prevails over whitelisted ones.
-  // If this field is not specified, no strings are excluded.
-  repeated string blacklist = 2 [
-    (gogoproto.nullable) = true,
-    (gogoproto.moretags) = "yaml:\"blacklist\""
-  ];
-}
-
-// Interpreter defines the various parameters for the interpreter.
-message Interpreter {
-  option (gogoproto.goproto_stringer) = true;
-
-  // predicates_filter specifies the filter for the predicates that are allowed to be used by the interpreter.
-  // The filter is used to whitelist or blacklist predicates represented as `<predicate_name>/[<arity>]`, for example:
-  // `findall/3`, or `call`. If a predicate name without arity is included in the filter, then all predicates with that
-  // name will be considered regardless of arity. For example, if `call` is included in the filter, then all predicates
-  // `call/1`, `call/2`, `call/3`... will be allowed.
-  Filter predicates_filter = 1 [
-    (gogoproto.nullable) = false,
-    (gogoproto.moretags) = "yaml:\"predicates_filter\""
-  ];
-
-  // bootstrap specifies the initial program to run when booting the logic interpreter.
-  // If not specified, the default boot sequence will be executed.
-  string bootstrap = 3 [
-    (gogoproto.nullable) = true,
-    (gogoproto.moretags) = "yaml:\"bootstrap\""
-  ];
-
-  // virtual_files_filter specifies the filter for the virtual files that are allowed to be used by the interpreter.
-  // The filter is used to whitelist or blacklist virtual files represented as URI, for example:
-  // `file:///path/to/file`, `cosmwasm:cw-storage:axone...?query=foo`
-  // The filter is applied to the components of the URI, for example:
-  // `file:///path/to/file` -> `file`, `/path/to/file`
-  // `cosmwasm:cw-storage:axone...?query=foo` -> `cosmwasm`, `cw-storage`, `axone...`, `query=foo`
-  // If a component is included in the filter, then all components with that name will be considered, starting from the
-  // beginning of the URI. For example, if `file` is included in the filter, then all URIs that start with `file` will be
-  // allowed, regardless of the rest of the components. But `file2` will not be allowed.
-  // If the component is not included in the filter, then the component is ignored and the next component is considered.
-  Filter virtual_files_filter = 4 [
-    (gogoproto.nullable) = false,
-    (gogoproto.moretags) = "yaml:\"filesystem_filter\""
-  ];
 }
 
 // GasPolicy defines the policy for calculating predicate invocation costs and the resulting gas consumption.

--- a/x/logic/keeper/grpc_query_ask_test.go
+++ b/x/logic/keeper/grpc_query_ask_test.go
@@ -32,24 +32,20 @@ import (
 	"github.com/axone-protocol/axoned/v14/x/logic/types"
 )
 
-//nolint:lll,gocognit
 func TestGRPCAsk(t *testing.T) {
 	emptySolution := types.Result{}
 	Convey("Given a test cases", t, func() {
 		cases := []struct {
-			program               string
-			query                 string
-			limit                 uint64
-			maxResultCount        uint64
-			maxSize               uint64
-			predicateBlacklist    []string
-			virtualFilesWhitelist []string
-			virtualFilesBlacklist []string
-			maxGas                uint64
-			maxVariables          uint64
-			predicateCosts        map[string]uint64
-			expectedAnswer        *types.Answer
-			expectedError         string
+			program        string
+			query          string
+			limit          uint64
+			maxResultCount uint64
+			maxSize        uint64
+			maxGas         uint64
+			maxVariables   uint64
+			predicateCosts map[string]uint64
+			expectedAnswer *types.Answer
+			expectedError  string
 		}{
 			{
 				program: "foo.",
@@ -174,7 +170,7 @@ func TestGRPCAsk(t *testing.T) {
 				predicateCosts: map[string]uint64{
 					"consult/1": 10000,
 				},
-				expectedError: "out of gas: logic <consult/1> (11125/3000): limit exceeded",
+				expectedError: "out of gas: logic <consult/1> (11107/3000): limit exceeded",
 			},
 			{
 				program:       "recursionOfDeath :- recursionOfDeath.",
@@ -260,56 +256,6 @@ func TestGRPCAsk(t *testing.T) {
 				expectedAnswer: &types.Answer{
 					Variables: []string{"X", "O"},
 					Results:   []types.Result{{Error: "error(existence_error(procedure,father/3),root)"}},
-				},
-			},
-			{
-				program:            "header(X) :- consult('/v1/lib/chain.pl'), header_info(X).",
-				query:              "header(X).",
-				predicateBlacklist: []string{"consult/1"},
-				expectedAnswer: &types.Answer{
-					HasMore:   false,
-					Variables: []string{"X"},
-					Results:   []types.Result{{Error: "error(permission_error(execute,forbidden_predicate,consult/1),header/1)"}},
-				},
-			},
-			{
-				program:            "contains_forbidden_predicate(X) :- consult('/v1/lib/chain.pl'), header_info(X).",
-				query:              "contains_forbidden_predicate(X).",
-				predicateBlacklist: []string{"consult/1"},
-				expectedAnswer: &types.Answer{
-					HasMore:   false,
-					Variables: []string{"X"},
-					Results:   []types.Result{{Error: "error(permission_error(execute,forbidden_predicate,consult/1),contains_forbidden_predicate/1)"}},
-				},
-			},
-			{
-				program:            "cannot_be_blacklisted(X) :- X = 42.",
-				query:              "cannot_be_blacklisted(X).",
-				predicateBlacklist: []string{"cannot_be_blacklisted/1"},
-				expectedAnswer: &types.Answer{
-					HasMore:   false,
-					Variables: []string{"X"},
-					Results: []types.Result{{Substitutions: []types.Substitution{{
-						Variable: "X", Expression: "42",
-					}}}},
-				},
-			},
-			{
-				program:               `test :- open('cosmwasm:okp4-objectarium:okp41ffzp0xmjhwkltuxcvccl0z9tyfuu7txp5ke0tpkcjpzuq9fcj3pqrteqt3?query=%7B%22object_data%22%3A%7B%22id%22%3A%22content1%22%7D%7D', read, _, []).`,
-				query:                 "test.",
-				virtualFilesBlacklist: []string{"cosmwasm:"},
-				expectedAnswer: &types.Answer{
-					HasMore: false,
-					Results: []types.Result{{Error: "error(permission_error(open,source_sink,cosmwasm:okp4-objectarium:okp41ffzp0xmjhwkltuxcvccl0z9tyfuu7txp5ke0tpkcjpzuq9fcj3pqrteqt3?query=%7B%22object_data%22%3A%7B%22id%22%3A%22content1%22%7D%7D),open/4)"}},
-				},
-			},
-			{
-				program:               `test :- open('https://example.com/data.pl', read, _, []).`,
-				query:                 "test.",
-				virtualFilesWhitelist: []string{"cosmwasm:"},
-				expectedAnswer: &types.Answer{
-					HasMore: false,
-					Results: []types.Result{{Error: "error(permission_error(open,source_sink,https://example.com/data.pl),open/4)"}},
 				},
 			},
 			{
@@ -466,15 +412,6 @@ func TestGRPCAsk(t *testing.T) {
 					params.Limits.MaxSize = tc.maxSize
 					params.Limits.MaxVariables = tc.maxVariables
 
-					if tc.predicateBlacklist != nil {
-						params.Interpreter.PredicatesFilter.Blacklist = tc.predicateBlacklist
-					}
-					if tc.virtualFilesWhitelist != nil {
-						params.Interpreter.VirtualFilesFilter.Whitelist = tc.virtualFilesWhitelist
-					}
-					if tc.virtualFilesBlacklist != nil {
-						params.Interpreter.VirtualFilesFilter.Blacklist = tc.virtualFilesBlacklist
-					}
 					if tc.predicateCosts != nil {
 						predicateCosts := make([]types.PredicateCost, 0, len(tc.predicateCosts))
 						for predicate, cost := range tc.predicateCosts {

--- a/x/logic/keeper/grpc_query_params_test.go
+++ b/x/logic/keeper/grpc_query_params_test.go
@@ -31,13 +31,6 @@ func TestGRPCParams(t *testing.T) {
 		}{
 			{
 				params: types.NewParams(
-					types.NewInterpreter(
-						types.WithBootstrap("bootstrap"),
-						types.WithPredicatesBlacklist([]string{"halt/1"}),
-						types.WithPredicatesWhitelist([]string{"source_file/1"}),
-						types.WithVirtualFilesBlacklist([]string{"file1"}),
-						types.WithVirtualFilesWhitelist([]string{"file2"}),
-					),
 					types.NewLimits(
 						types.WithMaxSize(2),
 						types.WithMaxResultCount(3),
@@ -49,13 +42,6 @@ func TestGRPCParams(t *testing.T) {
 			},
 			{
 				params: types.NewParams(
-					types.NewInterpreter(
-						types.WithBootstrap("bootstrap"),
-						types.WithPredicatesBlacklist([]string{"halt/1"}),
-						types.WithPredicatesWhitelist([]string{"source_file/1"}),
-						types.WithVirtualFilesBlacklist([]string{"file1"}),
-						types.WithVirtualFilesWhitelist([]string{"file2"}),
-					),
 					types.NewLimits(
 						types.WithMaxSize(2),
 						types.WithMaxResultCount(3),

--- a/x/logic/keeper/interpreter.go
+++ b/x/logic/keeper/interpreter.go
@@ -9,14 +9,12 @@ import (
 	"github.com/axone-protocol/prolog/v3"
 	"github.com/axone-protocol/prolog/v3/engine"
 	"github.com/samber/lo"
-	orderedmap "github.com/wk8/go-ordered-map/v2"
 
 	errorsmod "cosmossdk.io/errors"
 	storetypes "cosmossdk.io/store/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/axone-protocol/axoned/v14/x/logic/fs/filtered"
 	"github.com/axone-protocol/axoned/v14/x/logic/interpreter"
 	"github.com/axone-protocol/axoned/v14/x/logic/interpreter/bootstrap"
 	"github.com/axone-protocol/axoned/v14/x/logic/meter"
@@ -82,17 +80,6 @@ func (k Keeper) queryInterpreter(
 func (k Keeper) newInterpreter(ctx context.Context, params types.Params) (*prolog.Interpreter, fmt.Stringer, error) {
 	sdkctx := sdk.UnwrapSDKContext(ctx)
 
-	interpreterParams := params.GetInterpreter()
-	whitelistPredicates := util.NonZeroOrDefault(interpreterParams.PredicatesFilter.Whitelist, interpreter.RegistryNames)
-	blacklistPredicates := interpreterParams.PredicatesFilter.Blacklist
-
-	whitelistUrls := lo.Map(
-		util.NonZeroOrDefault(interpreterParams.VirtualFilesFilter.Whitelist, []string{}),
-		util.Indexed(util.ParseURLMust))
-	blacklistUrls := lo.Map(
-		util.NonZeroOrDefault(interpreterParams.VirtualFilesFilter.Blacklist, []string{}),
-		util.Indexed(util.ParseURLMust))
-
 	var userOutputBuffer writerStringer
 	limits := params.GetLimits()
 	if limits.MaxUserOutputSize > 0 {
@@ -108,14 +95,13 @@ func (k Keeper) newInterpreter(ctx context.Context, params types.Params) (*prolo
 
 	options := []interpreter.Option{
 		interpreter.WithHooks(
-			whitelistBlacklistHookFn(whitelistPredicates, blacklistPredicates),
 			gasMeterHookFn(sdkctx, params.GetGasPolicy()),
 			telemetryPredicateCallCounterHookFn(),
 			telemetryPredicateDurationHookFn(),
 		),
 		interpreter.WithPredicates(ctx, interpreter.RegistryNames),
-		interpreter.WithBootstrap(ctx, util.NonZeroOrDefault(interpreterParams.GetBootstrap(), bootstrap.Bootstrap())),
-		interpreter.WithFS(filtered.NewFS(fsProvider, whitelistUrls, blacklistUrls)),
+		interpreter.WithBootstrap(ctx, bootstrap.Bootstrap()),
+		interpreter.WithFS(fsProvider),
 		interpreter.WithUserOutputWriter(userOutputBuffer),
 		interpreter.WithMaxVariables(limits.MaxVariables),
 	}
@@ -123,45 +109,6 @@ func (k Keeper) newInterpreter(ctx context.Context, params types.Params) (*prolo
 	i, err := interpreter.New(options...)
 
 	return i, userOutputBuffer, err
-}
-
-// whitelistBlacklistHookFn returns a hook function that checks if the given predicate is allowed to be executed.
-// The predicate is allowed if it is in the whitelist or not in the blacklist.
-func whitelistBlacklistHookFn(whitelist, blacklist []string) engine.HookFunc {
-	allowed := lo.Reduce(
-		lo.Filter(interpreter.RegistryNames,
-			util.Indexed(util.WhitelistBlacklistMatches(whitelist, blacklist, prolog2.PredicateMatches))),
-		func(agg *orderedmap.OrderedMap[string, struct{}], item string, _ int) *orderedmap.OrderedMap[string, struct{}] {
-			agg.Set(item, struct{}{})
-			return agg
-		},
-		orderedmap.New[string, struct{}](orderedmap.WithCapacity[string, struct{}](len(interpreter.RegistryNames))))
-
-	return func(opcode engine.Opcode, operand engine.Term, env *engine.Env) error {
-		if opcode != engine.OpCall {
-			return nil
-		}
-
-		predicate, ok := stringifyOperand(operand)
-		if !ok {
-			return engine.SyntaxError(operand, env)
-		}
-
-		if !interpreter.IsRegistered(predicate) {
-			return nil
-		}
-
-		if _, found := allowed.Get(predicate); !found {
-			return engine.PermissionError(
-				prolog2.AtomOperationExecute,
-				prolog2.AtomPermissionForbiddenPredicate,
-				engine.NewAtom(predicate),
-				env,
-			)
-		}
-
-		return nil
-	}
 }
 
 // gasMeterHookFn returns a hook function that consumes gas based on the cost of the executed predicate.

--- a/x/logic/keeper/migrator.go
+++ b/x/logic/keeper/migrator.go
@@ -1,0 +1,35 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/axone-protocol/axoned/v14/x/logic/types"
+)
+
+// Migrator is a struct for handling in-place state migrations.
+type Migrator struct {
+	keeper Keeper
+}
+
+// NewMigrator returns a Migrator instance for the state migration.
+func NewMigrator(k Keeper) Migrator {
+	return Migrator{keeper: k}
+}
+
+// Migrate4to5 rewrites the stored params using the v5 canonical schema.
+// Removed interpreter filter and bootstrap fields are ignored on read and
+// dropped from the rewritten state.
+func (m Migrator) Migrate4to5(ctx sdk.Context) error {
+	store := ctx.KVStore(m.keeper.storeKey)
+	bz := store.Get(types.ParamsKey)
+	if bz == nil {
+		return nil
+	}
+
+	var params types.Params
+	if err := m.keeper.cdc.Unmarshal(bz, &params); err != nil {
+		return err
+	}
+
+	return m.keeper.SetParams(ctx, params)
+}

--- a/x/logic/keeper/migrator_test.go
+++ b/x/logic/keeper/migrator_test.go
@@ -1,0 +1,117 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/cosmos-sdk/testutil"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+
+	"github.com/axone-protocol/axoned/v14/x/logic"
+	"github.com/axone-protocol/axoned/v14/x/logic/keeper"
+	"github.com/axone-protocol/axoned/v14/x/logic/types"
+)
+
+func TestMigrator_Migrate4to5(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		populateLegacyFields bool
+	}{
+		{
+			name:                 "legacy interpreter fields empty",
+			populateLegacyFields: false,
+		},
+		{
+			name:                 "legacy interpreter fields populated",
+			populateLegacyFields: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			encCfg := moduletestutil.MakeTestEncodingConfig(logic.AppModuleBasic{})
+			key := storetypes.NewKVStoreKey(types.StoreKey)
+			testCtx := testutil.DefaultContextWithDB(t, key, storetypes.NewTransientStoreKey("transient_test"))
+
+			logicKeeper := keeper.NewKeeper(
+				encCfg.Codec,
+				encCfg.InterfaceRegistry,
+				key,
+				key,
+				authtypes.NewModuleAddress(govtypes.ModuleName),
+				nil,
+				nil,
+				nil,
+				nil,
+			)
+
+			expectedParams := types.NewParams(
+				types.NewLimits(
+					types.WithMaxSize(11),
+					types.WithMaxResultCount(7),
+					types.WithMaxUserOutputSize(13),
+					types.WithMaxVariables(17),
+				),
+				types.NewGasPolicy(
+					types.WithWeightingFactor(19),
+					types.WithDefaultPredicateCost(23),
+					types.WithPredicateCosts([]types.PredicateCost{
+						{Predicate: "consult/1", Cost: 29},
+					}),
+				),
+			)
+
+			expectedBz, err := encCfg.Codec.Marshal(&expectedParams)
+			require.NoError(t, err)
+
+			legacyBz := legacyParamsBytes(expectedBz, tc.populateLegacyFields)
+			require.NotEqual(t, expectedBz, legacyBz)
+
+			store := testCtx.Ctx.KVStore(key)
+			store.Set(types.ParamsKey, legacyBz)
+
+			err = keeper.NewMigrator(*logicKeeper).Migrate4to5(testCtx.Ctx)
+			require.NoError(t, err)
+
+			require.Equal(t, expectedBz, store.Get(types.ParamsKey))
+			require.Equal(t, expectedParams, logicKeeper.GetParams(testCtx.Ctx))
+		})
+	}
+}
+
+func legacyParamsBytes(canonical []byte, populateLegacyFields bool) []byte {
+	var interpreter []byte
+	if populateLegacyFields {
+		interpreter = appendLegacyFilter(interpreter, 1, []string{"consult/1"}, []string{"open/4"})
+		interpreter = protowire.AppendTag(interpreter, 3, protowire.BytesType)
+		interpreter = protowire.AppendString(interpreter, "user_bootstrap.")
+		interpreter = appendLegacyFilter(interpreter, 4, []string{"cosmwasm:"}, []string{"https://"})
+	}
+
+	legacy := protowire.AppendTag(nil, 1, protowire.BytesType)
+	legacy = protowire.AppendBytes(legacy, interpreter)
+	legacy = append(legacy, canonical...)
+
+	return legacy
+}
+
+func appendLegacyFilter(dst []byte, fieldNum protowire.Number, whitelist, blacklist []string) []byte {
+	var filter []byte
+	for _, item := range whitelist {
+		filter = protowire.AppendTag(filter, 1, protowire.BytesType)
+		filter = protowire.AppendString(filter, item)
+	}
+	for _, item := range blacklist {
+		filter = protowire.AppendTag(filter, 2, protowire.BytesType)
+		filter = protowire.AppendString(filter, item)
+	}
+
+	dst = protowire.AppendTag(dst, fieldNum, protowire.BytesType)
+	dst = protowire.AppendBytes(dst, filter)
+
+	return dst
+}

--- a/x/logic/module.go
+++ b/x/logic/module.go
@@ -23,7 +23,7 @@ import (
 )
 
 // ConsensusVersion defines the current x/logic module consensus version.
-const ConsensusVersion = 4
+const ConsensusVersion = 5
 
 var (
 	_ module.HasGenesis  = AppModule{}
@@ -127,6 +127,11 @@ func (am AppModule) IsAppModule() {}
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServiceServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServiceServer(cfg.QueryServer(), am.keeper)
+
+	m := keeper.NewMigrator(am.keeper)
+	if err := cfg.RegisterMigration(types.ModuleName, 4, m.Migrate4to5); err != nil {
+		panic(fmt.Sprintf("failed to migrate x/%s from version 4 to 5: %v", types.ModuleName, err))
+	}
 }
 
 // InitGenesis performs the module's genesis initialization. It returns no validator updates.

--- a/x/logic/tests/predicate/features/asserta_1.feature
+++ b/x/logic/tests/predicate/features/asserta_1.feature
@@ -20,7 +20,7 @@ Feature: asserta/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3977
+      gas_used: 3779
       answer:
         has_more: false
         variables: ["X", "Y"]
@@ -49,7 +49,7 @@ Feature: asserta/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         results:
@@ -79,7 +79,7 @@ Feature: asserta/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3977
+      gas_used: 3779
       answer:
         has_more: false
         variables: ["X"]
@@ -115,7 +115,7 @@ Feature: asserta/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3989
+      gas_used: 3791
       answer:
         has_more: false
         variables: ["InitialValue", "IncrementedValue", "DecrementedValue"]

--- a/x/logic/tests/predicate/features/assertz_1.feature
+++ b/x/logic/tests/predicate/features/assertz_1.feature
@@ -20,7 +20,7 @@ Feature: assertz/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3977
+      gas_used: 3779
       answer:
         has_more: false
         variables: ["X", "Y"]
@@ -49,7 +49,7 @@ Feature: assertz/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         results:
@@ -79,7 +79,7 @@ Feature: assertz/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3977
+      gas_used: 3779
       answer:
         has_more: false
         variables: ["X"]
@@ -116,7 +116,7 @@ Scenario: Add and remove items in an inventory.
   Then the answer we get is:
     """ yaml
     height: 42
-    gas_used: 3984
+    gas_used: 3786
     answer:
       has_more: false
       variables: ["I","CurrentInventory"]

--- a/x/logic/tests/predicate/features/atomic_list_concat_2.feature
+++ b/x/logic/tests/predicate/features/atomic_list_concat_2.feature
@@ -16,7 +16,7 @@ Feature: atomic_list_concat/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4295
+      gas_used: 4097
       answer:
         has_more: false
         variables: ["Atom"]
@@ -39,7 +39,7 @@ Feature: atomic_list_concat/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3981
+      gas_used: 3783
       answer:
         has_more: false
         variables: ["List", "Atom"]
@@ -61,7 +61,7 @@ Feature: atomic_list_concat/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3987
+      gas_used: 3789
       answer:
         has_more: false
         variables: ["List", "Tail", "Atom"]
@@ -82,7 +82,7 @@ Feature: atomic_list_concat/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3989
+      gas_used: 3791
       answer:
         has_more: false
         variables: ["Atom"]

--- a/x/logic/tests/predicate/features/atomic_list_concat_3.feature
+++ b/x/logic/tests/predicate/features/atomic_list_concat_3.feature
@@ -16,7 +16,7 @@ Feature: atomic_list_concat/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4147
+      gas_used: 3949
       answer:
         has_more: false
         variables: ["Atom"]
@@ -41,7 +41,7 @@ Feature: atomic_list_concat/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4179
+      gas_used: 3981
       answer:
         has_more: false
         variables: ["URI"]
@@ -64,7 +64,7 @@ Feature: atomic_list_concat/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4012
+      gas_used: 3814
       answer:
         has_more: false
         variables: ["Separator", "Atom"]
@@ -85,7 +85,7 @@ Feature: atomic_list_concat/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4016
+      gas_used: 3818
       answer:
         has_more: false
         variables: ["Atom"]

--- a/x/logic/tests/predicate/features/bank_balances_2.feature
+++ b/x/logic/tests/predicate/features/bank_balances_2.feature
@@ -22,7 +22,7 @@ Feature: bank_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4033
+      gas_used: 3835
       answer:
         has_more: false
         variables: ["Balances"]
@@ -50,7 +50,7 @@ Feature: bank_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4017
+      gas_used: 3819
       answer:
         has_more: false
         variables: ["Balances"]
@@ -84,7 +84,7 @@ Feature: bank_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4035
+      gas_used: 3837
       answer:
         has_more: false
         variables: ["Denom"]
@@ -118,7 +118,7 @@ Feature: bank_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4037
+      gas_used: 3839
       answer:
         has_more: false
         variables: ["Amount"]
@@ -151,7 +151,7 @@ Feature: bank_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4037
+      gas_used: 3839
       answer:
         has_more: false
         variables: ["Amount"]
@@ -179,7 +179,7 @@ Feature: bank_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4025
+      gas_used: 3827
       answer:
         has_more: false
         results:
@@ -202,7 +202,7 @@ Feature: bank_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4002
+      gas_used: 3804
       answer:
         has_more: false
         variables: ["Address", "Balances"]
@@ -226,7 +226,7 @@ Feature: bank_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3999
+      gas_used: 3801
       answer:
         has_more: false
         variables: ["Balances"]
@@ -250,7 +250,7 @@ Feature: bank_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3999
+      gas_used: 3801
       answer:
         has_more: false
         results:

--- a/x/logic/tests/predicate/features/bank_locked_balances_2.feature
+++ b/x/logic/tests/predicate/features/bank_locked_balances_2.feature
@@ -21,7 +21,7 @@ Feature: bank_locked_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4033
+      gas_used: 3835
       answer:
         has_more: false
         variables: ["Balances"]
@@ -49,7 +49,7 @@ Feature: bank_locked_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4017
+      gas_used: 3819
       answer:
         has_more: false
         variables: ["Balances"]
@@ -83,7 +83,7 @@ Feature: bank_locked_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4037
+      gas_used: 3839
       answer:
         has_more: false
         variables: ["Amount"]
@@ -111,7 +111,7 @@ Feature: bank_locked_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4025
+      gas_used: 3827
       answer:
         has_more: false
         results:
@@ -134,7 +134,7 @@ Feature: bank_locked_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4002
+      gas_used: 3804
       answer:
         has_more: false
         variables: ["Address", "Balances"]
@@ -158,7 +158,7 @@ Feature: bank_locked_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3999
+      gas_used: 3801
       answer:
         has_more: false
         variables: ["Balances"]
@@ -182,7 +182,7 @@ Feature: bank_locked_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3999
+      gas_used: 3801
       answer:
         has_more: false
         results:

--- a/x/logic/tests/predicate/features/bank_spendable_balances_2.feature
+++ b/x/logic/tests/predicate/features/bank_spendable_balances_2.feature
@@ -21,7 +21,7 @@ Feature: bank_spendable_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4033
+      gas_used: 3835
       answer:
         has_more: false
         variables: ["Balances"]
@@ -49,7 +49,7 @@ Feature: bank_spendable_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4017
+      gas_used: 3819
       answer:
         has_more: false
         variables: ["Balances"]
@@ -83,7 +83,7 @@ Feature: bank_spendable_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4037
+      gas_used: 3839
       answer:
         has_more: false
         variables: ["Amount"]
@@ -111,7 +111,7 @@ Feature: bank_spendable_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4025
+      gas_used: 3827
       answer:
         has_more: false
         results:
@@ -134,7 +134,7 @@ Feature: bank_spendable_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4002
+      gas_used: 3804
       answer:
         has_more: false
         variables: ["Address", "Balances"]
@@ -158,7 +158,7 @@ Feature: bank_spendable_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3999
+      gas_used: 3801
       answer:
         has_more: false
         variables: ["Balances"]
@@ -182,7 +182,7 @@ Feature: bank_spendable_balances/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3999
+      gas_used: 3801
       answer:
         has_more: false
         results:

--- a/x/logic/tests/predicate/features/base64_2.feature
+++ b/x/logic/tests/predicate/features/base64_2.feature
@@ -15,7 +15,7 @@ Feature: base64/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3976
+      gas_used: 3778
       answer:
         has_more: false
         variables: ["Encoded", "Decoded"]

--- a/x/logic/tests/predicate/features/base64_encoded_3.feature
+++ b/x/logic/tests/predicate/features/base64_encoded_3.feature
@@ -17,7 +17,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["X"]
@@ -41,7 +41,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["X"]
@@ -67,7 +67,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["X"]
@@ -94,7 +94,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3976
+      gas_used: 3778
       answer:
         has_more: false
         variables: ["Classic", "UrlSafe"]
@@ -122,7 +122,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["X"]
@@ -148,7 +148,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["X"]
@@ -171,7 +171,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["X"]
@@ -192,7 +192,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["X"]
@@ -214,7 +214,7 @@ Feature: base64_encoded/3
       Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 3975
+        gas_used: 3777
         answer:
           has_more: false
           variables: ["X"]
@@ -235,7 +235,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 3975
+        gas_used: 3777
         answer:
           has_more: false
           variables: ["X"]
@@ -257,7 +257,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 3975
+        gas_used: 3777
         answer:
           has_more: false
           variables: ["X"]
@@ -278,7 +278,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 3975
+        gas_used: 3777
         answer:
           has_more: false
           variables: ["X"]
@@ -298,7 +298,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["X"]
@@ -318,7 +318,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["X"]
@@ -338,7 +338,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["X"]
@@ -360,7 +360,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 3975
+        gas_used: 3777
         answer:
           has_more: false
           variables: ["X"]
@@ -382,7 +382,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 3975
+        gas_used: 3777
         answer:
           has_more: false
           variables: ["X"]

--- a/x/logic/tests/predicate/features/base64url_2.feature
+++ b/x/logic/tests/predicate/features/base64url_2.feature
@@ -15,7 +15,7 @@ Feature: base64url/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3976
+      gas_used: 3778
       answer:
         has_more: false
         variables: ["Encoded", "Decoded"]

--- a/x/logic/tests/predicate/features/bech32_address_2.feature
+++ b/x/logic/tests/predicate/features/bech32_address_2.feature
@@ -16,7 +16,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Address"]
@@ -39,7 +39,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Hrp", "Address"]
@@ -63,7 +63,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Address"]
@@ -84,7 +84,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Bech32"]
@@ -109,7 +109,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3976
+      gas_used: 3778
       answer:
         has_more: false
         results:
@@ -130,7 +130,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3976
+      gas_used: 3778
       answer:
         has_more: false
         results:
@@ -146,7 +146,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         results:
@@ -163,7 +163,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Hrp"]
@@ -186,7 +186,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Address"]
@@ -207,7 +207,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["X"]
@@ -227,7 +227,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Bech32"]
@@ -247,7 +247,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Bech32"]
@@ -267,7 +267,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Bech32"]
@@ -287,7 +287,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Bech32"]
@@ -307,7 +307,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Bech32"]
@@ -327,7 +327,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Address", "Bech32"]
@@ -347,7 +347,7 @@ Feature: bech32_address/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Hrp", "Bech32"]

--- a/x/logic/tests/predicate/features/comet_info_1.feature
+++ b/x/logic/tests/predicate/features/comet_info_1.feature
@@ -16,7 +16,7 @@ Feature: comet_info/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3991
+      gas_used: 3793
       answer:
         has_more: false
         variables: ["CometInfo"]
@@ -47,7 +47,7 @@ Feature: comet_info/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3994
+      gas_used: 3796
       answer:
         has_more: false
         variables: ["Address"]
@@ -77,7 +77,7 @@ Feature: comet_info/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3995
+      gas_used: 3797
       answer:
         has_more: false
         variables: ["Round"]
@@ -110,7 +110,7 @@ Feature: comet_info/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3991
+      gas_used: 3793
       answer:
         has_more: false
         results:

--- a/x/logic/tests/predicate/features/consult_1.feature
+++ b/x/logic/tests/predicate/features/consult_1.feature
@@ -34,7 +34,7 @@ Feature: consult/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3978
+      gas_used: 3780
       answer:
         has_more: false
         variables: ["Who"]
@@ -90,7 +90,7 @@ Feature: consult/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3977
+      gas_used: 3779
       answer:
         has_more: false
         variables: ["X"]
@@ -144,7 +144,7 @@ Feature: consult/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3976
+      gas_used: 3778
       answer:
         has_more: false
         variables: ["File"]

--- a/x/logic/tests/predicate/features/current_output_1.feature
+++ b/x/logic/tests/predicate/features/current_output_1.feature
@@ -28,7 +28,7 @@ Feature: current_output/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4043
+      gas_used: 3845
       answer:
         has_more: false
         variables:
@@ -66,7 +66,7 @@ Feature: current_output/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4045
+      gas_used: 3847
       answer:
         has_more: false
         variables:
@@ -104,7 +104,7 @@ Feature: current_output/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4044
+      gas_used: 3846
       answer:
         has_more: false
         variables:
@@ -145,7 +145,7 @@ Feature: current_output/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4065
+      gas_used: 3867
       answer:
         has_more: false
         variables:
@@ -176,7 +176,7 @@ Feature: current_output/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4556
+      gas_used: 4358
       answer:
         has_more: false
         variables:

--- a/x/logic/tests/predicate/features/foldl_4.feature
+++ b/x/logic/tests/predicate/features/foldl_4.feature
@@ -18,7 +18,7 @@ Feature: foldl/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3992
+      gas_used: 3794
       answer:
         has_more: false
         variables: ["Total"]
@@ -42,7 +42,7 @@ Feature: foldl/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Total"]
@@ -66,7 +66,7 @@ Feature: foldl/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3976
+      gas_used: 3778
       answer:
         has_more: false
         variables: ["Total"]
@@ -92,7 +92,7 @@ Feature: foldl/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3985
+      gas_used: 3787
       answer:
         has_more: false
         variables: ["Result"]

--- a/x/logic/tests/predicate/features/foldl_5.feature
+++ b/x/logic/tests/predicate/features/foldl_5.feature
@@ -18,7 +18,7 @@ Feature: foldl/5
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3988
+      gas_used: 3790
       answer:
         has_more: false
         variables: ["DotProduct"]
@@ -44,7 +44,7 @@ Feature: foldl/5
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3976
+      gas_used: 3778
       answer:
         has_more: false
         variables: ["Result"]
@@ -70,7 +70,7 @@ Feature: foldl/5
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3982
+      gas_used: 3784
       answer:
         has_more: false
         variables: ["Pairs"]

--- a/x/logic/tests/predicate/features/foldl_6.feature
+++ b/x/logic/tests/predicate/features/foldl_6.feature
@@ -18,7 +18,7 @@ Feature: foldl/6
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3984
+      gas_used: 3786
       answer:
         has_more: false
         variables: ["Result"]
@@ -44,7 +44,7 @@ Feature: foldl/6
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3976
+      gas_used: 3778
       answer:
         has_more: false
         variables: ["Result"]
@@ -70,7 +70,7 @@ Feature: foldl/6
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3982
+      gas_used: 3784
       answer:
         has_more: false
         variables: ["Triples"]

--- a/x/logic/tests/predicate/features/foldl_7.feature
+++ b/x/logic/tests/predicate/features/foldl_7.feature
@@ -18,7 +18,7 @@ Feature: foldl/7
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3984
+      gas_used: 3786
       answer:
         has_more: false
         variables: ["Result"]
@@ -44,7 +44,7 @@ Feature: foldl/7
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3976
+      gas_used: 3778
       answer:
         has_more: false
         variables: ["Result"]
@@ -70,7 +70,7 @@ Feature: foldl/7
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3979
+      gas_used: 3781
       answer:
         has_more: false
         variables: ["Quads"]

--- a/x/logic/tests/predicate/features/header_info_1.feature
+++ b/x/logic/tests/predicate/features/header_info_1.feature
@@ -15,7 +15,7 @@ Feature: header_info/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3991
+      gas_used: 3793
       answer:
         has_more: false
         variables: ["HeaderInfo"]
@@ -50,7 +50,7 @@ Feature: header_info/1
     Then the answer we get is:
       """ yaml
       height: 100
-      gas_used: 3994
+      gas_used: 3796
       answer:
         has_more: false
         variables: ["Height"]
@@ -84,7 +84,7 @@ Feature: header_info/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3994
+      gas_used: 3796
       answer:
         has_more: false
         variables: ["Time"]
@@ -121,7 +121,7 @@ Feature: header_info/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3991
+      gas_used: 3793
       answer:
         has_more: false
         results:

--- a/x/logic/tests/predicate/features/must_be_2.feature
+++ b/x/logic/tests/predicate/features/must_be_2.feature
@@ -14,7 +14,7 @@ Feature: must_be/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         results:
@@ -38,7 +38,7 @@ Feature: must_be/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3986
+      gas_used: 3788
       answer:
         has_more: false
         variables: ["Result"]
@@ -64,7 +64,7 @@ Feature: must_be/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3997
+      gas_used: 3799
       answer:
         has_more: false
         variables: ["X"]
@@ -86,7 +86,7 @@ Feature: must_be/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3997
+      gas_used: 3799
       answer:
         has_more: false
         results:
@@ -108,7 +108,7 @@ Feature: must_be/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4005
+      gas_used: 3807
       answer:
         has_more: false
         variables: ["Partial", "Tail"]

--- a/x/logic/tests/predicate/features/open_3.feature
+++ b/x/logic/tests/predicate/features/open_3.feature
@@ -31,7 +31,7 @@ Feature: open/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3976
+      gas_used: 3778
       answer:
         has_more: false
         variables:

--- a/x/logic/tests/predicate/features/open_4.feature
+++ b/x/logic/tests/predicate/features/open_4.feature
@@ -43,7 +43,7 @@ Feature: open/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3988
+      gas_used: 3790
       answer:
         has_more: false
         variables: ["URI"]
@@ -86,7 +86,7 @@ Feature: open/4
     Then the answer we get is:
       """ yaml
      height: 42
-      gas_used: 3979
+      gas_used: 3781
       answer:
         has_more: false
         variables: ["Chars"]
@@ -127,7 +127,7 @@ Feature: open/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3979
+      gas_used: 3781
       answer:
         has_more: false
         variables: ["Chars"]
@@ -149,7 +149,7 @@ Feature: open/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Stream"]
@@ -170,7 +170,7 @@ Feature: open/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Stream"]
@@ -191,7 +191,7 @@ Feature: open/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Stream"]
@@ -221,7 +221,7 @@ Feature: open/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Stream"]
@@ -241,7 +241,7 @@ Feature: open/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Stream"]
@@ -260,7 +260,7 @@ Feature: open/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Stream"]
@@ -279,7 +279,7 @@ Feature: open/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Resource", "Stream"]
@@ -298,7 +298,7 @@ Feature: open/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         variables: ["Mode", "Stream"]

--- a/x/logic/tests/predicate/features/retract_1.feature
+++ b/x/logic/tests/predicate/features/retract_1.feature
@@ -16,7 +16,7 @@ Feature: retract/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3977
+      gas_used: 3779
       answer:
         has_more: false
         variables: ["X","Y"]
@@ -40,7 +40,7 @@ Feature: retract/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3975
+      gas_used: 3777
       answer:
         has_more: false
         results:

--- a/x/logic/tests/predicate/features/term_to_atom_2.feature
+++ b/x/logic/tests/predicate/features/term_to_atom_2.feature
@@ -16,7 +16,7 @@ Feature: term_to_atom/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4172
+      gas_used: 3974
       answer:
         has_more: false
         variables: ["Atom"]
@@ -41,7 +41,7 @@ Feature: term_to_atom/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 5033
+      gas_used: 4835
       answer:
         has_more: false
         variables: ["Term"]
@@ -64,7 +64,7 @@ Feature: term_to_atom/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3991
+      gas_used: 3793
       answer:
         has_more: false
         variables: ["Term", "Atom"]
@@ -85,7 +85,7 @@ Feature: term_to_atom/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 3984
+      gas_used: 3786
       answer:
         has_more: false
         variables: ["Term"]
@@ -106,7 +106,7 @@ Feature: term_to_atom/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4473
+      gas_used: 4275
       answer:
         has_more: false
         variables: ["Term"]

--- a/x/logic/types/params.go
+++ b/x/logic/types/params.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"fmt"
-	"net/url"
 )
 
 // Parameter store keys.
@@ -11,18 +10,16 @@ var (
 )
 
 // NewParams creates a new Params object.
-func NewParams(interpreter Interpreter, limits Limits, gasPolicy GasPolicy) Params {
+func NewParams(limits Limits, gasPolicy GasPolicy) Params {
 	return Params{
-		Interpreter: interpreter,
-		Limits:      limits,
-		GasPolicy:   gasPolicy,
+		Limits:    limits,
+		GasPolicy: gasPolicy,
 	}
 }
 
 // DefaultParams returns a default set of parameters.
 func DefaultParams() Params {
 	return NewParams(
-		NewInterpreter(),
 		NewLimits(
 			WithMaxSize(5000),
 			WithMaxResultCount(3),
@@ -35,92 +32,12 @@ func DefaultParams() Params {
 
 // Validate validates the set of params.
 func (p Params) Validate() error {
-	if err := validateInterpreter(p.Interpreter); err != nil {
-		return err
-	}
 	return validateLimits(p.Limits)
 }
 
 // String implements the Stringer interface.
 func (p Params) String() string {
-	return p.Interpreter.String() + "\n" +
-		p.Limits.String()
-}
-
-// NewInterpreter creates a new Interpreter with the given options.
-func NewInterpreter(opts ...InterpreterOption) Interpreter {
-	i := Interpreter{}
-	for _, opt := range opts {
-		opt(&i)
-	}
-
-	if i.PredicatesFilter.Whitelist == nil {
-		i.PredicatesFilter.Whitelist = []string{}
-	}
-
-	if i.PredicatesFilter.Blacklist == nil {
-		i.PredicatesFilter.Blacklist = []string{}
-	}
-
-	return i
-}
-
-// InterpreterOption is a functional option for configuring the Interpreter.
-type InterpreterOption func(*Interpreter)
-
-// WithPredicatesWhitelist sets the whitelist of predicates.
-func WithPredicatesWhitelist(whitelist []string) InterpreterOption {
-	return func(i *Interpreter) {
-		i.PredicatesFilter.Whitelist = whitelist
-	}
-}
-
-// WithPredicatesBlacklist sets the blacklist of predicates.
-func WithPredicatesBlacklist(blacklist []string) InterpreterOption {
-	return func(i *Interpreter) {
-		i.PredicatesFilter.Blacklist = blacklist
-	}
-}
-
-// WithVirtualFilesWhitelist sets the whitelist of predicates.
-func WithVirtualFilesWhitelist(whitelist []string) InterpreterOption {
-	return func(i *Interpreter) {
-		i.VirtualFilesFilter.Whitelist = whitelist
-	}
-}
-
-// WithVirtualFilesBlacklist sets the blacklist of predicates.
-func WithVirtualFilesBlacklist(blacklist []string) InterpreterOption {
-	return func(i *Interpreter) {
-		i.VirtualFilesFilter.Blacklist = blacklist
-	}
-}
-
-// WithBootstrap sets the bootstrap program.
-func WithBootstrap(bootstrap string) InterpreterOption {
-	return func(i *Interpreter) {
-		i.Bootstrap = bootstrap
-	}
-}
-
-func validateInterpreter(i any) error {
-	interpreter, ok := i.(Interpreter)
-	if !ok {
-		return fmt.Errorf("invalid parameter type: %T", i)
-	}
-
-	for _, file := range interpreter.VirtualFilesFilter.Whitelist {
-		if _, err := url.Parse(file); err != nil {
-			return fmt.Errorf("invalid virtual file in whitelist: %s", file)
-		}
-	}
-	for _, file := range interpreter.VirtualFilesFilter.Blacklist {
-		if _, err := url.Parse(file); err != nil {
-			return fmt.Errorf("invalid virtual file in blacklist: %s", file)
-		}
-	}
-
-	return nil
+	return p.Limits.String() + "\n" + p.GasPolicy.String()
 }
 
 // LimitsOption is a functional option for configuring the Limits.

--- a/x/logic/types/params.pb.go
+++ b/x/logic/types/params.pb.go
@@ -25,8 +25,6 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // Params defines all the configuration parameters of the "logic" module.
 type Params struct {
-	// Interpreter specifies the parameter for the logic interpreter.
-	Interpreter Interpreter `protobuf:"bytes,1,opt,name=interpreter,proto3" json:"interpreter" yaml:"interpreter"`
 	// Limits defines the limits of the logic module.
 	// The limits are used to prevent the interpreter from running for too long.
 	// If the interpreter runs for too long, the execution will be aborted.
@@ -66,13 +64,6 @@ func (m *Params) XXX_DiscardUnknown() {
 }
 
 var xxx_messageInfo_Params proto.InternalMessageInfo
-
-func (m *Params) GetInterpreter() Interpreter {
-	if m != nil {
-		return m.Interpreter
-	}
-	return Interpreter{}
-}
 
 func (m *Params) GetLimits() Limits {
 	if m != nil {
@@ -166,144 +157,6 @@ func (m *Limits) GetMaxVariables() uint64 {
 	return 0
 }
 
-// Filter defines the parameters for filtering the set of strings which can designate anything.
-// The filter is used to whitelist or blacklist strings.
-type Filter struct {
-	// whitelist specifies a list of strings that are allowed.
-	// If this field is not specified, all strings (in the context of the filter) are allowed.
-	Whitelist []string `protobuf:"bytes,1,rep,name=whitelist,proto3" json:"whitelist,omitempty" yaml:"whitelist"`
-	// blacklist specifies a list of strings that are excluded from the set of allowed strings.
-	// If a string is included in both whitelist and blacklist, it will be excluded. This means that
-	// blacklisted strings prevails over whitelisted ones.
-	// If this field is not specified, no strings are excluded.
-	Blacklist []string `protobuf:"bytes,2,rep,name=blacklist,proto3" json:"blacklist,omitempty" yaml:"blacklist"`
-}
-
-func (m *Filter) Reset()         { *m = Filter{} }
-func (m *Filter) String() string { return proto.CompactTextString(m) }
-func (*Filter) ProtoMessage()    {}
-func (*Filter) Descriptor() ([]byte, []int) {
-	return fileDescriptor_4697d60c461b684e, []int{2}
-}
-func (m *Filter) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *Filter) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_Filter.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *Filter) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Filter.Merge(m, src)
-}
-func (m *Filter) XXX_Size() int {
-	return m.Size()
-}
-func (m *Filter) XXX_DiscardUnknown() {
-	xxx_messageInfo_Filter.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Filter proto.InternalMessageInfo
-
-func (m *Filter) GetWhitelist() []string {
-	if m != nil {
-		return m.Whitelist
-	}
-	return nil
-}
-
-func (m *Filter) GetBlacklist() []string {
-	if m != nil {
-		return m.Blacklist
-	}
-	return nil
-}
-
-// Interpreter defines the various parameters for the interpreter.
-type Interpreter struct {
-	// predicates_filter specifies the filter for the predicates that are allowed to be used by the interpreter.
-	// The filter is used to whitelist or blacklist predicates represented as `<predicate_name>/[<arity>]`, for example:
-	// `findall/3`, or `call`. If a predicate name without arity is included in the filter, then all predicates with that
-	// name will be considered regardless of arity. For example, if `call` is included in the filter, then all predicates
-	// `call/1`, `call/2`, `call/3`... will be allowed.
-	PredicatesFilter Filter `protobuf:"bytes,1,opt,name=predicates_filter,json=predicatesFilter,proto3" json:"predicates_filter" yaml:"predicates_filter"`
-	// bootstrap specifies the initial program to run when booting the logic interpreter.
-	// If not specified, the default boot sequence will be executed.
-	Bootstrap string `protobuf:"bytes,3,opt,name=bootstrap,proto3" json:"bootstrap,omitempty" yaml:"bootstrap"`
-	// virtual_files_filter specifies the filter for the virtual files that are allowed to be used by the interpreter.
-	// The filter is used to whitelist or blacklist virtual files represented as URI, for example:
-	// `file:///path/to/file`, `cosmwasm:cw-storage:axone...?query=foo`
-	// The filter is applied to the components of the URI, for example:
-	// `file:///path/to/file` -> `file`, `/path/to/file`
-	// `cosmwasm:cw-storage:axone...?query=foo` -> `cosmwasm`, `cw-storage`, `axone...`, `query=foo`
-	// If a component is included in the filter, then all components with that name will be considered, starting from the
-	// beginning of the URI. For example, if `file` is included in the filter, then all URIs that start with `file` will be
-	// allowed, regardless of the rest of the components. But `file2` will not be allowed.
-	// If the component is not included in the filter, then the component is ignored and the next component is considered.
-	VirtualFilesFilter Filter `protobuf:"bytes,4,opt,name=virtual_files_filter,json=virtualFilesFilter,proto3" json:"virtual_files_filter" yaml:"filesystem_filter"`
-}
-
-func (m *Interpreter) Reset()         { *m = Interpreter{} }
-func (m *Interpreter) String() string { return proto.CompactTextString(m) }
-func (*Interpreter) ProtoMessage()    {}
-func (*Interpreter) Descriptor() ([]byte, []int) {
-	return fileDescriptor_4697d60c461b684e, []int{3}
-}
-func (m *Interpreter) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *Interpreter) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_Interpreter.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *Interpreter) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Interpreter.Merge(m, src)
-}
-func (m *Interpreter) XXX_Size() int {
-	return m.Size()
-}
-func (m *Interpreter) XXX_DiscardUnknown() {
-	xxx_messageInfo_Interpreter.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Interpreter proto.InternalMessageInfo
-
-func (m *Interpreter) GetPredicatesFilter() Filter {
-	if m != nil {
-		return m.PredicatesFilter
-	}
-	return Filter{}
-}
-
-func (m *Interpreter) GetBootstrap() string {
-	if m != nil {
-		return m.Bootstrap
-	}
-	return ""
-}
-
-func (m *Interpreter) GetVirtualFilesFilter() Filter {
-	if m != nil {
-		return m.VirtualFilesFilter
-	}
-	return Filter{}
-}
-
 // GasPolicy defines the policy for calculating predicate invocation costs and the resulting gas consumption.
 // The gas policy is defined as a list of predicates and their associated unit costs, a default unit cost for predicates
 // if not specified in the list, and a weighting factor that is applied to the unit cost of each predicate to yield.
@@ -323,7 +176,7 @@ func (m *GasPolicy) Reset()         { *m = GasPolicy{} }
 func (m *GasPolicy) String() string { return proto.CompactTextString(m) }
 func (*GasPolicy) ProtoMessage()    {}
 func (*GasPolicy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_4697d60c461b684e, []int{4}
+	return fileDescriptor_4697d60c461b684e, []int{2}
 }
 func (m *GasPolicy) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -387,7 +240,7 @@ func (m *PredicateCost) Reset()         { *m = PredicateCost{} }
 func (m *PredicateCost) String() string { return proto.CompactTextString(m) }
 func (*PredicateCost) ProtoMessage()    {}
 func (*PredicateCost) Descriptor() ([]byte, []int) {
-	return fileDescriptor_4697d60c461b684e, []int{5}
+	return fileDescriptor_4697d60c461b684e, []int{3}
 }
 func (m *PredicateCost) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -433,8 +286,6 @@ func (m *PredicateCost) GetCost() uint64 {
 func init() {
 	proto.RegisterType((*Params)(nil), "logic.v1beta3.Params")
 	proto.RegisterType((*Limits)(nil), "logic.v1beta3.Limits")
-	proto.RegisterType((*Filter)(nil), "logic.v1beta3.Filter")
-	proto.RegisterType((*Interpreter)(nil), "logic.v1beta3.Interpreter")
 	proto.RegisterType((*GasPolicy)(nil), "logic.v1beta3.GasPolicy")
 	proto.RegisterType((*PredicateCost)(nil), "logic.v1beta3.PredicateCost")
 }
@@ -442,53 +293,43 @@ func init() {
 func init() { proto.RegisterFile("logic/v1beta3/params.proto", fileDescriptor_4697d60c461b684e) }
 
 var fileDescriptor_4697d60c461b684e = []byte{
-	// 722 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0xcd, 0x6e, 0xd3, 0x4a,
-	0x14, 0x8e, 0x93, 0xdc, 0xdc, 0x9b, 0xc9, 0x4d, 0x93, 0xfa, 0xa6, 0x17, 0x93, 0xd2, 0x38, 0x0c,
-	0x9b, 0x6e, 0x48, 0x44, 0x2b, 0x75, 0x51, 0x89, 0x8d, 0x0b, 0x01, 0x24, 0x24, 0xa2, 0x41, 0xfc,
-	0x88, 0x4d, 0x34, 0x71, 0xa6, 0xee, 0x08, 0x3b, 0x63, 0x79, 0x26, 0xad, 0xd3, 0x25, 0x4f, 0x80,
-	0x58, 0x20, 0x16, 0x2c, 0x78, 0x9c, 0x2e, 0xbb, 0x64, 0x65, 0xa1, 0xf6, 0x0d, 0xfc, 0x04, 0xc8,
-	0x33, 0x8e, 0x9d, 0xa4, 0xdd, 0xb0, 0xb3, 0xcf, 0xf7, 0x73, 0x3e, 0x9f, 0x73, 0x64, 0xd0, 0x76,
-	0x99, 0x43, 0xed, 0xfe, 0xe9, 0xa3, 0x31, 0x11, 0x78, 0xbf, 0xef, 0xe3, 0x00, 0x7b, 0xbc, 0xe7,
-	0x07, 0x4c, 0x30, 0xbd, 0x2e, 0xb1, 0x5e, 0x8a, 0xb5, 0x5b, 0x0e, 0x73, 0x98, 0x44, 0xfa, 0xc9,
-	0x93, 0x22, 0xc1, 0x4f, 0x45, 0x50, 0x19, 0x4a, 0x95, 0xfe, 0x1e, 0xd4, 0xe8, 0x54, 0x90, 0xc0,
-	0x0f, 0x88, 0x20, 0x81, 0xa1, 0x75, 0xb5, 0xdd, 0xda, 0x5e, 0xbb, 0xb7, 0xe2, 0xd2, 0x7b, 0x91,
-	0x33, 0xac, 0xf6, 0x45, 0x64, 0x16, 0xe2, 0xc8, 0xd4, 0xe7, 0xd8, 0x73, 0x0f, 0xe1, 0x92, 0x18,
-	0xa2, 0x65, 0x2b, 0xfd, 0x09, 0xa8, 0xb8, 0xd4, 0xa3, 0x82, 0x1b, 0x45, 0x69, 0xba, 0xb5, 0x66,
-	0xfa, 0x52, 0x82, 0xd6, 0x56, 0xea, 0x57, 0x57, 0x7e, 0x4a, 0x02, 0x51, 0xaa, 0xd5, 0x11, 0x00,
-	0x0e, 0xe6, 0x23, 0x9f, 0xb9, 0xd4, 0x9e, 0x1b, 0x25, 0xe9, 0x64, 0xac, 0x39, 0x3d, 0xc3, 0x7c,
-	0x28, 0x71, 0xeb, 0x6e, 0x6a, 0xb6, 0xa9, 0xcc, 0x72, 0x25, 0x44, 0x55, 0x67, 0xc1, 0x3a, 0x2c,
-	0x7f, 0xfb, 0x61, 0x16, 0xe0, 0xd7, 0x22, 0xa8, 0xa8, 0x0c, 0x7a, 0x0f, 0xfc, 0xe3, 0xe1, 0x70,
-	0xc4, 0xe9, 0x39, 0x91, 0x2d, 0xca, 0xd6, 0x7f, 0x71, 0x64, 0x36, 0x94, 0xc9, 0x02, 0x81, 0xe8,
-	0x6f, 0x0f, 0x87, 0xaf, 0xe9, 0x39, 0xd1, 0x9f, 0x82, 0x66, 0x52, 0x0d, 0x08, 0x9f, 0xb9, 0x62,
-	0x64, 0xb3, 0xd9, 0x54, 0xc8, 0x8f, 0x2c, 0x5b, 0xdb, 0x71, 0x64, 0xde, 0xc9, 0x75, 0xcb, 0x0c,
-	0x88, 0x36, 0x3c, 0x1c, 0x22, 0x59, 0x39, 0x4a, 0x0a, 0xfa, 0x10, 0xb4, 0x12, 0xd2, 0x8c, 0x93,
-	0x60, 0xc4, 0x66, 0xc2, 0x9f, 0x09, 0x15, 0xa1, 0x2c, 0xad, 0xcc, 0x38, 0x32, 0xb7, 0x73, 0xab,
-	0x75, 0x16, 0x44, 0x9b, 0x1e, 0x0e, 0xdf, 0x70, 0x12, 0xbc, 0x92, 0x45, 0x19, 0xec, 0x31, 0xa8,
-	0x27, 0xdc, 0x53, 0x1c, 0x50, 0x3c, 0x76, 0x09, 0x37, 0xfe, 0x92, 0x56, 0x46, 0x1c, 0x99, 0xad,
-	0xdc, 0x2a, 0x83, 0x21, 0xfa, 0xd7, 0xc3, 0xe1, 0xdb, 0xc5, 0xab, 0x1c, 0x8c, 0x06, 0x43, 0x50,
-	0x19, 0x50, 0x37, 0x59, 0xe1, 0x01, 0xa8, 0x9e, 0x9d, 0x50, 0x41, 0x5c, 0xca, 0x85, 0xa1, 0x75,
-	0x4b, 0xbb, 0x55, 0xcb, 0xb8, 0x88, 0x4c, 0x2d, 0x8e, 0xcc, 0xa6, 0xb2, 0xcb, 0x60, 0x88, 0x72,
-	0x6a, 0xa2, 0x1b, 0xbb, 0xd8, 0xfe, 0x28, 0x75, 0xc5, 0xdb, 0x74, 0x19, 0x0c, 0x51, 0x4e, 0x85,
-	0xdf, 0x8b, 0xa0, 0xb6, 0x74, 0x6b, 0xfa, 0x04, 0x6c, 0xfa, 0x01, 0x99, 0x50, 0x1b, 0x0b, 0xc2,
-	0x47, 0xc7, 0x32, 0x54, 0x7a, 0xa2, 0xeb, 0xd7, 0xa4, 0x12, 0x5b, 0xdd, 0xf4, 0x00, 0x0c, 0xd5,
-	0xe6, 0x86, 0x1a, 0xa2, 0x66, 0x5e, 0xcb, 0xbf, 0x72, 0xcc, 0x98, 0xe0, 0x22, 0xc0, 0xbe, 0x5c,
-	0xff, 0xcd, 0xb4, 0x0b, 0x38, 0x49, 0xbb, 0x78, 0xd6, 0x29, 0x68, 0x9d, 0xd2, 0x40, 0xcc, 0xb0,
-	0x9b, 0x98, 0xe7, 0x01, 0xcb, 0x7f, 0x10, 0x50, 0x0a, 0xe7, 0x5c, 0x10, 0x2f, 0x0b, 0xa8, 0xa7,
-	0xa6, 0x83, 0x04, 0x52, 0xaa, 0x74, 0x31, 0x5f, 0x8a, 0xa0, 0x9a, 0xdd, 0xba, 0x3e, 0x00, 0xcd,
-	0x33, 0x42, 0x9d, 0x13, 0x41, 0xa7, 0xce, 0xe8, 0x18, 0xdb, 0x82, 0xa9, 0xd9, 0xac, 0x1c, 0xe1,
-	0x3a, 0x03, 0xa2, 0x46, 0x56, 0x1a, 0xc8, 0x8a, 0xfe, 0x0e, 0xfc, 0x3f, 0x21, 0xc7, 0x38, 0xb9,
-	0xd3, 0x6c, 0x34, 0x23, 0x9b, 0xf1, 0xc5, 0x49, 0xdf, 0x8f, 0x23, 0x73, 0x47, 0xb9, 0xdd, 0xce,
-	0x83, 0xa8, 0x95, 0x02, 0xc3, 0x45, 0xfd, 0x88, 0x71, 0xa1, 0x4f, 0x40, 0x63, 0x95, 0xc8, 0x8d,
-	0x52, 0xb7, 0xb4, 0x5b, 0xdb, 0xbb, 0xb7, 0x36, 0x9a, 0x15, 0x99, 0xb5, 0x93, 0x4e, 0x68, 0x6b,
-	0x6d, 0x85, 0x69, 0xaf, 0x0d, 0x7f, 0x99, 0xcd, 0xa1, 0x0b, 0xea, 0xab, 0x6d, 0x0f, 0x40, 0x35,
-	0xa3, 0xc8, 0x81, 0xdc, 0x58, 0x67, 0x06, 0x43, 0x94, 0x53, 0xf5, 0x07, 0xa0, 0xbc, 0xf4, 0xd5,
-	0x8d, 0x38, 0x32, 0x6b, 0x8a, 0xae, 0xfa, 0x4a, 0xd0, 0x7a, 0x7e, 0x71, 0xd5, 0xd1, 0x2e, 0xaf,
-	0x3a, 0xda, 0xaf, 0xab, 0x8e, 0xf6, 0xf9, 0xba, 0x53, 0xb8, 0xbc, 0xee, 0x14, 0x7e, 0x5e, 0x77,
-	0x0a, 0x1f, 0x7a, 0x0e, 0x15, 0x27, 0xb3, 0x71, 0xcf, 0x66, 0x5e, 0x1f, 0x87, 0x6c, 0x4a, 0x1e,
-	0xca, 0x7f, 0xad, 0xcd, 0x5c, 0xf5, 0x3a, 0xe9, 0x87, 0x7d, 0xf5, 0xdf, 0x16, 0x73, 0x9f, 0xf0,
-	0x71, 0x45, 0xc2, 0xfb, 0xbf, 0x03, 0x00, 0x00, 0xff, 0xff, 0xf3, 0x73, 0xf6, 0x1b, 0xcd, 0x05,
-	0x00, 0x00,
+	// 563 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x93, 0xcf, 0x6e, 0xd3, 0x4c,
+	0x14, 0xc5, 0xe3, 0xd4, 0x5f, 0xbe, 0x66, 0x4a, 0x9a, 0xd4, 0x24, 0x60, 0x5a, 0xea, 0x29, 0xc3,
+	0xa6, 0x1b, 0x6c, 0xd1, 0x4a, 0x2c, 0x2a, 0xb1, 0x71, 0xa1, 0x20, 0x84, 0x44, 0x64, 0x04, 0x48,
+	0x6c, 0xac, 0x89, 0x33, 0x75, 0x2d, 0xd9, 0x19, 0xcb, 0x33, 0x2e, 0x4e, 0x9f, 0x02, 0xb1, 0x40,
+	0x2c, 0x79, 0x02, 0x9e, 0x23, 0xcb, 0x2e, 0x59, 0x59, 0x28, 0x79, 0x03, 0x3f, 0x01, 0xf2, 0x4c,
+	0xfe, 0x5a, 0xec, 0xec, 0x73, 0x7e, 0xf7, 0xdc, 0xb9, 0x57, 0x33, 0x60, 0x3f, 0xa4, 0x7e, 0xe0,
+	0x59, 0xd7, 0x4f, 0x07, 0x84, 0xe3, 0x53, 0x2b, 0xc6, 0x09, 0x8e, 0x98, 0x19, 0x27, 0x94, 0x53,
+	0xad, 0x25, 0x3c, 0x73, 0xee, 0xed, 0x77, 0x7d, 0xea, 0x53, 0xe1, 0x58, 0xe5, 0x97, 0x84, 0xd0,
+	0x2f, 0x05, 0x34, 0xfa, 0xa2, 0x4a, 0x7b, 0x01, 0x1a, 0x61, 0x10, 0x05, 0x9c, 0xe9, 0xf5, 0x23,
+	0xe5, 0x78, 0xe7, 0xa4, 0x67, 0x6e, 0x04, 0x98, 0x6f, 0x85, 0x69, 0xf7, 0x26, 0x39, 0xac, 0x15,
+	0x39, 0x6c, 0x8d, 0x71, 0x14, 0x9e, 0x21, 0x59, 0x82, 0x9c, 0x79, 0xad, 0xe6, 0x00, 0xe0, 0x63,
+	0xe6, 0xc6, 0x34, 0x0c, 0xbc, 0xb1, 0xbe, 0x25, 0x92, 0xf4, 0x4a, 0xd2, 0x2b, 0xcc, 0xfa, 0xc2,
+	0xb7, 0x1f, 0xcc, 0xc3, 0xf6, 0x64, 0xd8, 0xaa, 0x12, 0x39, 0x4d, 0x7f, 0x41, 0x9d, 0xa9, 0x3f,
+	0x7e, 0xc2, 0xda, 0x1b, 0x75, 0x5b, 0xe9, 0xd4, 0xd1, 0xf7, 0x3a, 0x68, 0xc8, 0x93, 0x68, 0x26,
+	0xd8, 0x8e, 0x70, 0xe6, 0xb2, 0xe0, 0x86, 0x88, 0x46, 0xaa, 0x7d, 0xb7, 0xc8, 0x61, 0x5b, 0x46,
+	0x2d, 0x1c, 0xe4, 0xfc, 0x1f, 0xe1, 0xec, 0x7d, 0x70, 0x43, 0xb4, 0x97, 0xa0, 0x53, 0xaa, 0x09,
+	0x61, 0x69, 0xc8, 0x5d, 0x8f, 0xa6, 0x23, 0x2e, 0x46, 0x55, 0xed, 0x83, 0x22, 0x87, 0xf7, 0x57,
+	0x75, 0xeb, 0x04, 0x72, 0x76, 0x23, 0x9c, 0x39, 0x42, 0x39, 0x2f, 0x05, 0xad, 0x0f, 0xba, 0x25,
+	0x94, 0x32, 0x92, 0xb8, 0x34, 0xe5, 0x71, 0xca, 0xe5, 0x11, 0x54, 0x11, 0x05, 0x8b, 0x1c, 0x1e,
+	0xac, 0xa2, 0xaa, 0x14, 0x72, 0xf6, 0x22, 0x9c, 0x7d, 0x60, 0x24, 0x79, 0x27, 0x44, 0x71, 0xb0,
+	0xe7, 0xa0, 0x55, 0xb2, 0xd7, 0x38, 0x09, 0xf0, 0x20, 0x24, 0x4c, 0xff, 0x4f, 0x44, 0xe9, 0x45,
+	0x0e, 0xbb, 0xab, 0xa8, 0xa5, 0x8d, 0x9c, 0x3b, 0x11, 0xce, 0x3e, 0x2e, 0x7e, 0xc5, 0x7a, 0x14,
+	0xf4, 0xad, 0x0e, 0x9a, 0xcb, 0xc5, 0x6a, 0x17, 0xa0, 0xf3, 0x85, 0x04, 0xfe, 0x15, 0x0f, 0x46,
+	0xbe, 0x7b, 0x89, 0x3d, 0x4e, 0x13, 0x5d, 0xa9, 0xce, 0x5a, 0x25, 0x90, 0xd3, 0x5e, 0x4a, 0x17,
+	0x42, 0xd1, 0x3e, 0x81, 0x7b, 0x43, 0x72, 0x89, 0xcb, 0x75, 0xc4, 0x09, 0x19, 0x06, 0x1e, 0xe6,
+	0xc4, 0xf5, 0x28, 0x5b, 0x6c, 0xee, 0x51, 0x91, 0xc3, 0x43, 0x99, 0xf6, 0x6f, 0x0e, 0x39, 0xdd,
+	0xb9, 0xd1, 0x5f, 0xe8, 0xe7, 0x94, 0x71, 0x6d, 0x08, 0xda, 0x9b, 0x20, 0xd3, 0xb7, 0x8e, 0xb6,
+	0x8e, 0x77, 0x4e, 0x1e, 0x56, 0x2e, 0xcb, 0x46, 0x99, 0x7d, 0x38, 0xbf, 0x30, 0x3d, 0xd9, 0xb3,
+	0xda, 0x6b, 0x37, 0x5e, 0xa7, 0x19, 0x0a, 0x41, 0x6b, 0xb3, 0xed, 0x33, 0xd0, 0x5c, 0x22, 0x62,
+	0x21, 0x4d, 0x5b, 0x9f, 0xe4, 0x50, 0x29, 0x72, 0xd8, 0xa9, 0x44, 0x22, 0x67, 0x85, 0x6a, 0x8f,
+	0x81, 0xba, 0x36, 0x75, 0xbb, 0xc8, 0xe1, 0x8e, 0xc4, 0x65, 0x5f, 0x61, 0xda, 0xaf, 0x27, 0x53,
+	0x43, 0xb9, 0x9d, 0x1a, 0xca, 0x9f, 0xa9, 0xa1, 0x7c, 0x9d, 0x19, 0xb5, 0xdb, 0x99, 0x51, 0xfb,
+	0x3d, 0x33, 0x6a, 0x9f, 0x4d, 0x3f, 0xe0, 0x57, 0xe9, 0xc0, 0xf4, 0x68, 0x64, 0xe1, 0x8c, 0x8e,
+	0xc8, 0x13, 0xf1, 0xfc, 0x3c, 0x1a, 0xca, 0xdf, 0xa1, 0x95, 0x59, 0xf2, 0x29, 0xf3, 0x71, 0x4c,
+	0xd8, 0xa0, 0x21, 0xec, 0xd3, 0xbf, 0x01, 0x00, 0x00, 0xff, 0xff, 0xc3, 0x2b, 0x18, 0x53, 0xe0,
+	0x03, 0x00, 0x00,
 }
 
 func (m *Params) Marshal() (dAtA []byte, err error) {
@@ -531,16 +372,6 @@ func (m *Params) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	}
 	i--
 	dAtA[i] = 0x12
-	{
-		size, err := m.Interpreter.MarshalToSizedBuffer(dAtA[:i])
-		if err != nil {
-			return 0, err
-		}
-		i -= size
-		i = encodeVarintParams(dAtA, i, uint64(size))
-	}
-	i--
-	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
 }
 
@@ -584,97 +415,6 @@ func (m *Limits) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i--
 		dAtA[i] = 0x10
 	}
-	return len(dAtA) - i, nil
-}
-
-func (m *Filter) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *Filter) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *Filter) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	if len(m.Blacklist) > 0 {
-		for iNdEx := len(m.Blacklist) - 1; iNdEx >= 0; iNdEx-- {
-			i -= len(m.Blacklist[iNdEx])
-			copy(dAtA[i:], m.Blacklist[iNdEx])
-			i = encodeVarintParams(dAtA, i, uint64(len(m.Blacklist[iNdEx])))
-			i--
-			dAtA[i] = 0x12
-		}
-	}
-	if len(m.Whitelist) > 0 {
-		for iNdEx := len(m.Whitelist) - 1; iNdEx >= 0; iNdEx-- {
-			i -= len(m.Whitelist[iNdEx])
-			copy(dAtA[i:], m.Whitelist[iNdEx])
-			i = encodeVarintParams(dAtA, i, uint64(len(m.Whitelist[iNdEx])))
-			i--
-			dAtA[i] = 0xa
-		}
-	}
-	return len(dAtA) - i, nil
-}
-
-func (m *Interpreter) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *Interpreter) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *Interpreter) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	{
-		size, err := m.VirtualFilesFilter.MarshalToSizedBuffer(dAtA[:i])
-		if err != nil {
-			return 0, err
-		}
-		i -= size
-		i = encodeVarintParams(dAtA, i, uint64(size))
-	}
-	i--
-	dAtA[i] = 0x22
-	if len(m.Bootstrap) > 0 {
-		i -= len(m.Bootstrap)
-		copy(dAtA[i:], m.Bootstrap)
-		i = encodeVarintParams(dAtA, i, uint64(len(m.Bootstrap)))
-		i--
-		dAtA[i] = 0x1a
-	}
-	{
-		size, err := m.PredicatesFilter.MarshalToSizedBuffer(dAtA[:i])
-		if err != nil {
-			return 0, err
-		}
-		i -= size
-		i = encodeVarintParams(dAtA, i, uint64(size))
-	}
-	i--
-	dAtA[i] = 0xa
 	return len(dAtA) - i, nil
 }
 
@@ -777,8 +517,6 @@ func (m *Params) Size() (n int) {
 	}
 	var l int
 	_ = l
-	l = m.Interpreter.Size()
-	n += 1 + l + sovParams(uint64(l))
 	l = m.Limits.Size()
 	n += 1 + l + sovParams(uint64(l))
 	l = m.GasPolicy.Size()
@@ -804,44 +542,6 @@ func (m *Limits) Size() (n int) {
 	if m.MaxVariables != 0 {
 		n += 1 + sovParams(uint64(m.MaxVariables))
 	}
-	return n
-}
-
-func (m *Filter) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	if len(m.Whitelist) > 0 {
-		for _, s := range m.Whitelist {
-			l = len(s)
-			n += 1 + l + sovParams(uint64(l))
-		}
-	}
-	if len(m.Blacklist) > 0 {
-		for _, s := range m.Blacklist {
-			l = len(s)
-			n += 1 + l + sovParams(uint64(l))
-		}
-	}
-	return n
-}
-
-func (m *Interpreter) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	l = m.PredicatesFilter.Size()
-	n += 1 + l + sovParams(uint64(l))
-	l = len(m.Bootstrap)
-	if l > 0 {
-		n += 1 + l + sovParams(uint64(l))
-	}
-	l = m.VirtualFilesFilter.Size()
-	n += 1 + l + sovParams(uint64(l))
 	return n
 }
 
@@ -917,39 +617,6 @@ func (m *Params) Unmarshal(dAtA []byte) error {
 			return fmt.Errorf("proto: Params: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Interpreter", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowParams
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthParams
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthParams
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.Interpreter.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Limits", wireType)
@@ -1142,268 +809,6 @@ func (m *Limits) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
-		default:
-			iNdEx = preIndex
-			skippy, err := skipParams(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if (skippy < 0) || (iNdEx+skippy) < 0 {
-				return ErrInvalidLengthParams
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *Filter) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowParams
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: Filter: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Filter: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Whitelist", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowParams
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthParams
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthParams
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Whitelist = append(m.Whitelist, string(dAtA[iNdEx:postIndex]))
-			iNdEx = postIndex
-		case 2:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Blacklist", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowParams
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthParams
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthParams
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Blacklist = append(m.Blacklist, string(dAtA[iNdEx:postIndex]))
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipParams(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if (skippy < 0) || (iNdEx+skippy) < 0 {
-				return ErrInvalidLengthParams
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *Interpreter) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowParams
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: Interpreter: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Interpreter: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field PredicatesFilter", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowParams
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthParams
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthParams
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.PredicatesFilter.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		case 3:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Bootstrap", wireType)
-			}
-			var stringLen uint64
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowParams
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				stringLen |= uint64(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			intStringLen := int(stringLen)
-			if intStringLen < 0 {
-				return ErrInvalidLengthParams
-			}
-			postIndex := iNdEx + intStringLen
-			if postIndex < 0 {
-				return ErrInvalidLengthParams
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			m.Bootstrap = string(dAtA[iNdEx:postIndex])
-			iNdEx = postIndex
-		case 4:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field VirtualFilesFilter", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowParams
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthParams
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthParams
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.VirtualFilesFilter.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipParams(dAtA[iNdEx:])

--- a/x/logic/types/params_test.go
+++ b/x/logic/types/params_test.go
@@ -10,29 +10,18 @@ import (
 )
 
 func TestValidateParams(t *testing.T) {
-	Convey("Given a test cases", t, func() {
+	Convey("Given test cases", t, func() {
 		cases := []struct {
-			name      string
-			params    types.Params
-			expectErr bool
-			err       error
+			name   string
+			params types.Params
 		}{
 			{
-				name:      "validate default params",
-				params:    types.DefaultParams(),
-				expectErr: false,
-				err:       nil,
+				name:   "default params",
+				params: types.DefaultParams(),
 			},
 			{
-				name: "validate set params",
+				name: "custom params",
 				params: types.NewParams(
-					types.NewInterpreter(
-						types.WithBootstrap("bootstrap"),
-						types.WithPredicatesBlacklist([]string{"halt/1"}),
-						types.WithPredicatesWhitelist([]string{"source_file/1"}),
-						types.WithVirtualFilesBlacklist([]string{"file1"}),
-						types.WithVirtualFilesWhitelist([]string{"file2"}),
-					),
 					types.NewLimits(
 						types.WithMaxSize(2),
 						types.WithMaxResultCount(3),
@@ -44,53 +33,19 @@ func TestValidateParams(t *testing.T) {
 						DefaultPredicateCost: 1,
 					},
 				),
-				expectErr: false,
-				err:       nil,
-			},
-			{
-				name: "validate invalid virtual files blacklist params",
-				params: types.NewParams(
-					types.NewInterpreter(
-						types.WithVirtualFilesBlacklist([]string{"https://foo{bar/"}),
-					),
-					types.NewLimits(),
-					types.GasPolicy{},
-				),
-				expectErr: true,
-				err:       fmt.Errorf("invalid virtual file in blacklist: https://foo{bar/"),
-			},
-			{
-				name: "validate invalid virtual files whitelist params",
-				params: types.NewParams(
-					types.NewInterpreter(
-						types.WithVirtualFilesWhitelist([]string{"https://foo{bar/"}),
-					),
-					types.NewLimits(),
-					types.GasPolicy{},
-				),
-				expectErr: true,
-				err:       fmt.Errorf("invalid virtual file in whitelist: https://foo{bar/"),
 			},
 		}
 
 		for nc, tc := range cases {
-			Convey(
-				fmt.Sprintf("Given test case #%d: %v, with params: %v", nc, tc.name, tc.params), func() {
-					Convey("when validate params", func() {
-						err := tc.params.Validate()
+			Convey(fmt.Sprintf("Given test case #%d: %s", nc, tc.name), func() {
+				Convey("when validate params", func() {
+					err := tc.params.Validate()
 
-						if tc.expectErr {
-							Convey("then params validation expect error", func() {
-								So(err, ShouldNotBeNil)
-								So(err, ShouldResemble, tc.err)
-							})
-						} else {
-							Convey("then error should be nil", func() {
-								So(err, ShouldBeNil)
-							})
-						}
+					Convey("then error should be nil", func() {
+						So(err, ShouldBeNil)
 					})
 				})
+			})
 		}
 	})
 }


### PR DESCRIPTION
This PR introduces a breaking change in `x/logic` by removing interpreter-level params from module state, including:
1. predicate allow/deny filters
2. VFS scheme allow/deny filters
3. the bootstrap parameter

⚠️ **Breaking change**: A Cosmos SDK _state migration_ is included for `x/logic` consensus `version 5` and is executed as part of the chain upgrade `v15.0.0` (to come), rewriting legacy params into the new canonical schema.

### Posture

In [Axone](https://axone.xyz), the execution surface is defined by construction:
- The interpreter exposes a closed, chain-embedded ISO predicate set only.
- Any interaction with the host happens exclusively through the VFS.
- VFS devices are deterministic and fully metered.
- Execution is bounded by strict limits and gas accounting.

Given these guarantees, filtering individual predicates or VFS schemes is not an objective safety mechanism anymore. It is a governance-controlled compatibility breaker.

### Why predicate and VFS filters are removed

_Allow_/_deny_ filters enable parameter changes that can instantly invalidate programs that were previously valid and deployed, without any semantic upgrade path. This is equivalent to amputating the on-chain language ABI.

When a bug exists, the correct response is to fix and upgrade the runtime or the corresponding VFS device, not to evict features at the parameter level.

### Why bootstrap is removed

The bootstrap parameter allows the chain configuration to alter the interpreter boot sequence by injecting an arbitrary initial program. This brings no meaningful value in the current model:
- Bootstrapping is part of the runtime contract and should be deterministic and uniform.
- Allowing a configurable initial program is another implicit “ABI switch” that can change semantics without an upgrade path.
- The interpreter already has a well-defined default boot sequence (stdlib, initialization, etc.). If it needs to evolve, it should evolve via versioned upgrades, not through parameter-level indirection.

In short: boot behavior is runtime design, not governance configuration.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for chain upgrade path v15.0.0.
  * Introduced state migration utility for updating parameters to version 5.

* **Chores**
  * Simplified module parameters by removing interpreter configuration options.
  * Removed predicate and virtual file filtering capabilities.
  * Bumped consensus version to 5.
  * Updated gas usage calculations across all test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->