### PR TITLE
Build/golang 1.25

### DIFF
--- a/.github/workflows/project-auto-merge-dependabot.yml
+++ b/.github/workflows/project-auto-merge-dependabot.yml
@@ -31,8 +31,7 @@ jobs:
         env:
           UPDATE_TYPE: ${{ steps.meta.outputs.update-type }}
         run: |
-          if [[ "$UPDATE_TYPE" == "version-update:semver-patch" ]] || \
-             [[ "$UPDATE_TYPE" == "version-update:semver-minor" ]]; then
+          if [[ "$UPDATE_TYPE" == "version-update:semver-patch" ]]; then
             echo "should_merge=true" >> "$GITHUB_OUTPUT"
           else
             echo "should_merge=false" >> "$GITHUB_OUTPUT"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #--- Build stage
-FROM golang:1.25-alpine3.22@sha256:2c16ac01b3d038ca2ed421d66cea489e3cb670c251b4f8bbcfad2ebfb75f884c AS go-builder
+FROM golang:1.25-alpine3.23@sha256:7a00384194cf2cb68924bbb918d675f1517357433c8541bac0ab2f929b9d5447 AS go-builder
 
 WORKDIR /src
 
@@ -10,7 +10,7 @@ ADD https://github.com/CosmWasm/wasmvm/releases/download/v3.0.2/libwasmvm_muslc.
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 # hadolint ignore=DL3018
 RUN \
-    apk add --no-cache ca-certificates build-base=0.5-r3 git=~2.49 linux-headers=6.14.2-r0 \
+    apk add --no-cache ca-certificates=20251003-r0 build-base=0.5-r3 git=2.52.0-r0 linux-headers=6.16.12-r0 \
  && sha256sum /lib/libwasmvm_muslc.aarch64.a | grep b9df5056ab9f61d3f9b944060b44e893d7ade7dad6ff134b36276be0f9a4185a \
  && sha256sum /lib/libwasmvm_muslc.x86_64.a | grep b249396cf884b207f49f46bcf5b8d1fd73b8618eebbe35afb8bf60a8bb24f30a
 
@@ -19,9 +19,10 @@ COPY . /src/
 RUN BUILD_TAGS=muslc LINK_STATICALLY=true make build-go
 
 #--- Image stage
-FROM alpine:3.23.3
+FROM scratch
 
 COPY --from=go-builder /src/target/dist/axoned /usr/bin/axoned
+COPY --from=go-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 WORKDIR /opt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #--- Build stage
-FROM golang:1.24-alpine3.22@sha256:40d22b0a80c91066605c64848a69cb366a50f1c2e47faf2558d23c0165d18f32 AS go-builder
+FROM golang:1.25-alpine3.22@sha256:2c16ac01b3d038ca2ed421d66cea489e3cb670c251b4f8bbcfad2ebfb75f884c AS go-builder
 
 WORKDIR /src
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ COVER_ALL_FILE         := $(TARGET_FOLDER)/coverage.txt
 COVER_HTML_FILE        := $(TARGET_FOLDER)/coverage.html
 
 # Docker images
-DOCKER_IMAGE_GOLANG	      = golang:1.24-alpine3.22
+DOCKER_IMAGE_GOLANG	      = golang:1.25-alpine3.22
 DOCKER_IMAGE_PROTO        = ghcr.io/cosmos/proto-builder:0.14.0
 DOCKER_IMAGE_BUF          = bufbuild/buf:1.4.0
 DOCKER_PROTO_RUN         := docker run --rm --user $(id -u):$(id -g) -v $(HOME)/.cache:/root/.cache -v $(PWD):/workspace --workdir /workspace $(DOCKER_IMAGE_PROTO)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ AXONE blockchain and hosted in the [axone-protocol/contracts](https://github.com
 
 ### Prerequisites
 
-- install [Go] `1.24+` following instructions from the [official Go documentation](https://golang.org/doc/install);
+- install [Go] `1.25+` following instructions from the [official Go documentation](https://golang.org/doc/install);
 - use [gofumpt](https://github.com/mvdan/gofumpt) as formatter. You can integrate it in your favorite IDE following these [instructions](https://github.com/mvdan/gofumpt#installation) or invoke the makefile `make format-go`;
 - verify that [Docker] is properly installed and if not, follow the [instructions](https://docs.docker.com) for your environment;
 - verify that [`make`](https://fr.wikipedia.org/wiki/Make) is properly installed if you intend to use the provided `Makefile`.


### PR DESCRIPTION
Self explanatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go runtime from 1.24 to 1.25 across build toolchain and Docker images.
  * Enhanced Docker image configuration with updated Alpine base and CA certificate bundle support.
  * Updated auto-merge workflow to restrict approvals to patch-level version updates only.

* **Documentation**
  * Updated Go version prerequisite requirement to 1.25+ in README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->