### PR TITLE
chore(deps): bump Go and Alpine versions to 1.25 and 3.23

### DIFF
--- a/.heighliner/chains.yaml
+++ b/.heighliner/chains.yaml
@@ -14,5 +14,5 @@
       platforms:
         - linux/amd64
         - linux/arm64
-      go-version: "1.24"
-      alpine-version: "3.22"
+      go-version: "1.25"
+      alpine-version: "3.23"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ COVER_ALL_FILE         := $(TARGET_FOLDER)/coverage.txt
 COVER_HTML_FILE        := $(TARGET_FOLDER)/coverage.html
 
 # Docker images
-DOCKER_IMAGE_GOLANG	      = golang:1.25-alpine3.22
 DOCKER_IMAGE_PROTO        = ghcr.io/cosmos/proto-builder:0.14.0
 DOCKER_IMAGE_BUF          = bufbuild/buf:1.4.0
 DOCKER_PROTO_RUN         := docker run --rm --user $(id -u):$(id -g) -v $(HOME)/.cache:/root/.cache -v $(PWD):/workspace --workdir /workspace $(DOCKER_IMAGE_PROTO)


### PR DESCRIPTION
Self explanatory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build toolchain and runtime versions to enhance performance and stability across all supported deployment platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->