### PR TITLE
Docs/vfs documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -422,8 +422,8 @@ doc-command: ## Generate markdown documentation for the command
 doc-predicate: ## Generate markdown documentation for all the predicates (module logic)
 	@${call echo_msg, 📖, Generating, documentation, for Predicates}
 	@OUT_FOLDER="docs/predicate"; \
-	rm -rf $$OUT_FOLDER; \
 	mkdir -p $$OUT_FOLDER; \
+	find $$OUT_FOLDER -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +; \
 	go run -mod=readonly ./scripts/. predicate
 	@markdownlint-cli2 --fix --config docs/.markdownlint.yaml "docs/predicate/**/*.md"
 

--- a/docs/predicate/dev/dev_call_4.md
+++ b/docs/predicate/dev/dev_call_4.md
@@ -18,6 +18,7 @@ Load this module before using the predicate:
 ## Description
 
 Executes a transactional device call following a half-duplex protocol.
+See [VFS overview](../vfs) for the consumer-facing path catalog and device protocol.
 
 ## Overview
 

--- a/docs/predicate/vfs.md
+++ b/docs/predicate/vfs.md
@@ -1,0 +1,303 @@
+# Virtual File System
+
+The AXONE logic Virtual File System (VFS) is the capability surface exposed to
+Prolog programs. Programs do not read the node filesystem directly. They resolve
+versioned `/v1/...` paths mounted by the AXONE blockchain to load AXONE libraries,
+inspect the current execution context, read chain-backed state, or call chain
+services.
+
+Most programs should use the predicates documented in this section. The VFS paths
+matter when you are composing lower-level predicates, auditing what a wrapper
+does, or integrating a capability that does not yet have a dedicated predicate.
+
+## `/v1`
+
+The path determines the protocol:
+
+| Path family | Open mode | Stream type | What changes for callers |
+| --- | --- | --- | --- |
+| `/v1/lib/...` | `read` or `consult/1` | Text | Loads Prolog source provided by the AXONE blockchain. |
+| `/v1/run/...` | `read` | Text | Reads immutable data for the current logic execution. |
+| `/v1/var/lib/...` | `read` | Text | Reads deterministic chain-backed state exposed to logic. |
+| `/v1/dev/...` | `read_write` | Text or binary | Writes a request, then reads the response from a transactional endpoint. |
+
+Read-only paths usually return Prolog terms terminated by `.`. Always close the
+stream you open:
+
+```prolog
+setup_call_cleanup(
+  open('/v1/run/header/height', read, Stream, [type(text)]),
+  read_term(Stream, Height, []),
+  close(Stream)
+).
+```
+
+Transactional paths under `/v1/dev/...` follow a half-duplex protocol. The first
+read commits the request; after that the stream is response-only and further
+writes fail. Prefer `dev_call/4` from `/v1/lib/dev.pl` when you need direct
+device access:
+
+```prolog
+:- consult('/v1/lib/dev.pl').
+
+call_device(Path, RequestBytes, ResponseBytes) :-
+  dev_call(Path, binary, dev_write_bytes(RequestBytes), dev_read_bytes(ResponseBytes)).
+```
+
+Device calls are bounded by request and response size limits. Use the wrapper
+predicates listed below when they exist; they encode the expected request shape
+and error mapping for the target capability.
+
+## `/v1/lib/*.pl`
+
+AXONE embeds reusable Prolog libraries under `/v1/lib`. Load them with
+`consult/1`; they are Prolog source files.
+
+| Field | Value |
+| --- | --- |
+| Paths | `/v1/lib/*.pl` |
+| Open mode | `read`, usually through `consult/1` |
+| Stream type | Text |
+| Response | Prolog source code |
+
+Example:
+
+```prolog
+:- consult('/v1/lib/chain.pl').
+:- consult('/v1/lib/bank.pl').
+```
+
+## `/v1/run/header`
+
+The `/v1/run/header` paths expose the SDK header snapshot for the current logic
+execution. Use them when the relation depends on the AXONE block context.
+
+| Field | Value |
+| --- | --- |
+| Paths | `/v1/run/header/@`, `/v1/run/header/height`, `/v1/run/header/hash`, `/v1/run/header/time`, `/v1/run/header/chain_id`, `/v1/run/header/app_hash` |
+| Open mode | `read` |
+| Stream type | Text |
+| Response | One Prolog term. `@` returns a `header{...}` dict; field paths return the selected field. |
+| Recommended predicate | `header_info/1` from `/v1/lib/chain.pl` |
+
+Example:
+
+```prolog
+:- consult('/v1/lib/chain.pl').
+
+current_height(Height) :-
+  header_info(Header),
+  Height = Header.height.
+```
+
+## `/v1/run/comet`
+
+The `/v1/run/comet` paths expose CometBFT block data attached to the current
+execution, such as validator information, proposer address, evidence, and last
+commit data.
+
+| Field | Value |
+| --- | --- |
+| Paths | `/v1/run/comet/@`, `/v1/run/comet/validators_hash`, `/v1/run/comet/proposer_address`, `/v1/run/comet/evidence`, `/v1/run/comet/last_commit`, `/v1/run/comet/last_commit/round`, `/v1/run/comet/last_commit/votes` |
+| Open mode | `read` |
+| Stream type | Text |
+| Response | One Prolog term. `@` returns a `comet{...}` dict; field paths return the selected field. |
+| Recommended predicate | `comet_info/1` from `/v1/lib/chain.pl` |
+
+## `/v1/run/source/files`
+
+`/v1/run/source/files` lists the Prolog source files loaded in the current
+interpreter.
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/run/source/files` |
+| Open mode | `read` |
+| Stream type | Text |
+| Response | One Prolog list of source file atoms |
+| Recommended predicate | `source_file/1` |
+
+## `/v1/var/lib/bank/<address>`
+
+The `/v1/var/lib/bank/<address>` paths expose account balances from AXONE chain
+state. `<address>` must be a valid account Bech32 address.
+
+| Field | Value |
+| --- | --- |
+| Paths | `/v1/var/lib/bank/<address>/balances/@`, `/v1/var/lib/bank/<address>/spendable/@`, `/v1/var/lib/bank/<address>/locked/@` |
+| Open mode | `read` |
+| Stream type | Text |
+| Response | A stream of `Denom-Amount` Prolog terms, one term per coin |
+| Recommended predicates | `bank_balances/2`, `bank_spendable_balances/2`, `bank_locked_balances/2` from `/v1/lib/bank.pl` |
+
+Amounts are integers when they fit in `int64`; larger amounts are atoms
+preserving the full decimal value.
+
+## `/v1/var/lib/logic/users/<publisher>/programs/<program_id>.pl`
+
+Published logic programs are exposed as Prolog source files. This lets a program
+load another program that has been published on AXONE chain state.
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/var/lib/logic/users/<publisher>/programs/<program_id>.pl` |
+| Open mode | `read`, usually through `consult/1` |
+| Stream type | Text |
+| Response | Prolog source code |
+| Recommended predicate | `consult/1` |
+
+`<publisher>` is the publisher account address. `<program_id>` is the hex
+program identifier.
+
+## `/v1/dev/codec/<codec>`
+
+Codec paths transform data through codecs supported by the AXONE blockchain. They
+are transactional endpoints: open in `read_write`, write the complete request,
+then read the serialized response term.
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/dev/codec/<codec>` |
+| Open mode | `read_write` |
+| Stream type | Text |
+| Request | Command plus payload. Shape depends on the codec. |
+| Response | One serialized Prolog term, usually `ok(Value)` or `error(Code)` |
+| Recommended predicates | `bech32_address/2`, `json_prolog/2`, `json_read/2`, `json_write/2`, and text helpers such as `string_bytes/3` |
+
+### `/v1/dev/codec/bech32`
+
+The Bech32 codec converts between AXONE Bech32 atoms and `Hrp-Bytes` Prolog
+pairs.
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/dev/codec/bech32` |
+| Request | `encode <hrp> <hex_bytes>` or `decode <bech32>` |
+| Response | `ok(Bech32)`, `ok(Hrp-Bytes)`, or `error(Code)` |
+| Recommended predicate | `bech32_address/2` from `/v1/lib/bech32.pl` |
+
+### `/v1/dev/codec/json`
+
+The JSON codec converts between JSON text and AXONE's canonical Prolog JSON
+representation.
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/dev/codec/json` |
+| Request | `decode` followed by JSON text, or `encode` followed by a canonical Prolog JSON term |
+| Response | `ok(Value)` or `error(Code)` |
+| Recommended predicates | `json_prolog/2`, `json_read/2`, `json_write/2` from `/v1/lib/json.pl` |
+
+Canonical JSON terms use `json(NameValueList)` for objects, lists for arrays,
+atoms for strings, numbers for JSON numbers, and `@(true)`, `@(false)`, and
+`@(null)` for booleans and null.
+
+### `/v1/dev/codec/text`
+
+The text codec converts between Prolog textual values and byte lists. It backs
+the `string_bytes/3` predicate for encodings such as `text`, `utf8`, `octet`,
+and `hex`.
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/dev/codec/text` |
+| Request | `encode` or `decode`, followed by a Prolog payload term |
+| Response | `ok(Value)` or `error(Code)` |
+| Recommended predicate | `string_bytes/3` |
+
+## `/v1/dev/crypto/<algorithm>`
+
+Crypto paths expose hashing and signature verification supported by the AXONE
+blockchain.
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/dev/crypto/<algorithm>` |
+| Open mode | `read_write` |
+| Stream type | Binary for hashes, text for signature verification |
+| Request | Hash devices receive raw bytes. Signature devices receive `verify <pubkey_hex> <data_hex> <signature_hex>`. |
+| Response | Hash devices return raw digest bytes. Signature devices return a Prolog term such as `ok(true)`, `ok(false)`, or `error(Code)`. |
+| Recommended predicates | `crypto_data_hash/3`, `eddsa_verify/4`, `ecdsa_verify/4` from `/v1/lib/crypto.pl` |
+
+### `/v1/dev/crypto/md5`
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/dev/crypto/md5` |
+| Operation | MD5 digest |
+| Stream type | Binary |
+| Request | Raw bytes |
+| Response | Raw digest bytes |
+| Recommended predicate | `crypto_data_hash/3` with `algorithm(md5)` |
+
+### `/v1/dev/crypto/sha256`
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/dev/crypto/sha256` |
+| Operation | SHA-256 digest |
+| Stream type | Binary |
+| Request | Raw bytes |
+| Response | Raw digest bytes |
+| Recommended predicate | `crypto_data_hash/3` with `algorithm(sha256)` |
+
+### `/v1/dev/crypto/sha512`
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/dev/crypto/sha512` |
+| Operation | SHA-512 digest |
+| Stream type | Binary |
+| Request | Raw bytes |
+| Response | Raw digest bytes |
+| Recommended predicate | `crypto_data_hash/3` with `algorithm(sha512)` |
+
+### `/v1/dev/crypto/ed25519`
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/dev/crypto/ed25519` |
+| Operation | Ed25519 signature verification |
+| Stream type | Text |
+| Request | `verify <pubkey_hex> <data_hex> <signature_hex>` |
+| Response | `ok(true)`, `ok(false)`, or `error(Code)` |
+| Recommended predicate | `eddsa_verify/4` with `type(ed25519)` |
+
+### `/v1/dev/crypto/secp256r1`
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/dev/crypto/secp256r1` |
+| Operation | ECDSA secp256r1 signature verification |
+| Stream type | Text |
+| Request | `verify <pubkey_hex> <data_hex> <signature_hex>` |
+| Response | `ok(true)`, `ok(false)`, or `error(Code)` |
+| Recommended predicate | `ecdsa_verify/4` with `type(secp256r1)` |
+
+### `/v1/dev/crypto/secp256k1`
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/dev/crypto/secp256k1` |
+| Operation | ECDSA secp256k1 signature verification |
+| Stream type | Text |
+| Request | `verify <pubkey_hex> <data_hex> <signature_hex>` |
+| Response | `ok(true)`, `ok(false)`, or `error(Code)` |
+| Recommended predicate | `ecdsa_verify/4` with `type(secp256k1)` |
+
+## `/v1/dev/wasm/<contract_address>/query`
+
+The CosmWasm query path executes a smart query against a contract address visible
+from the AXONE blockchain.
+
+| Field | Value |
+| --- | --- |
+| Path | `/v1/dev/wasm/<contract_address>/query` |
+| Open mode | `read_write` |
+| Stream type | Binary |
+| Request | Raw query bytes, typically UTF-8 JSON |
+| Response | Raw contract response bytes |
+| Recommended predicate | `wasm_query/3` from `/v1/lib/wasm.pl` |
+
+This device is query-only. It does not execute transactions or mutate contract
+state.

--- a/docs/proto/logic.md
+++ b/docs/proto/logic.md
@@ -135,125 +135,14 @@ the last bytes are kept.
 
 ## Virtual File System (VFS)
 
-A key concept of the module is the VFS exposed to the Prolog VM through `open/4` and `consult/1`.
+The Prolog VM evaluates programs against a Virtual File System (VFS) exposed by the AXONE blockchain. For most users,
+the important point is that reusable logic is loaded with `consult/1`: built-in libraries and published user programs
+are both consumed as Prolog sources.
 
-Prolog code does not access the node's real file system. It only sees the capabilities explicitly mounted by the
-host under a canonical namespace rooted at `/v1`.
+Users normally interact with the predicates provided by those libraries rather than with VFS paths directly. The
+consumer-facing VFS catalog is maintained in the predicate documentation.
 
-This makes the module easier to understand:
-
-- if a resource is visible through the VFS, Prolog can use it;
-- if it is not mounted in the VFS, it does not exist from the program's perspective.
-
-The namespace follows a stable layout:
-
-- `/v1/lib`: immutable host-provided Prolog libraries;
-- `/v1/run`: invocation-scoped runtime snapshots;
-- `/v1/var/lib`: persistent chain-backed data exposed as files;
-- `/v1/dev`: transactional device-like capabilities.
-
-In several mounts, the special path segment `@` denotes the canonical aggregate representation of a resource.
-
-## `/v1/lib`: Built-In Prolog Libraries
-
-The module ships with reusable Prolog libraries that can be loaded explicitly with `consult/1`.
-
-Available libraries include:
-
-- `/v1/lib/apply.pl`: higher-order helpers such as `maplist/2..7` and `foldl/4..7`;
-- `/v1/lib/bank.pl`: helpers for account balances;
-- `/v1/lib/bech32.pl`: Bech32 encode/decode helpers;
-- `/v1/lib/chain.pl`: helpers exposing header and Comet block information;
-- `/v1/lib/crypto.pl`: small crypto-adjacent helpers such as hexadecimal conversions;
-- `/v1/lib/dev.pl`: low-level helpers for transactional VFS devices;
-- `/v1/lib/error.pl`: error and type-checking helpers;
-- `/v1/lib/lists.pl`: list processing helpers;
-- `/v1/lib/type.pl`: type predicates used by the other libraries;
-- `/v1/lib/wasm.pl`: helpers for CosmWasm smart queries.
-
-Example:
-
-```prolog
-:- consult('/v1/lib/chain.pl').
-
-current_chain(ChainID) :-
-  header_info(Header),
-  ChainID = Header.chain_id.
-```
-
-These libraries are regular Prolog sources. They are not magical special forms: users load them explicitly and can
-combine them with their own predicates.
-
-## `/v1/run`: Runtime Snapshots
-
-`/v1/run` exposes information tied to the current query execution context.
-
-The standard mounts are:
-
-- `/v1/run/header`
-- `/v1/run/comet`
-
-Examples of readable paths include:
-
-- `/v1/run/header/@`
-- `/v1/run/header/height`
-- `/v1/run/header/hash`
-- `/v1/run/header/time`
-- `/v1/run/header/chain_id`
-- `/v1/run/header/app_hash`
-- `/v1/run/comet/@`
-- `/v1/run/comet/validators_hash`
-- `/v1/run/comet/proposer_address`
-- `/v1/run/comet/evidence`
-- `/v1/run/comet/last_commit`
-
-These files are read-only snapshots. They are intended for logical inspection, not mutation.
-
-Example:
-
-```prolog
-:- consult('/v1/lib/chain.pl').
-
-block_height(Height) :-
-  header_info(Header),
-  Height = Header.height.
-```
-
-## `/v1/var/lib`: Persistent Chain-Backed Data
-
-`/v1/var/lib` exposes data backed by blockchain state, still through file-like paths.
-
-The standard mounts currently include:
-
-- `/v1/var/lib/bank`
-- `/v1/var/lib/logic/users`
-
-### Bank Data
-
-Bank balances are exposed under paths such as:
-
-- `/v1/var/lib/bank/<address>/balances/@`
-- `/v1/var/lib/bank/<address>/spendable/@`
-- `/v1/var/lib/bank/<address>/locked/@`
-
-The `bank.pl` library wraps those paths into higher-level predicates:
-
-- `bank_balances/2`
-- `bank_spendable_balances/2`
-- `bank_locked_balances/2`
-
-Example:
-
-```prolog
-:- consult('/v1/lib/bank.pl').
-
-rich_account(Address) :-
-  bank_spendable_balances(Address, Balances),
-  member(uaxone-Amount, Balances),
-  Amount > 1000000.
-```
-
-### Published User Programs
+## Published User Programs
 
 User-published programs are exposed under:
 
@@ -269,57 +158,6 @@ A stored source can therefore be loaded like any other Prolog file:
 :- consult('/v1/var/lib/logic/users/axone1.../programs/<program_id>.pl').
 ```
 
-## `/v1/dev`: Transactional Devices
-
-`/v1/dev` exposes interactive capabilities through file-like request/response devices.
-
-This is where the Axone Prolog VM extension for `read_write` streams becomes important. In Axone, `open/4` can open a
-resource in `read_write` mode, which allows half-duplex transactional I/O:
-
-1. write a request;
-2. trigger the device on first read;
-3. read back the response.
-
-This pattern is used for deterministic host capabilities that are easier to model as devices than as plain predicates.
-
-Standard device mounts include:
-
-- `/v1/dev/codec/<codec>`
-- `/v1/dev/wasm/<contract_address>/query`
-
-In most cases, users should prefer the provided helper libraries rather than interact with devices directly.
-
-### Codec Devices
-
-Codec devices are mounted under `/v1/dev/codec`. For example, the Bech32 helper library delegates encoding and
-decoding to the `bech32` codec device.
-
-Users typically do not open those devices themselves. Instead they use predicates such as:
-
-- `bech32_address/2`
-- `hex_bytes/2`
-
-### WASM Query Devices
-
-CosmWasm smart queries are exposed through:
-
-```text
-/v1/dev/wasm/<contract_address>/query
-```
-
-The recommended user-facing helper is `wasm_query/3` from `/v1/lib/wasm.pl`.
-
-Example:
-
-```prolog
-:- consult('/v1/lib/wasm.pl').
-
-contract_query(Address, RequestBytes, ResponseBytes) :-
-  wasm_query(Address, RequestBytes, ResponseBytes).
-```
-
-The device is query-only. It lets users ask a contract for data, not execute transactions.
-
 ## `consult/1` and Reuse
 
 `consult/1` is the main mechanism for composing logic from multiple sources.
@@ -328,7 +166,10 @@ Users can consult:
 
 - built-in libraries from `/v1/lib`;
 - chain-backed published programs from `/v1/var/lib/logic/users/...`;
-- lists of files, just as in regular Prolog.
+- an explicit Prolog list of known source paths.
+
+The VFS cannot be enumerated from Prolog. To discover published programs, use the module query endpoints such as
+`Programs` and `ProgramsByPublisher`, then load the selected program path with `consult/1`.
 
 This is the idiomatic way to build reusable logic on top of the module. In other words, `StoreProgram` does not create
 a new query endpoint by itself; it publishes a source file that later queries can load with `consult/1`.
@@ -472,16 +313,14 @@ Use `StoreProgram` when:
 The `logic` module should be understood as a user-facing Prolog query engine for blockchain data, backed by:
 
 - a deterministic Axone Prolog VM;
-- a capability-oriented VFS;
+- a VFS-backed library loading model;
 - built-in Prolog libraries;
-- query-only devices for advanced integrations;
 - immutable, on-chain published user programs that can be reused as libraries.
 
 If you want to understand how to use the module, the central ideas are simple:
 
 - write Prolog;
 - load libraries with `consult/1`;
-- inspect chain capabilities through `/v1`;
 - publish reusable sources with `StoreProgram`;
 - execute logic with `Ask`.
 

--- a/proto/logic/docs.yaml
+++ b/proto/logic/docs.yaml
@@ -131,125 +131,14 @@ description: |
 
   ## Virtual File System (VFS)
 
-  A key concept of the module is the VFS exposed to the Prolog VM through `open/4` and `consult/1`.
+  The Prolog VM evaluates programs against a Virtual File System (VFS) exposed by the AXONE blockchain. For most users,
+  the important point is that reusable logic is loaded with `consult/1`: built-in libraries and published user programs
+  are both consumed as Prolog sources.
 
-  Prolog code does not access the node's real file system. It only sees the capabilities explicitly mounted by the
-  host under a canonical namespace rooted at `/v1`.
+  Users normally interact with the predicates provided by those libraries rather than with VFS paths directly. The
+  consumer-facing VFS catalog is maintained in the predicate documentation.
 
-  This makes the module easier to understand:
-
-  - if a resource is visible through the VFS, Prolog can use it;
-  - if it is not mounted in the VFS, it does not exist from the program's perspective.
-
-  The namespace follows a stable layout:
-
-  - `/v1/lib`: immutable host-provided Prolog libraries;
-  - `/v1/run`: invocation-scoped runtime snapshots;
-  - `/v1/var/lib`: persistent chain-backed data exposed as files;
-  - `/v1/dev`: transactional device-like capabilities.
-
-  In several mounts, the special path segment `@` denotes the canonical aggregate representation of a resource.
-
-  ## `/v1/lib`: Built-In Prolog Libraries
-
-  The module ships with reusable Prolog libraries that can be loaded explicitly with `consult/1`.
-
-  Available libraries include:
-
-  - `/v1/lib/apply.pl`: higher-order helpers such as `maplist/2..7` and `foldl/4..7`;
-  - `/v1/lib/bank.pl`: helpers for account balances;
-  - `/v1/lib/bech32.pl`: Bech32 encode/decode helpers;
-  - `/v1/lib/chain.pl`: helpers exposing header and Comet block information;
-  - `/v1/lib/crypto.pl`: small crypto-adjacent helpers such as hexadecimal conversions;
-  - `/v1/lib/dev.pl`: low-level helpers for transactional VFS devices;
-  - `/v1/lib/error.pl`: error and type-checking helpers;
-  - `/v1/lib/lists.pl`: list processing helpers;
-  - `/v1/lib/type.pl`: type predicates used by the other libraries;
-  - `/v1/lib/wasm.pl`: helpers for CosmWasm smart queries.
-
-  Example:
-
-  ```prolog
-  :- consult('/v1/lib/chain.pl').
-
-  current_chain(ChainID) :-
-    header_info(Header),
-    ChainID = Header.chain_id.
-  ```
-
-  These libraries are regular Prolog sources. They are not magical special forms: users load them explicitly and can
-  combine them with their own predicates.
-
-  ## `/v1/run`: Runtime Snapshots
-
-  `/v1/run` exposes information tied to the current query execution context.
-
-  The standard mounts are:
-
-  - `/v1/run/header`
-  - `/v1/run/comet`
-
-  Examples of readable paths include:
-
-  - `/v1/run/header/@`
-  - `/v1/run/header/height`
-  - `/v1/run/header/hash`
-  - `/v1/run/header/time`
-  - `/v1/run/header/chain_id`
-  - `/v1/run/header/app_hash`
-  - `/v1/run/comet/@`
-  - `/v1/run/comet/validators_hash`
-  - `/v1/run/comet/proposer_address`
-  - `/v1/run/comet/evidence`
-  - `/v1/run/comet/last_commit`
-
-  These files are read-only snapshots. They are intended for logical inspection, not mutation.
-
-  Example:
-
-  ```prolog
-  :- consult('/v1/lib/chain.pl').
-
-  block_height(Height) :-
-    header_info(Header),
-    Height = Header.height.
-  ```
-
-  ## `/v1/var/lib`: Persistent Chain-Backed Data
-
-  `/v1/var/lib` exposes data backed by blockchain state, still through file-like paths.
-
-  The standard mounts currently include:
-
-  - `/v1/var/lib/bank`
-  - `/v1/var/lib/logic/users`
-
-  ### Bank Data
-
-  Bank balances are exposed under paths such as:
-
-  - `/v1/var/lib/bank/<address>/balances/@`
-  - `/v1/var/lib/bank/<address>/spendable/@`
-  - `/v1/var/lib/bank/<address>/locked/@`
-
-  The `bank.pl` library wraps those paths into higher-level predicates:
-
-  - `bank_balances/2`
-  - `bank_spendable_balances/2`
-  - `bank_locked_balances/2`
-
-  Example:
-
-  ```prolog
-  :- consult('/v1/lib/bank.pl').
-
-  rich_account(Address) :-
-    bank_spendable_balances(Address, Balances),
-    member(uaxone-Amount, Balances),
-    Amount > 1000000.
-  ```
-
-  ### Published User Programs
+  ## Published User Programs
 
   User-published programs are exposed under:
 
@@ -265,57 +154,6 @@ description: |
   :- consult('/v1/var/lib/logic/users/axone1.../programs/<program_id>.pl').
   ```
 
-  ## `/v1/dev`: Transactional Devices
-
-  `/v1/dev` exposes interactive capabilities through file-like request/response devices.
-
-  This is where the Axone Prolog VM extension for `read_write` streams becomes important. In Axone, `open/4` can open a
-  resource in `read_write` mode, which allows half-duplex transactional I/O:
-
-  1. write a request;
-  2. trigger the device on first read;
-  3. read back the response.
-
-  This pattern is used for deterministic host capabilities that are easier to model as devices than as plain predicates.
-
-  Standard device mounts include:
-
-  - `/v1/dev/codec/<codec>`
-  - `/v1/dev/wasm/<contract_address>/query`
-
-  In most cases, users should prefer the provided helper libraries rather than interact with devices directly.
-
-  ### Codec Devices
-
-  Codec devices are mounted under `/v1/dev/codec`. For example, the Bech32 helper library delegates encoding and
-  decoding to the `bech32` codec device.
-
-  Users typically do not open those devices themselves. Instead they use predicates such as:
-
-  - `bech32_address/2`
-  - `hex_bytes/2`
-
-  ### WASM Query Devices
-
-  CosmWasm smart queries are exposed through:
-
-  ```text
-  /v1/dev/wasm/<contract_address>/query
-  ```
-
-  The recommended user-facing helper is `wasm_query/3` from `/v1/lib/wasm.pl`.
-
-  Example:
-
-  ```prolog
-  :- consult('/v1/lib/wasm.pl').
-
-  contract_query(Address, RequestBytes, ResponseBytes) :-
-    wasm_query(Address, RequestBytes, ResponseBytes).
-  ```
-
-  The device is query-only. It lets users ask a contract for data, not execute transactions.
-
   ## `consult/1` and Reuse
 
   `consult/1` is the main mechanism for composing logic from multiple sources.
@@ -324,7 +162,10 @@ description: |
 
   - built-in libraries from `/v1/lib`;
   - chain-backed published programs from `/v1/var/lib/logic/users/...`;
-  - lists of files, just as in regular Prolog.
+  - an explicit Prolog list of known source paths.
+
+  The VFS cannot be enumerated from Prolog. To discover published programs, use the module query endpoints such as
+  `Programs` and `ProgramsByPublisher`, then load the selected program path with `consult/1`.
 
   This is the idiomatic way to build reusable logic on top of the module. In other words, `StoreProgram` does not create
   a new query endpoint by itself; it publishes a source file that later queries can load with `consult/1`.
@@ -468,15 +309,13 @@ description: |
   The `logic` module should be understood as a user-facing Prolog query engine for blockchain data, backed by:
 
   - a deterministic Axone Prolog VM;
-  - a capability-oriented VFS;
+  - a VFS-backed library loading model;
   - built-in Prolog libraries;
-  - query-only devices for advanced integrations;
   - immutable, on-chain published user programs that can be reused as libraries.
 
   If you want to understand how to use the module, the central ideas are simple:
 
   - write Prolog;
   - load libraries with `consult/1`;
-  - inspect chain capabilities through `/v1`;
   - publish reusable sources with `StoreProgram`;
   - execute logic with `Ask`.

--- a/x/logic/lib/dev.pl
+++ b/x/logic/lib/dev.pl
@@ -6,6 +6,7 @@
 %! dev_call(+Path, +Type, :WriteGoal, :ReadGoal) is det.
 %
 % Executes a transactional device call following a half-duplex protocol.
+% See [VFS overview](../vfs) for the consumer-facing path catalog and device protocol.
 %
 % ## Overview
 %


### PR DESCRIPTION
Adds a dedicated predicate VFS overview that documents paths by capability and simplifies the logic proto overview so it focuses on module usage and published program reuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify how Prolog programs load and access reusable logic libraries.
  * Improved explanations of the Virtual File System and library discovery mechanisms.
  * Streamlined guidance on using built-in libraries and published programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->