### PR TITLE
build(nix): add project language servers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
         {
           default = pkgs.mkShell {
             packages = [
+              pkgs.bash-language-server
               pkgs.buf
               pkgs.git
               pkgs.gnumake
@@ -33,11 +34,16 @@
               pkgs.gofumpt
               pkgs.golangci-lint
               pkgs.gomplate
+              pkgs.gopls
               pkgs.jq
               pkgs.markdownlint-cli2
+              pkgs.marksman
+              pkgs.nil
               pkgs.protobuf
+              pkgs.protobuf-language-server
               pkgs.protoc-gen-go
               pkgs.protoc-gen-go-grpc
+              pkgs.yaml-language-server
             ];
 
             shellHook = ''


### PR DESCRIPTION
Makes [omp.sh](omp.sh) happier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language server support for Bash, Go, Markdown, Nix, Protobuf, and YAML in the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->