### PR TITLE
Refactor/logic text atoms

### DIFF
--- a/.agents/skills/axone-logic-predicate/SKILL.md
+++ b/.agents/skills/axone-logic-predicate/SKILL.md
@@ -51,6 +51,22 @@ For `/v1/dev/...` endpoints, keep the protocol aligned with the existing half-du
 
 ## Implementation patterns
 
+### Public textual representation
+
+Public domain predicates must use atoms as the canonical representation for
+textual inputs and outputs. Do not make a public predicate accept atoms,
+character lists, and character code lists through a broad `text` contract unless
+representation conversion is the predicate's explicit purpose.
+
+- Use `must_be(atom, Value)` at public predicate boundaries for textual values.
+- Return textual values as atoms.
+- Keep byte payloads as `list(byte)` when the API is explicitly byte-oriented.
+- Leave conversion predicates such as `atom_chars/2`, `atom_codes/2`,
+  `string_bytes/3`, and stream-reading helpers responsible for representation
+  conversion.
+- Require callers to perform explicit conversions before calling domain
+  predicates when they hold character lists or code lists.
+
 ### Pure Prolog predicate
 
 - Add or update a library file in `x/logic/lib/*.pl`

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - '.github/workflows/test-go.yml'
       - '**/*.go'
+      - 'x/logic/**/*.pl'
+      - 'x/logic/tests/predicate/features/**/*.feature'
       - 'go.mod'
       - 'go.sum'
       - 'Makefile'
@@ -15,6 +17,8 @@ on:
     paths:
       - '.github/workflows/test-go.yml'
       - '**/*.go'
+      - 'x/logic/**/*.pl'
+      - 'x/logic/tests/predicate/features/**/*.feature'
       - 'go.mod'
       - 'go.sum'
       - 'Makefile'

--- a/docs/predicate/base64/base64_encoded_3.md
+++ b/docs/predicate/base64/base64_encoded_3.md
@@ -19,7 +19,7 @@ Load this module before using the predicate:
 
 base64_encoded(-Plain, +Encoded, +Options) is det.
 
-Relates a text value to its Base64-encoded representation as specified by
+Relates an atom to its Base64-encoded atom representation as specified by
 [RFC 4648](https://rfc-editor.org/rfc/rfc4648.html).
 
 The predicate follows a functional direction:
@@ -28,14 +28,14 @@ The predicate follows a functional direction:
 - otherwise, when `Encoded` is instantiated, it decodes `Encoded` into `Plain`;
 - otherwise, it throws `instantiation_error`.
 
-`Plain` may be an atom, a list of characters, or a list of character codes.
-`Encoded` may be an atom, a list of characters, or a list of character codes.
+`Plain` and `Encoded` are atoms. Use explicit conversion predicates such as
+`atom_chars/2`, `atom_codes/2`, or `string_bytes/3` when another textual
+representation is needed.
 
 Supported options are:
 
 - `charset(+Charset)` where `Charset` is `classic` (default) or `url`;
 - `padding(+Boolean)` where `Boolean` is `true` (default) or `false`;
-- `as(+Type)` where `Type` is `string` (default) or `atom`;
 - `encoding(+Encoding)` to translate between text and bytes, defaulting to `utf8`.
 
 ## Signature
@@ -46,12 +46,12 @@ base64_encoded(+Plain, -Encoded, +Options) is det
 
 ## Examples
 
-### Encode a string into a Base64 encoded string (with default options)
+### Encode an atom into a Base64 encoded atom with default options
 
-This scenario demonstrates how to encode a plain string into its Base64 representation using the `base64_encoded/3`
+This scenario demonstrates how to encode a plain atom into its Base64 representation using the `base64_encoded/3`
 predicate. The default options are used, meaning:
 
-- The output is returned as a list of characters (`as(string)`).
+- The output is returned as an atom.
 - Padding characters (`=`) are included (`padding(true)`).
 - The classic Base64 character set is used (`charset(classic)`), not the URL-safe variant.
 
@@ -69,21 +69,19 @@ base64_encoded('Hello World', X, []).
 
 ```  yaml
 height: 42
-gas_used: 9993
+gas_used: 9406
 answer:
   has_more: false
   variables: ["X"]
   results:
   - substitutions:
     - variable: X
-      expression: "['S','G','V',s,b,'G','8',g,'V','2','9',y,b,'G','Q',=]"
+      expression: "'SGVsbG8gV29ybGQ='"
 ```
 
-### Encode a string into a Base64 encoded atom
+### Reject the removed output-shape option
 
-This scenario demonstrates how to encode a plain string into a Base64-encoded atom using the `base64_encoded/3`
-predicate. The `as(atom)` option is specified, so the result is returned as a Prolog atom instead of a character
-list. All other options use their default values.
+This scenario demonstrates that `base64_encoded/3` has a single textual output shape: atom.
 
 Here are the steps of the scenario:
 
@@ -99,22 +97,20 @@ base64_encoded('Hello World', X, [as(atom)]).
 
 ```  yaml
 height: 42
-gas_used: 10289
+gas_used: 4407
 answer:
   has_more: false
   variables: ["X"]
   results:
-  - substitutions:
-    - variable: X
-      expression: "'SGVsbG8gV29ybGQ='"
+  - error: "error(type_error(option,as(atom)),base64_encoded/3)"
+    substitutions:
 ```
 
 ### Encode a string into a Base64 encoded atom without padding
 
-This scenario demonstrates how to encode a plain string into a Base64-encoded atom using the `base64_encoded/3` predicate
+This scenario demonstrates how to encode a plain atom into a Base64-encoded atom using the `base64_encoded/3` predicate
 with custom options. The following options are used:
 
-- `as(atom)` – the result is returned as a Prolog atom.
 - `padding(false)` – padding characters (`=`) are omitted.
 - The classic Base64 character set is used by default (`charset(classic)`).
 
@@ -124,7 +120,7 @@ Here are the steps of the scenario:
 
 ```  prolog
 consult('/v1/lib/base64.pl'),
-base64_encoded('Hello World', X, [as(atom), padding(false)]).
+base64_encoded('Hello World', X, [padding(false)]).
 ```
 
 - **When** the query is run
@@ -132,7 +128,7 @@ base64_encoded('Hello World', X, [as(atom), padding(false)]).
 
 ```  yaml
 height: 42
-gas_used: 10894
+gas_used: 9982
 answer:
   has_more: false
   variables: ["X"]
@@ -142,12 +138,11 @@ answer:
       expression: "'SGVsbG8gV29ybGQ'"
 ```
 
-### Encode a String into a Base64 encoded atom in URL-Safe mode
+### Encode an atom into a Base64 encoded atom in URL-Safe mode
 
-This scenario demonstrates how to encode a plain string into a Base64-encoded atom using the `base64_encoded/3` predicate
+This scenario demonstrates how to encode a plain atom into a Base64-encoded atom using the `base64_encoded/3` predicate
 with URL-safe encoding. The following options are used:
 
-- `as(atom)` – the result is returned as a Prolog atom.
 - `charset(url)` – the URL-safe Base64 alphabet is used (e.g., `-` and `_` instead of `+` and `/`).
 - Padding characters are included by default (`padding(true)`).
 
@@ -157,8 +152,8 @@ Here are the steps of the scenario:
 
 ```  prolog
 consult('/v1/lib/base64.pl'),
-base64_encoded('<<???>>', Classic, [as(atom), charset(classic)]),
-base64_encoded('<<???>>', UrlSafe, [as(atom), charset(url)]).
+base64_encoded('<<???>>', Classic, [charset(classic)]),
+base64_encoded('<<???>>', UrlSafe, [charset(url)]).
 ```
 
 - **When** the query is run
@@ -166,7 +161,7 @@ base64_encoded('<<???>>', UrlSafe, [as(atom), charset(url)]).
 
 ```  yaml
 height: 42
-gas_used: 15075
+gas_used: 13251
 answer:
   has_more: false
   variables: ["Classic", "UrlSafe"]
@@ -178,11 +173,11 @@ answer:
       expression: "'PDw_Pz8-Pg=='"
 ```
 
-### Decode a Base64 encoded String into plain text
+### Decode a Base64 encoded atom into a plain atom
 
-This scenario demonstrates how to decode a Base64-encoded value back into plain text using the `base64_encoded/3` predicate.
-The encoded input can be provided as a character list or an atom. In this example, default options are used:
-•	The result (plain text) is returned as a character list (`as(string)`).
+This scenario demonstrates how to decode a Base64-encoded atom back into plain text using the `base64_encoded/3` predicate.
+In this example, default options are used:
+•	The result is returned as an atom.
 •	Padding characters in the input are allowed (`padding(true)`).
 •	The classic Base64 character set is used (`charset(classic)`).
 
@@ -200,22 +195,21 @@ base64_encoded(X, 'SGVsbG8gV29ybGQ=', []).
 
 ```  yaml
 height: 42
-gas_used: 12573
+gas_used: 11090
 answer:
   has_more: false
   variables: ["X"]
   results:
   - substitutions:
     - variable: X
-      expression: "['H',e,l,l,o,' ','W',o,r,l,d]"
+      expression: "'Hello World'"
 ```
 
-### Decode a Base64 Encoded string into a plain atom
+### Decode a Base64 encoded atom with explicit defaults
 
-This scenario demonstrates how to decode a Base64-encoded value back into plain text using the `base64_encoded/3` predicate,
-with the result returned as a Prolog atom. The following options are used:
+This scenario demonstrates how to decode a Base64-encoded value back into plain text using the `base64_encoded/3` predicate.
+The following options are used:
 
-- `as(atom)` – the decoded plain text is returned as an atom.
 - `padding(true)` – padding characters in the input are allowed (default).
 - `charset(classic)` – the classic Base64 character set is used (default).
 
@@ -225,7 +219,7 @@ Here are the steps of the scenario:
 
 ```  prolog
 consult('/v1/lib/base64.pl'),
-base64_encoded(X, 'SGVsbG8gV29ybGQ=', [as(atom)]).
+base64_encoded(X, 'SGVsbG8gV29ybGQ=', [padding(true), charset(classic)]).
 ```
 
 - **When** the query is run
@@ -233,7 +227,7 @@ base64_encoded(X, 'SGVsbG8gV29ybGQ=', [as(atom)]).
 
 ```  yaml
 height: 42
-gas_used: 13373
+gas_used: 12032
 answer:
   has_more: false
   variables: ["X"]
@@ -254,7 +248,7 @@ Here are the steps of the scenario:
 
 ```  prolog
 consult('/v1/lib/base64.pl'),
-base64_encoded('café', X, [as(atom), encoding('iso-8859-1')]).
+base64_encoded('café', X, [encoding('iso-8859-1')]).
 ```
 
 - **When** the query is run
@@ -262,7 +256,7 @@ base64_encoded('café', X, [as(atom), encoding('iso-8859-1')]).
 
 ```  yaml
 height: 42
-gas_used: 9195
+gas_used: 8279
 answer:
   has_more: false
   variables: ["X"]
@@ -291,7 +285,7 @@ base64_encoded('Hello World', X, [charset(bad)]).
 
 ```  yaml
 height: 42
-gas_used: 4445
+gas_used: 4439
 answer:
   has_more: false
   variables: ["X"]
@@ -319,7 +313,7 @@ base64_encoded('Hello World', X, [padding(bad)]).
 
 ```  yaml
 height: 42
-gas_used: 4776
+gas_used: 4770
 answer:
   has_more: false
   variables: ["X"]
@@ -328,10 +322,9 @@ answer:
     substitutions:
 ```
 
-### Error on incorrect as option
+### Error on removed as option
 
-This scenario demonstrates how the `base64_encoded/3` predicate behaves when an invalid value is provided for the
-`as` option.
+This scenario demonstrates how the `base64_encoded/3` predicate behaves when the removed `as` option is provided.
 
 Here are the steps of the scenario:
 
@@ -347,12 +340,12 @@ base64_encoded('Hello World', X, [as(bad)]).
 
 ```  yaml
 height: 42
-gas_used: 5207
+gas_used: 4406
 answer:
   has_more: false
   variables: ["X"]
   results:
-  - error: "error(domain_error(as,bad),base64_encoded/3)"
+  - error: "error(type_error(option,as(bad)),base64_encoded/3)"
     substitutions:
 ```
 
@@ -367,7 +360,7 @@ Here are the steps of the scenario:
 
 ```  prolog
 consult('/v1/lib/base64.pl'),
-base64_encoded(X, 'SGVsbG8gV29ybGQ=', [as(atom), encoding(unknown)]).
+base64_encoded(X, 'SGVsbG8gV29ybGQ=', [encoding(unknown)]).
 ```
 
 - **When** the query is run
@@ -375,7 +368,7 @@ base64_encoded(X, 'SGVsbG8gV29ybGQ=', [as(atom), encoding(unknown)]).
 
 ```  yaml
 height: 42
-gas_used: 14094
+gas_used: 11778
 answer:
   has_more: false
   variables: ["X"]
@@ -403,7 +396,7 @@ base64_encoded(X, 'SGVsbG8gV29ybGQ=', [encoding(bad, 'very bad')]).
 
 ```  yaml
 height: 42
-gas_used: 4447
+gas_used: 4439
 answer:
   has_more: false
   variables: ["X"]
@@ -431,7 +424,7 @@ base64_encoded('Hello World', X, [chatset(classic)]).
 
 ```  yaml
 height: 42
-gas_used: 4423
+gas_used: 4415
 answer:
   has_more: false
   variables: ["X"]

--- a/docs/predicate/base64/base64url_2.md
+++ b/docs/predicate/base64/base64url_2.md
@@ -19,10 +19,10 @@ Load this module before using the predicate:
 
 base64url(-Plain, +Encoded) is det.
 
-Relates a text value to its URL-safe Base64 representation.
+Relates an atom to its URL-safe Base64 atom representation.
 
 The predicate is equivalent to `base64_encoded/3` with options
-`[as(atom), encoding(utf8), charset(url), padding(false)]`.
+`[encoding(utf8), charset(url), padding(false)]`.
 
 ## Signature
 
@@ -32,9 +32,9 @@ base64url(+Plain, -Encoded) is det
 
 ## Examples
 
-### Encode and decode a string into a Base64 encoded atom in URL-Safe mode
+### Encode and decode an atom into a Base64 encoded atom in URL-Safe mode
 
-This scenario demonstrates how to encode an decode a plain string into a Base64-encoded atom using the `base64url/2`
+This scenario demonstrates how to encode and decode a plain atom into a Base64-encoded atom using the `base64url/2`
 predicate.
 
 Here are the steps of the scenario:
@@ -52,7 +52,7 @@ base64url(Decoded, 'PDw_Pz8-Pg').
 
 ```  yaml
 height: 42
-gas_used: 18554
+gas_used: 15694
 answer:
   has_more: false
   variables: ["Encoded", "Decoded"]

--- a/docs/predicate/crypto/crypto_data_hash_3.md
+++ b/docs/predicate/crypto/crypto_data_hash_3.md
@@ -54,7 +54,7 @@ hex_bytes(Hex, Hash).
 
 ```  yaml
 height: 42
-gas_used: 65436
+gas_used: 65533
 answer:
   has_more: false
   variables: ["Hash", "Hex"]

--- a/docs/predicate/crypto/ecdsa_verify_4.md
+++ b/docs/predicate/crypto/ecdsa_verify_4.md
@@ -27,7 +27,9 @@ Options may be a single option term or a list of option terms:
 - `type(+Algorithm)` selects `secp256r1` (default) or `secp256k1`;
 - `encoding(+Encoding)` selects how Data is interpreted, defaulting to `hex`.
 
-Supported encodings are `hex`, `octet`, `utf8`, and `text`.
+Supported encodings are `hex`, `octet`, `utf8`, and `text`. Textual data
+(`hex`, `utf8`, and `text`) is represented as an atom; `octet` data is
+represented as a list of bytes.
 
 ## Signature
 
@@ -65,7 +67,7 @@ valid_secp256r1(Verified).
 
 ```  yaml
 height: 42
-gas_used: 246079
+gas_used: 245814
 answer:
   has_more: false
   variables: ["Verified"]
@@ -103,7 +105,7 @@ valid_secp256k1(Verified).
 
 ```  yaml
 height: 42
-gas_used: 250523
+gas_used: 250258
 answer:
   has_more: false
   variables: ["Verified"]
@@ -147,7 +149,7 @@ Verified = true.
 
 ```  yaml
 height: 42
-gas_used: 493294
+gas_used: 492764
 answer:
   has_more: false
   variables: ["Verified"]
@@ -184,7 +186,7 @@ invalid_secp256r1.
 
 ```  yaml
 height: 42
-gas_used: 246047
+gas_used: 245782
 answer:
   has_more: false
   variables:

--- a/docs/predicate/crypto/eddsa_verify_4.md
+++ b/docs/predicate/crypto/eddsa_verify_4.md
@@ -26,7 +26,9 @@ Options may be a single option term or a list of option terms:
 - `type(+Algorithm)` selects `ed25519` (default);
 - `encoding(+Encoding)` selects how Data is interpreted, defaulting to `hex`.
 
-Supported encodings are `hex`, `octet`, `utf8`, and `text`.
+Supported encodings are `hex`, `octet`, `utf8`, and `text`. Textual data
+(`hex`, `utf8`, and `text`) is represented as an atom; `octet` data is
+represented as a list of bytes.
 
 ## Signature
 
@@ -64,7 +66,7 @@ valid_ed25519(Verified).
 
 ```  yaml
 height: 42
-gas_used: 235381
+gas_used: 235116
 answer:
   has_more: false
   variables: ["Verified"]
@@ -101,7 +103,7 @@ invalid_ed25519.
 
 ```  yaml
 height: 42
-gas_used: 235349
+gas_used: 235084
 answer:
   has_more: false
   variables:

--- a/docs/predicate/crypto/hex_bytes_2.md
+++ b/docs/predicate/crypto/hex_bytes_2.md
@@ -17,9 +17,9 @@ Load this module before using the predicate:
 
 ## Description
 
-Relates a hexadecimal text representation to a list of bytes.
+Relates a hexadecimal atom representation to a list of bytes.
 
-- Hex may be an atom, a list of characters, or a list of character codes.
+- Hex is an atom.
 - Bytes is a proper list of integers in [0,255].
 - At least one argument must be instantiated.
 - When converting Bytes to Hex, Hex is returned as a lowercase atom.
@@ -50,7 +50,7 @@ hex_bytes('501ACE', Bytes).
 
 ```  yaml
 height: 42
-gas_used: 5016
+gas_used: 4929
 answer:
   has_more: false
   variables: ["Bytes"]

--- a/docs/predicate/json/json_prolog_2.md
+++ b/docs/predicate/json/json_prolog_2.md
@@ -17,9 +17,11 @@ Load this module before using the predicate:
 
 ## Description
 
-Relates JSON text with its canonical Prolog representation.
+Relates JSON text atoms with their canonical Prolog representation.
 
-Json is text: an atom, a list of characters, or a list of character codes.
+Json is an atom. Use explicit conversion predicates such as `atom_chars/2`,
+`atom_codes/2`, or `string_bytes/3` when another textual representation is
+needed.
 
 The canonical representation for Term is:
 
@@ -55,7 +57,7 @@ json_prolog('{"foo":"bar","ok":true}', Term).
 
 ```  yaml
 height: 42
-gas_used: 12069
+gas_used: 12208
 answer:
   has_more: false
   variables: ["Term"]
@@ -83,7 +85,7 @@ json_prolog(Json, json([foo=bar,ok= @(true)])).
 
 ```  yaml
 height: 42
-gas_used: 11049
+gas_used: 11061
 answer:
   has_more: false
   variables: ["Json"]

--- a/docs/predicate/stdlib/consult_1.md
+++ b/docs/predicate/stdlib/consult_1.md
@@ -78,7 +78,7 @@ current_predicate(header_info/1).
 
 ```  yaml
 height: 42
-gas_used: 5028
+gas_used: 5020
 answer:
   has_more: false
   variables:

--- a/docs/predicate/uri/uri_encoded_3.md
+++ b/docs/predicate/uri/uri_encoded_3.md
@@ -24,8 +24,9 @@ Encoded is the URI encoding for Value.
 Component specifies the URI component where the value is used. It is one of
 `query_value`, `fragment`, `path` or `segment`.
 
-Value and Encoded may be atoms, lists of characters, or lists of character
-codes. Generated values are returned as atoms.
+Value and Encoded are atoms. Use explicit conversion predicates such as
+`atom_chars/2`, `atom_codes/2`, or `string_bytes/3` when another textual
+representation is needed.
 
 ## Signature
 
@@ -53,7 +54,7 @@ uri_encoded(path, Decoded, foo).
 
 ```  yaml
 height: 42
-gas_used: 6255
+gas_used: 6235
 answer:
   has_more: false
   variables: ["Decoded"]
@@ -81,7 +82,7 @@ uri_encoded(query_value, 'foo bar', Encoded).
 
 ```  yaml
 height: 42
-gas_used: 6357
+gas_used: 6337
 answer:
   has_more: false
   variables: ["Encoded"]

--- a/x/logic/lib/base64.pl
+++ b/x/logic/lib/base64.pl
@@ -6,7 +6,7 @@
 %! base64_encoded(+Plain, -Encoded, +Options) is det.
 %! base64_encoded(-Plain, +Encoded, +Options) is det.
 %
-% Relates a text value to its Base64-encoded representation as specified by
+% Relates an atom to its Base64-encoded atom representation as specified by
 % [RFC 4648](https://rfc-editor.org/rfc/rfc4648.html).
 %
 % The predicate follows a functional direction:
@@ -14,24 +14,26 @@
 % - otherwise, when `Encoded` is instantiated, it decodes `Encoded` into `Plain`;
 % - otherwise, it throws `instantiation_error`.
 %
-% `Plain` may be an atom, a list of characters, or a list of character codes.
-% `Encoded` may be an atom, a list of characters, or a list of character codes.
+% `Plain` and `Encoded` are atoms. Use explicit conversion predicates such as
+% `atom_chars/2`, `atom_codes/2`, or `string_bytes/3` when another textual
+% representation is needed.
 %
 % Supported options are:
 % - `charset(+Charset)` where `Charset` is `classic` (default) or `url`;
 % - `padding(+Boolean)` where `Boolean` is `true` (default) or `false`;
-% - `as(+Type)` where `Type` is `string` (default) or `atom`;
 % - `encoding(+Encoding)` to translate between text and bytes, defaulting to `utf8`.
 base64_encoded(Plain, Encoded, Options) :-
-  with_context(base64_encoded/3, base64_options(Options, Charset, Padding, As, Encoding)),
+  with_context(base64_encoded/3, base64_options(Options, Charset, Padding, Encoding)),
   ( nonvar(Plain)
-  -> with_context(base64_encoded/3, string_bytes(Plain, PlainBytes, Encoding)),
+  -> with_context(base64_encoded/3, must_be(atom, Plain)),
+     with_context(base64_encoded/3, string_bytes(Plain, PlainBytes, Encoding)),
      phrase(base64_bytes(Padding, PlainBytes, Charset), EncodedCodes),
-     base64_encoded_output(As, Encoded, EncodedCodes)
+     atom_codes(Encoded, EncodedCodes)
   ; nonvar(Encoded)
-  -> with_context(base64_encoded/3, string_bytes(Encoded, EncodedCodes, text)),
+  -> with_context(base64_encoded/3, must_be(atom, Encoded)),
+     atom_codes(Encoded, EncodedCodes),
      ( phrase(base64_bytes(Padding, PlainBytes, Charset), EncodedCodes)
-     -> base64_decoded_output(As, Plain, PlainBytes, Encoding)
+     -> base64_decoded_atom(Plain, PlainBytes, Encoding)
      ;  throw(error(domain_error(encoding(base64), Encoded), base64_encoded/3))
      )
   ; throw(error(instantiation_error, base64_encoded/3))
@@ -41,22 +43,19 @@ base64_encoded(Plain, Encoded, Options) :-
 %! base64url(+Plain, -Encoded) is det.
 %! base64url(-Plain, +Encoded) is det.
 %
-% Relates a text value to its URL-safe Base64 representation.
+% Relates an atom to its URL-safe Base64 atom representation.
 %
 % The predicate is equivalent to `base64_encoded/3` with options
-% `[as(atom), encoding(utf8), charset(url), padding(false)]`.
+% `[encoding(utf8), charset(url), padding(false)]`.
 base64url(Plain, Encoded) :-
-  base64_encoded(Plain, Encoded, [as(atom), encoding(utf8), charset(url), padding(false)]).
+  base64_encoded(Plain, Encoded, [encoding(utf8), charset(url), padding(false)]).
 
-base64_options(Options, Charset, Padding, As, Encoding) :-
+base64_options(Options, Charset, Padding, Encoding) :-
   base64_option(charset, Options, classic, Charset),
   must_be(atom, Charset),
   base64_charset(Charset),
   base64_option(padding, Options, true, Padding),
   base64_padding(Padding),
-  base64_option(as, Options, string, As),
-  must_be(atom, As),
-  base64_output_type(As),
   base64_option(encoding, Options, utf8, Encoding),
   must_be(atom, Encoding).
 
@@ -92,7 +91,6 @@ base64_option_match(Name, Option, Value) :-
 
 base64_option_known(charset(_)).
 base64_option_known(padding(_)).
-base64_option_known(as(_)).
 base64_option_known(encoding(_)).
 
 base64_charset(classic).
@@ -105,26 +103,9 @@ base64_padding(false).
 base64_padding(Padding) :-
   throw(error(domain_error(padding, Padding), base64_encoded/3)).
 
-base64_output_type(string).
-base64_output_type(atom).
-base64_output_type(As) :-
-  throw(error(domain_error(as, As), base64_encoded/3)).
-
-base64_encoded_output(atom, Encoded, Codes) :-
-  atom_codes(Encoded, Codes).
-base64_encoded_output(string, Encoded, Codes) :-
-  base64_codes_chars(Codes, Encoded).
-
-base64_decoded_output(atom, Plain, Bytes, Encoding) :-
+base64_decoded_atom(Plain, Bytes, Encoding) :-
   with_context(base64_encoded/3, string_bytes(Chars, Bytes, Encoding)),
   atom_chars(Plain, Chars).
-base64_decoded_output(string, Plain, Bytes, Encoding) :-
-  with_context(base64_encoded/3, string_bytes(Plain, Bytes, Encoding)).
-
-base64_codes_chars([], []).
-base64_codes_chars([Code | Rest], [Char | Chars]) :-
-  char_code(Char, Code),
-  base64_codes_chars(Rest, Chars).
 
 base64_bytes(Padding, Input, Charset) -->
   { nonvar(Input) },

--- a/x/logic/lib/crypto.pl
+++ b/x/logic/lib/crypto.pl
@@ -85,9 +85,11 @@ crypto_hash_data_bytes(octet, Data, Bytes) :-
   Bytes = Data.
 crypto_hash_data_bytes(utf8, Data, Bytes) :-
   !,
+  must_be(atom, Data),
   string_bytes(Data, Bytes, utf8).
 crypto_hash_data_bytes(text, Data, Bytes) :-
   !,
+  must_be(atom, Data),
   string_bytes(Data, Bytes, text).
 crypto_hash_data_bytes(Encoding, _, _) :-
   ( atom(Encoding)
@@ -115,7 +117,9 @@ crypto_hash_dev_call(Path, DataBytes, HashBytes) :-
 % - `type(+Algorithm)` selects `ed25519` (default);
 % - `encoding(+Encoding)` selects how Data is interpreted, defaulting to `hex`.
 %
-% Supported encodings are `hex`, `octet`, `utf8`, and `text`.
+% Supported encodings are `hex`, `octet`, `utf8`, and `text`. Textual data
+% (`hex`, `utf8`, and `text`) is represented as an atom; `octet` data is
+% represented as a list of bytes.
 eddsa_verify(PubKey, Data, Signature, Options) :-
   crypto_verify(
     eddsa_verify/4,
@@ -138,7 +142,9 @@ eddsa_verify(PubKey, Data, Signature, Options) :-
 % - `type(+Algorithm)` selects `secp256r1` (default) or `secp256k1`;
 % - `encoding(+Encoding)` selects how Data is interpreted, defaulting to `hex`.
 %
-% Supported encodings are `hex`, `octet`, `utf8`, and `text`.
+% Supported encodings are `hex`, `octet`, `utf8`, and `text`. Textual data
+% (`hex`, `utf8`, and `text`) is represented as an atom; `octet` data is
+% represented as a list of bytes.
 ecdsa_verify(PubKey, Data, Signature, Options) :-
   crypto_verify(
     ecdsa_verify/4,
@@ -227,9 +233,11 @@ crypto_verify_data_bytes(Context, octet, Data, Bytes) :-
   Bytes = Data.
 crypto_verify_data_bytes(Context, utf8, Data, Bytes) :-
   !,
+  with_context(Context, must_be(atom, Data)),
   with_context(Context, string_bytes(Data, Bytes, utf8)).
 crypto_verify_data_bytes(Context, text, Data, Bytes) :-
   !,
+  with_context(Context, must_be(atom, Data)),
   with_context(Context, string_bytes(Data, Bytes, text)).
 crypto_verify_data_bytes(Context, Encoding, _, _) :-
   ( atom(Encoding)
@@ -303,16 +311,16 @@ crypto_verify_response(Context, _) :-
 
 %! hex_bytes(?Hex, ?Bytes) is det.
 %
-% Relates a hexadecimal text representation to a list of bytes.
+% Relates a hexadecimal atom representation to a list of bytes.
 %
-% - Hex may be an atom, a list of characters, or a list of character codes.
+% - Hex is an atom.
 % - Bytes is a proper list of integers in [0,255].
 % - At least one argument must be instantiated.
 % - When converting Bytes to Hex, Hex is returned as a lowercase atom.
 hex_bytes(Hex, Bytes) :-
   ( nonvar(Hex)
-  -> with_context(hex_bytes/2, must_be(text, Hex)),
-     hex_text_chars(Hex, Chars),
+  -> with_context(hex_bytes/2, must_be(atom, Hex)),
+     atom_chars(Hex, Chars),
      hex_chars_bytes(Chars, Hex, DecodedBytes),
      ( nonvar(Bytes)
      -> with_context(hex_bytes/2, must_be(list(byte), Bytes)),
@@ -326,19 +334,6 @@ hex_bytes(Hex, Bytes) :-
      Hex = HexAtom
   ; throw(error(instantiation_error, hex_bytes/2))
   ).
-
-hex_text_chars(Hex, Chars) :-
-  ( atom(Hex)
-  -> atom_chars(Hex, Chars)
-  ; has_type(chars, Hex)
-  -> Chars = Hex
-  ; hex_codes_chars(Hex, Chars)
-  ).
-
-hex_codes_chars([], []).
-hex_codes_chars([Code | Rest], [Char | Chars]) :-
-  char_code(Char, Code),
-  hex_codes_chars(Rest, Chars).
 
 hex_chars_bytes([], _, []).
 hex_chars_bytes([_], Hex, _) :-

--- a/x/logic/lib/json.pl
+++ b/x/logic/lib/json.pl
@@ -6,9 +6,11 @@
 
 %! json_prolog(?Json, ?Term) is det.
 %
-% Relates JSON text with its canonical Prolog representation.
+% Relates JSON text atoms with their canonical Prolog representation.
 %
-% Json is text: an atom, a list of characters, or a list of character codes.
+% Json is an atom. Use explicit conversion predicates such as `atom_chars/2`,
+% `atom_codes/2`, or `string_bytes/3` when another textual representation is
+% needed.
 %
 % The canonical representation for Term is:
 % - JSON objects are represented as `json(NameValueList)`;
@@ -18,7 +20,8 @@
 % - JSON booleans and null are represented as `@(true)`, `@(false)`, and `@(null)`.
 json_prolog(Json, Term) :-
   ( nonvar(Json)
-  -> with_context(json_prolog/2, string_bytes(Json, JsonBytes, text)),
+  -> with_context(json_prolog/2, must_be(atom, Json)),
+     with_context(json_prolog/2, string_bytes(Json, JsonBytes, text)),
      json_decode_bytes(json_prolog/2, JsonBytes, Term)
   ; nonvar(Term)
   -> json_encode_term(json_prolog/2, Term, Json)

--- a/x/logic/lib/uri.pl
+++ b/x/logic/lib/uri.pl
@@ -11,8 +11,9 @@
 % Component specifies the URI component where the value is used. It is one of
 % `query_value`, `fragment`, `path` or `segment`.
 %
-% Value and Encoded may be atoms, lists of characters, or lists of character
-% codes. Generated values are returned as atoms.
+% Value and Encoded are atoms. Use explicit conversion predicates such as
+% `atom_chars/2`, `atom_codes/2`, or `string_bytes/3` when another textual
+% representation is needed.
 uri_encoded(Component, Value, Encoded) :-
   uri_component(Component, URIComponent),
   ( nonvar(Value)
@@ -42,14 +43,14 @@ uri_component(Component, _) :-
   throw(error(type_error(uri_component, Component), uri_encoded/3)).
 
 uri_encode(Component, Value, Encoded) :-
-  with_context(uri_encoded/3, must_be(text, Value)),
+  with_context(uri_encoded/3, must_be(atom, Value)),
   with_context(uri_encoded/3, string_bytes(Value, ValueBytes, text)),
   uri_escape_bytes(Component, ValueBytes, EncodedBytes),
   atom_codes(EncodedAtom, EncodedBytes),
   Encoded = EncodedAtom.
 
 uri_decode(Value, Encoded) :-
-  with_context(uri_encoded/3, must_be(text, Encoded)),
+  with_context(uri_encoded/3, must_be(atom, Encoded)),
   with_context(uri_encoded/3, string_bytes(Encoded, EncodedBytes, text)),
   uri_unescape_bytes(Encoded, EncodedBytes, DecodedBytes),
   with_context(uri_encoded/3, string_bytes(DecodedChars, DecodedBytes, text)),

--- a/x/logic/tests/predicate/features/base64_encoded_3.feature
+++ b/x/logic/tests/predicate/features/base64_encoded_3.feature
@@ -2,10 +2,10 @@ Feature: base64_encoded/3
   This feature is to test the base64_encoded/3 predicate.
 
   @great_for_documentation
-  Scenario: Encode a string into a Base64 encoded string (with default options)
-  This scenario demonstrates how to encode a plain string into its Base64 representation using the `base64_encoded/3`
+  Scenario: Encode an atom into a Base64 encoded atom with default options
+  This scenario demonstrates how to encode a plain atom into its Base64 representation using the `base64_encoded/3`
   predicate. The default options are used, meaning:
-  - The output is returned as a list of characters (`as(string)`).
+  - The output is returned as an atom.
   - Padding characters (`=`) are included (`padding(true)`).
   - The classic Base64 character set is used (`charset(classic)`), not the URL-safe variant.
 
@@ -18,32 +18,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 9993
-      answer:
-        has_more: false
-        variables: ["X"]
-        results:
-        - substitutions:
-          - variable: X
-            expression: "['S','G','V',s,b,'G','8',g,'V','2','9',y,b,'G','Q',=]"
-      """
-
-  @great_for_documentation
-  Scenario: Encode a string into a Base64 encoded atom
-    This scenario demonstrates how to encode a plain string into a Base64-encoded atom using the `base64_encoded/3`
-    predicate. The `as(atom)` option is specified, so the result is returned as a Prolog atom instead of a character
-    list. All other options use their default values.
-
-    Given the query:
-      """ prolog
-      consult('/v1/lib/base64.pl'),
-      base64_encoded('Hello World', X, [as(atom)]).
-      """
-    When the query is run
-    Then the answer we get is:
-      """ yaml
-      height: 42
-      gas_used: 10289
+      gas_used: 9406
       answer:
         has_more: false
         variables: ["X"]
@@ -54,23 +29,44 @@ Feature: base64_encoded/3
       """
 
   @great_for_documentation
+  Scenario: Reject the removed output-shape option
+    This scenario demonstrates that `base64_encoded/3` has a single textual output shape: atom.
+
+    Given the query:
+      """ prolog
+      consult('/v1/lib/base64.pl'),
+      base64_encoded('Hello World', X, [as(atom)]).
+      """
+    When the query is run
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 4407
+      answer:
+        has_more: false
+        variables: ["X"]
+        results:
+        - error: "error(type_error(option,as(atom)),base64_encoded/3)"
+          substitutions:
+      """
+
+  @great_for_documentation
   Scenario: Encode a string into a Base64 encoded atom without padding
-  This scenario demonstrates how to encode a plain string into a Base64-encoded atom using the `base64_encoded/3` predicate
+  This scenario demonstrates how to encode a plain atom into a Base64-encoded atom using the `base64_encoded/3` predicate
   with custom options. The following options are used:
-  - `as(atom)` – the result is returned as a Prolog atom.
   - `padding(false)` – padding characters (`=`) are omitted.
   - The classic Base64 character set is used by default (`charset(classic)`).
 
     Given the query:
       """ prolog
       consult('/v1/lib/base64.pl'),
-      base64_encoded('Hello World', X, [as(atom), padding(false)]).
+      base64_encoded('Hello World', X, [padding(false)]).
       """
     When the query is run
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 10894
+      gas_used: 9982
       answer:
         has_more: false
         variables: ["X"]
@@ -81,24 +77,23 @@ Feature: base64_encoded/3
       """
 
   @great_for_documentation
-  Scenario: Encode a String into a Base64 encoded atom in URL-Safe mode
-  This scenario demonstrates how to encode a plain string into a Base64-encoded atom using the `base64_encoded/3` predicate
+  Scenario: Encode an atom into a Base64 encoded atom in URL-Safe mode
+  This scenario demonstrates how to encode a plain atom into a Base64-encoded atom using the `base64_encoded/3` predicate
   with URL-safe encoding. The following options are used:
-  - `as(atom)` – the result is returned as a Prolog atom.
   - `charset(url)` – the URL-safe Base64 alphabet is used (e.g., `-` and `_` instead of `+` and `/`).
   - Padding characters are included by default (`padding(true)`).
 
     Given the query:
       """ prolog
       consult('/v1/lib/base64.pl'),
-      base64_encoded('<<???>>', Classic, [as(atom), charset(classic)]),
-      base64_encoded('<<???>>', UrlSafe, [as(atom), charset(url)]).
+      base64_encoded('<<???>>', Classic, [charset(classic)]),
+      base64_encoded('<<???>>', UrlSafe, [charset(url)]).
       """
     When the query is run
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 15075
+      gas_used: 13251
       answer:
         has_more: false
         variables: ["Classic", "UrlSafe"]
@@ -111,10 +106,10 @@ Feature: base64_encoded/3
       """
 
   @great_for_documentation
-  Scenario: Decode a Base64 encoded String into plain text
-  This scenario demonstrates how to decode a Base64-encoded value back into plain text using the `base64_encoded/3` predicate.
-  The encoded input can be provided as a character list or an atom. In this example, default options are used:
-  •	The result (plain text) is returned as a character list (`as(string)`).
+  Scenario: Decode a Base64 encoded atom into a plain atom
+  This scenario demonstrates how to decode a Base64-encoded atom back into plain text using the `base64_encoded/3` predicate.
+  In this example, default options are used:
+  •	The result is returned as an atom.
   •	Padding characters in the input are allowed (`padding(true)`).
   •	The classic Base64 character set is used (`charset(classic)`).
 
@@ -127,34 +122,33 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 12573
+      gas_used: 11090
       answer:
         has_more: false
         variables: ["X"]
         results:
         - substitutions:
           - variable: X
-            expression: "['H',e,l,l,o,' ','W',o,r,l,d]"
+            expression: "'Hello World'"
       """
 
   @great_for_documentation
-  Scenario: Decode a Base64 Encoded string into a plain atom
-  This scenario demonstrates how to decode a Base64-encoded value back into plain text using the `base64_encoded/3` predicate,
-  with the result returned as a Prolog atom. The following options are used:
-  - `as(atom)` – the decoded plain text is returned as an atom.
+  Scenario: Decode a Base64 encoded atom with explicit defaults
+  This scenario demonstrates how to decode a Base64-encoded value back into plain text using the `base64_encoded/3` predicate.
+  The following options are used:
   - `padding(true)` – padding characters in the input are allowed (default).
   - `charset(classic)` – the classic Base64 character set is used (default).
 
     Given the query:
       """ prolog
       consult('/v1/lib/base64.pl'),
-      base64_encoded(X, 'SGVsbG8gV29ybGQ=', [as(atom)]).
+      base64_encoded(X, 'SGVsbG8gV29ybGQ=', [padding(true), charset(classic)]).
       """
     When the query is run
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 13373
+      gas_used: 12032
       answer:
         has_more: false
         variables: ["X"]
@@ -172,13 +166,13 @@ Feature: base64_encoded/3
     Given the query:
       """ prolog
       consult('/v1/lib/base64.pl'),
-      base64_encoded('café', X, [as(atom), encoding('iso-8859-1')]).
+      base64_encoded('café', X, [encoding('iso-8859-1')]).
       """
     When the query is run
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 9195
+      gas_used: 8279
       answer:
         has_more: false
         variables: ["X"]
@@ -188,26 +182,25 @@ Feature: base64_encoded/3
             expression: "'Y2Fm6Q=='"
       """
 
-  Scenario: Encode a list of character codes
-  This scenario demonstrates that `base64_encoded/3` accepts a list of character codes as plain text input.
+  Scenario: Reject a list of character codes
+  This scenario demonstrates that callers must explicitly convert character codes to an atom before calling `base64_encoded/3`.
 
     Given the query:
       """ prolog
       consult('/v1/lib/base64.pl'),
-      base64_encoded([72,105], X, [as(atom)]).
+      base64_encoded([72,105], X, []).
       """
     When the query is run
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 7055
+      gas_used: 5203
       answer:
         has_more: false
         variables: ["X"]
         results:
-        - substitutions:
-          - variable: X
-            expression: "'SGk='"
+        - error: "error(type_error(atom,[72,105]),base64_encoded/3)"
+          substitutions:
       """
 
   Scenario: Decode a Base64 encoded atom without padding
@@ -216,13 +209,13 @@ Feature: base64_encoded/3
     Given the query:
       """ prolog
       consult('/v1/lib/base64.pl'),
-      base64_encoded(X, 'SGVsbG8', [as(atom), padding(false)]).
+      base64_encoded(X, 'SGVsbG8', [padding(false)]).
       """
     When the query is run
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 10761
+      gas_used: 9115
       answer:
         has_more: false
         variables: ["X"]
@@ -244,7 +237,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 5099
+      gas_used: 4903
       answer:
         has_more: false
         variables: ["X", "Y"]
@@ -267,7 +260,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4445
+      gas_used: 4439
       answer:
         has_more: false
         variables: ["X"]
@@ -289,7 +282,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4653
+      gas_used: 4647
       answer:
         has_more: false
         variables: ["X"]
@@ -312,7 +305,7 @@ Feature: base64_encoded/3
       Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 4776
+        gas_used: 4770
         answer:
           has_more: false
           variables: ["X"]
@@ -334,7 +327,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 4441
+        gas_used: 4433
         answer:
           has_more: false
           variables: ["X"]
@@ -344,9 +337,8 @@ Feature: base64_encoded/3
         """
 
   @great_for_documentation
-  Scenario: Error on incorrect as option
-  This scenario demonstrates how the `base64_encoded/3` predicate behaves when an invalid value is provided for the
-  `as` option.
+  Scenario: Error on removed as option
+  This scenario demonstrates how the `base64_encoded/3` predicate behaves when the removed `as` option is provided.
 
     Given the query:
         """ prolog
@@ -357,12 +349,12 @@ Feature: base64_encoded/3
     Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 5207
+        gas_used: 4406
         answer:
           has_more: false
           variables: ["X"]
           results:
-          - error: "error(domain_error(as,bad),base64_encoded/3)"
+          - error: "error(type_error(option,as(bad)),base64_encoded/3)"
             substitutions:
         """
 
@@ -379,7 +371,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 4436
+        gas_used: 4428
         answer:
           has_more: false
           variables: ["X"]
@@ -400,12 +392,12 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 5359
+      gas_used: 5195
       answer:
         has_more: false
         variables: ["X"]
         results:
-        - error: "error(type_error(text,wrong(input)),base64_encoded/3)"
+        - error: "error(type_error(atom,wrong(input)),base64_encoded/3)"
           substitutions:
       """
 
@@ -415,13 +407,13 @@ Feature: base64_encoded/3
     Given the query:
       """ prolog
       consult('/v1/lib/base64.pl'),
-      base64_encoded(X, '!!!!', [as(atom)]).
+      base64_encoded(X, '!!!!', []).
       """
     When the query is run
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 7221
+      gas_used: 5805
       answer:
         has_more: false
         variables: ["X"]
@@ -436,13 +428,13 @@ Feature: base64_encoded/3
     Given the query:
       """ prolog
       consult('/v1/lib/base64.pl'),
-      base64_encoded(X, 'QR', [as(atom), padding(false)]).
+      base64_encoded(X, 'QR', [padding(false)]).
       """
     When the query is run
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 7654
+      gas_used: 6329
       answer:
         has_more: false
         variables: ["X"]
@@ -457,13 +449,13 @@ Feature: base64_encoded/3
     Given the query:
       """ prolog
       consult('/v1/lib/base64.pl'),
-      base64_encoded(X, 'SGl', [as(atom), padding(false)]).
+      base64_encoded(X, 'SGl', [padding(false)]).
       """
     When the query is run
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 8278
+      gas_used: 6890
       answer:
         has_more: false
         variables: ["X"]
@@ -478,13 +470,13 @@ Feature: base64_encoded/3
     Given the query:
       """ prolog
       consult('/v1/lib/base64.pl'),
-      base64_encoded(X, 'QQ==QQ==', [as(atom)]).
+      base64_encoded(X, 'QQ==QQ==', []).
       """
     When the query is run
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 8720
+      gas_used: 7028
       answer:
         has_more: false
         variables: ["X"]
@@ -505,12 +497,12 @@ Feature: base64_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 5471
+      gas_used: 5331
       answer:
         has_more: false
         variables: ["X"]
         results:
-        - error: "error(type_error(text,wrong(input)),base64_encoded/3)"
+        - error: "error(type_error(atom,wrong(input)),base64_encoded/3)"
           substitutions:
       """
 
@@ -522,13 +514,13 @@ Feature: base64_encoded/3
     Given the query:
         """ prolog
         consult('/v1/lib/base64.pl'),
-        base64_encoded(X, 'SGVsbG8gV29ybGQ=', [as(atom), encoding(unknown)]).
+        base64_encoded(X, 'SGVsbG8gV29ybGQ=', [encoding(unknown)]).
         """
     When the query is run
     Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 14094
+        gas_used: 11778
         answer:
           has_more: false
           variables: ["X"]
@@ -551,7 +543,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 4447
+        gas_used: 4439
         answer:
           has_more: false
           variables: ["X"]
@@ -574,7 +566,7 @@ Feature: base64_encoded/3
     Then the answer we get is:
         """ yaml
         height: 42
-        gas_used: 4423
+        gas_used: 4415
         answer:
           has_more: false
           variables: ["X"]

--- a/x/logic/tests/predicate/features/base64url_2.feature
+++ b/x/logic/tests/predicate/features/base64url_2.feature
@@ -2,8 +2,8 @@ Feature: base64url/2
   This feature is to test the base64url/2 predicate.
 
   @great_for_documentation
-  Scenario: Encode and decode a string into a Base64 encoded atom in URL-Safe mode
-  This scenario demonstrates how to encode an decode a plain string into a Base64-encoded atom using the `base64url/2`
+  Scenario: Encode and decode an atom into a Base64 encoded atom in URL-Safe mode
+  This scenario demonstrates how to encode and decode a plain atom into a Base64-encoded atom using the `base64url/2`
   predicate.
 
     Given the query:
@@ -16,7 +16,7 @@ Feature: base64url/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 18554
+      gas_used: 15694
       answer:
         has_more: false
         variables: ["Encoded", "Decoded"]
@@ -40,7 +40,7 @@ Feature: base64url/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 8896
+      gas_used: 7396
       answer:
         has_more: false
         variables: ["X"]
@@ -61,7 +61,7 @@ Feature: base64url/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 8198
+      gas_used: 6827
       answer:
         has_more: false
         variables: ["X"]

--- a/x/logic/tests/predicate/features/consult_1.feature
+++ b/x/logic/tests/predicate/features/consult_1.feature
@@ -44,7 +44,7 @@ Feature: consult/1
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 5028
+      gas_used: 5020
       answer:
         has_more: false
         variables:

--- a/x/logic/tests/predicate/features/crypto_data_hash_3.feature
+++ b/x/logic/tests/predicate/features/crypto_data_hash_3.feature
@@ -15,7 +15,7 @@ Feature: crypto_data_hash/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 65436
+      gas_used: 65533
       answer:
         has_more: false
         variables: ["Hash", "Hex"]
@@ -42,7 +42,7 @@ Feature: crypto_data_hash/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 147034
+      gas_used: 147228
       answer:
         has_more: false
         variables: ["Sha512Bytes", "Md5Bytes", "Sha512", "Md5"]
@@ -73,7 +73,7 @@ Feature: crypto_data_hash/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 130018
+      gas_used: 129923
       answer:
         has_more: false
         variables: ["HashFromHex", "HashFromOctet", "HexFromHex", "HexFromOctet"]
@@ -89,6 +89,26 @@ Feature: crypto_data_hash/3
             expression: "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
       """
 
+  Scenario: Reject character codes for textual hash data
+    This scenario demonstrates that textual encodings require atoms; use encoding(octet) for byte lists.
+
+    Given the query:
+      """ prolog
+      consult('/v1/lib/crypto.pl'),
+      crypto_data_hash([104,101,108,108,111], Hash, []).
+      """
+    When the query is run
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 4920
+      answer:
+        has_more: false
+        variables: ["Hash"]
+        results:
+        - error: "error(type_error(atom,[104,101,108,108,111]),crypto_data_hash/3)"
+      """
+
   Scenario: Match a computed hash against an expected value
     This scenario demonstrates that crypto_data_hash/3 can verify a provided digest.
 
@@ -102,7 +122,7 @@ Feature: crypto_data_hash/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 18117
+      gas_used: 18127
       answer:
         has_more: false
         variables: ["Expected"]

--- a/x/logic/tests/predicate/features/ecdsa_verify_4.feature
+++ b/x/logic/tests/predicate/features/ecdsa_verify_4.feature
@@ -22,7 +22,7 @@ Feature: ecdsa_verify/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 246079
+      gas_used: 245814
       answer:
         has_more: false
         variables: ["Verified"]
@@ -53,7 +53,7 @@ Feature: ecdsa_verify/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 250523
+      gas_used: 250258
       answer:
         has_more: false
         variables: ["Verified"]
@@ -90,7 +90,7 @@ Feature: ecdsa_verify/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 493294
+      gas_used: 492764
       answer:
         has_more: false
         variables: ["Verified"]
@@ -120,7 +120,7 @@ Feature: ecdsa_verify/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 246047
+      gas_used: 245782
       answer:
         has_more: false
         variables:

--- a/x/logic/tests/predicate/features/eddsa_verify_4.feature
+++ b/x/logic/tests/predicate/features/eddsa_verify_4.feature
@@ -22,7 +22,7 @@ Feature: eddsa_verify/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 235381
+      gas_used: 235116
       answer:
         has_more: false
         variables: ["Verified"]
@@ -53,7 +53,7 @@ Feature: eddsa_verify/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 241785
+      gas_used: 241520
       answer:
         has_more: false
         variables: ["Verified"]
@@ -83,7 +83,7 @@ Feature: eddsa_verify/4
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 235349
+      gas_used: 235084
       answer:
         has_more: false
         variables:

--- a/x/logic/tests/predicate/features/hex_bytes_2.feature
+++ b/x/logic/tests/predicate/features/hex_bytes_2.feature
@@ -14,7 +14,7 @@ Feature: hex_bytes/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 5016
+      gas_used: 4929
       answer:
         has_more: false
         variables: ["Bytes"]
@@ -47,8 +47,8 @@ Feature: hex_bytes/2
             expression: "'501ace'"
       """
 
-  Scenario: Decode hexadecimal character codes into bytes
-    This scenario demonstrates that hex_bytes/2 accepts a list of character codes as hexadecimal input.
+  Scenario: Reject hexadecimal character codes
+    This scenario demonstrates that callers must explicitly convert character codes to an atom before calling hex_bytes/2.
 
     Given the query:
       """ prolog
@@ -59,14 +59,12 @@ Feature: hex_bytes/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 6091
+      gas_used: 4622
       answer:
         has_more: false
         variables: ["Bytes"]
         results:
-        - substitutions:
-          - variable: Bytes
-            expression: "[80,26,206]"
+        - error: "error(type_error(atom,[53,48,49,65,67,69]),hex_bytes/2)"
       """
 
   Scenario: Reject an invalid hexadecimal sequence
@@ -81,7 +79,7 @@ Feature: hex_bytes/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4932
+      gas_used: 4845
       answer:
         has_more: false
         variables: ["Bytes"]

--- a/x/logic/tests/predicate/features/json_prolog_2.feature
+++ b/x/logic/tests/predicate/features/json_prolog_2.feature
@@ -14,7 +14,7 @@ Feature: json_prolog/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 12069
+      gas_used: 12208
       answer:
         has_more: false
         variables: ["Term"]
@@ -37,7 +37,7 @@ Feature: json_prolog/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 11049
+      gas_used: 11061
       answer:
         has_more: false
         variables: ["Json"]
@@ -58,12 +58,31 @@ Feature: json_prolog/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 6957
+      gas_used: 7149
       answer:
         has_more: false
         variables: ["Term"]
         results:
         - error: "error(syntax_error(json(malformed_json(1))),json_prolog/2)"
+      """
+
+  Scenario: Reject JSON character codes
+
+    Given the query:
+      """ prolog
+      consult('/v1/lib/json.pl'),
+      json_prolog([123,125], Term).
+      """
+    When the query is run
+    Then the answer we get is:
+      """ yaml
+      height: 42
+      gas_used: 4536
+      answer:
+        has_more: false
+        variables: ["Term"]
+        results:
+        - error: "error(type_error(atom,[123,125]),json_prolog/2)"
       """
 
   Scenario: Reject invalid Prolog JSON terms
@@ -77,7 +96,7 @@ Feature: json_prolog/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 8034
+      gas_used: 8046
       answer:
         has_more: false
         variables: ["Json"]
@@ -96,7 +115,7 @@ Feature: json_prolog/2
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4191
+      gas_used: 4203
       answer:
         has_more: false
         variables: ["Json", "Term"]

--- a/x/logic/tests/predicate/features/uri_encoded_3.feature
+++ b/x/logic/tests/predicate/features/uri_encoded_3.feature
@@ -14,7 +14,7 @@ Feature: uri_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 6255
+      gas_used: 6235
       answer:
         has_more: false
         variables: ["Decoded"]
@@ -37,7 +37,7 @@ Feature: uri_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 6357
+      gas_used: 6337
       answer:
         has_more: false
         variables: ["Encoded"]
@@ -59,7 +59,7 @@ Feature: uri_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 9292
+      gas_used: 9272
       answer:
         has_more: false
         variables: ["Encoded"]
@@ -81,7 +81,7 @@ Feature: uri_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 7775
+      gas_used: 7755
       answer:
         has_more: false
         variables: ["Encoded"]
@@ -103,7 +103,7 @@ Feature: uri_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 7924
+      gas_used: 7904
       answer:
         has_more: false
         variables: ["Encoded"]
@@ -125,7 +125,7 @@ Feature: uri_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 7763
+      gas_used: 7743
       answer:
         has_more: false
         variables: ["Encoded"]
@@ -147,7 +147,7 @@ Feature: uri_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 10658
+      gas_used: 10638
       answer:
         has_more: false
         variables: ["Decoded"]
@@ -197,8 +197,8 @@ Feature: uri_encoded/3
         - error: "error(instantiation_error,uri_encoded/3)"
       """
 
-  Scenario: Error on an invalid text value in encode mode
-    This scenario demonstrates the error returned when the plain-text value is not a text term.
+  Scenario: Error on an invalid atom value in encode mode
+    This scenario demonstrates the error returned when the plain value is not an atom.
 
     Given the query:
       """ prolog
@@ -209,15 +209,15 @@ Feature: uri_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4644
+      gas_used: 4582
       answer:
         has_more: false
         results:
-        - error: "error(type_error(text,compound(2)),uri_encoded/3)"
+        - error: "error(type_error(atom,compound(2)),uri_encoded/3)"
       """
 
-  Scenario: Error on an invalid text value in decode mode
-    This scenario demonstrates the error returned when the encoded value is not a text term.
+  Scenario: Error on an invalid atom value in decode mode
+    This scenario demonstrates the error returned when the encoded value is not an atom.
 
     Given the query:
       """ prolog
@@ -228,12 +228,12 @@ Feature: uri_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 4720
+      gas_used: 4658
       answer:
         has_more: false
         variables: ["Decoded"]
         results:
-        - error: "error(type_error(text,compound(2)),uri_encoded/3)"
+        - error: "error(type_error(atom,compound(2)),uri_encoded/3)"
       """
 
   Scenario: Fail on mismatching fully ground values
@@ -248,12 +248,12 @@ Feature: uri_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 6374
+      gas_used: 6354
       answer:
         has_more: false
       """
 
-  Scenario: Fail when the encoded target is a non-unifiable non-text term in encode mode
+  Scenario: Fail when the encoded target is a non-unifiable non-atom term in encode mode
     This scenario demonstrates that encode mode computes the encoded atom and then simply fails on unification.
 
     Given the query:
@@ -265,7 +265,7 @@ Feature: uri_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 5319
+      gas_used: 5299
       answer:
         has_more: false
       """
@@ -282,7 +282,7 @@ Feature: uri_encoded/3
     Then the answer we get is:
       """ yaml
       height: 42
-      gas_used: 5927
+      gas_used: 5907
       answer:
         has_more: false
         variables: ["Decoded"]


### PR DESCRIPTION
Clarifies the contract of _Logic_ predicates that handle _text_: public APIs now consistently use atoms for textual inputs and
 outputs. `base64_encoded/3` always returns an atom and removes the `as/1` option; `base64url/2`, `json_prolog/2`, `uri_encoded/3`, `hex_bytes/2`, and the textual modes of the _crypto_ predicates follow the same rule.

⚠️ This is a _breaking change_ for consumers passing **character lists** or **character-code lists**: they _must_ convert explicitly with `atom_chars/2`, `atom_codes/2`, or `string_bytes/3`. Explicitly byte-oriented APIs keep using `list(byte)`, notably through `encoding(octet)`.

By eliminating implicit conversions, character-list construction, and Base64’s output-shape branch, the change also mechanically reduces gas consumption on affected execution paths.

Predicate scenarios and generated documentation now cover this contract and the corresponding `type_error(atom, ...)` errors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Text-based Base64, cryptographic, JSON, URI, and hexadecimal predicates now consistently require atoms.
  * Removed support for character/code lists and Base64 output-type options.
  * Invalid input types now produce explicit atom type errors.
* **Documentation**
  * Updated predicate guidance and examples to clarify atom-based text handling and explicit conversions.
* **Tests**
  * Expanded coverage for rejected input types, invalid options, malformed data, and updated gas usage expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->